### PR TITLE
feat(ui): resizable panels

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -50,6 +50,7 @@
     "lucide-react": "^0.564.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-resizable-panels": "^4.6.4",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.4(react@19.2.4)
+      react-resizable-panels:
+        specifier: ^4.6.4
+        version: 4.6.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
@@ -2541,6 +2544,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-resizable-panels@4.6.5:
+    resolution: {integrity: sha512-pmQP6qv9KmsesNMvWVNvVfVJAwYSOWWbAOAtrPR8Cre20+j1NWIlyft0btjtDQE+OepXmI6g3VPrCXQY0oD7+Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -5303,6 +5312,11 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  react-resizable-panels@4.6.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -119,7 +119,13 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
         <ResizableHandle withHandle data-panel-group-direction="vertical" />
 
         {/* DAG Chart - lazy loaded to split elkjs into separate chunk */}
-        <ResizablePanel defaultSize="75%" minSize="25%" collapsible collapsedSize="0%" className="overflow-hidden">
+        <ResizablePanel
+          defaultSize="75%"
+          minSize="25%"
+          collapsible
+          collapsedSize="0%"
+          className="overflow-hidden"
+        >
           <Suspense
             fallback={
               <div className="flex items-center justify-center h-full text-muted-foreground">

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, lazy, Suspense } from 'react';
 import { useQueryBundle } from '@/hooks/useQueryBundle';
 import { useQueryPlanVisualization } from '@/hooks/useQueryPlanVisualization';
 import { TreeView } from '@/components/ui/tree-view';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { type QueryPlanDataItem } from '@/services/query-plan/types';
 import { Network } from 'lucide-react';
 
@@ -90,37 +91,46 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
 
   return (
     <div className="w-full flex flex-col h-[calc(100vh-4rem)]">
-      <div className="border-b border-border bg-card shadow-sm">
-        <div className="flex items-center gap-2 px-4 py-1.5 border-b border-border">
-          <Network className="h-4 w-4 text-primary" />
-          <h3 className="text-xs font-semibold text-foreground">Query Plan Explorer</h3>
-          <div className="text-xs text-muted-foreground">
-            {queryBundle.entities.query_group.instance_name} -{' '}
-            {queryBundle.entities.query.instance_name}
-          </div>
+      <div className="flex items-center gap-2 px-4 py-1.5 border-b border-border bg-card shadow-sm flex-shrink-0">
+        <Network className="h-4 w-4 text-primary" />
+        <h3 className="text-xs font-semibold text-foreground">Query Plan Explorer</h3>
+        <div className="text-xs text-muted-foreground">
+          {queryBundle.entities.query_group.instance_name} -{' '}
+          {queryBundle.entities.query.instance_name}
         </div>
-        <div className="overflow-y-auto [&::-webkit-scrollbar]:w-0 [scrollbar-width:none] [-ms-overflow-style:none] max-h-40">
+      </div>
+
+      <ResizablePanelGroup orientation="vertical" className="flex-1">
+        <ResizablePanel
+          defaultSize="15%"
+          minSize="10%"
+          collapsible
+          collapsedSize="0%"
+          className="overflow-y-auto [&::-webkit-scrollbar]:w-0 [scrollbar-width:none] [-ms-overflow-style:none]"
+        >
           <TreeView<QueryPlanDataItem>
             data={treeData}
             initialSelectedItemId={planId}
             onSelectChange={handlePlanSelect}
             renderItem={renderItem}
           />
-        </div>
-      </div>
+        </ResizablePanel>
 
-      {/* DAG Chart - lazy loaded to split elkjs into separate chunk */}
-      <div className="flex-1 overflow-hidden">
-        <Suspense
-          fallback={
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              Loading visualization...
-            </div>
-          }
-        >
-          <DAGChart data={dagData} queryId={queryId} engineId={engineId} height="100%" />
-        </Suspense>
-      </div>
+        <ResizableHandle withHandle data-panel-group-direction="vertical" />
+
+        {/* DAG Chart - lazy loaded to split elkjs into separate chunk */}
+        <ResizablePanel defaultSize="75%" minSize="25%" collapsible collapsedSize="0%" className="overflow-hidden">
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                Loading visualization...
+              </div>
+            }
+          >
+            <DAGChart data={dagData} queryId={queryId} engineId={engineId} height="100%" />
+          </Suspense>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   );
 }

--- a/ui/src/components/dag/DAGChart.tsx
+++ b/ui/src/components/dag/DAGChart.tsx
@@ -103,7 +103,7 @@ const FlowLayout = ({
   const navigate = useNavigate();
   const hasUserInteracted = useRef(false);
 
-  const handleMoveStart = useCallback<OnMoveStart>((event) => {
+  const handleMoveStart = useCallback<OnMoveStart>(event => {
     if (event !== null) {
       hasUserInteracted.current = true;
     }

--- a/ui/src/components/dag/DAGChart.tsx
+++ b/ui/src/components/dag/DAGChart.tsx
@@ -1,5 +1,5 @@
 import ELK from 'elkjs';
-import { useCallback, useLayoutEffect, MouseEvent } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, MouseEvent, type RefObject } from 'react';
 import {
   Background,
   ReactFlow,
@@ -89,15 +89,24 @@ const FlowLayout = ({
   data,
   queryId,
   engineId,
+  containerRef,
 }: {
   data: DAGData;
   queryId: string;
   engineId: string;
+  containerRef: RefObject<HTMLDivElement | null>;
 }) => {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<QueryPlanNodeData>>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const { fitView } = useReactFlow();
   const navigate = useNavigate();
+  const hasUserInteracted = useRef(false);
+
+  const handleMoveStart = useCallback((event: MouseEvent | TouchEvent) => {
+    if (event !== null) {
+      hasUserInteracted.current = true;
+    }
+  }, []);
 
   // Convert DAGData to ReactFlow format
   const convertToReactFlow = useCallback(() => {
@@ -153,8 +162,24 @@ const FlowLayout = ({
     [navigate, engineId, queryId]
   );
 
+  // Re-fit view when the react-flow container is resized, but only if the user
+  // hasn't interacted with the chart (to maintain any focus states applied)
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const observer = new ResizeObserver(() => {
+      if (nodes.length > 0 && !hasUserInteracted.current) {
+        fitView({ padding: 0.1, minZoom: 0.1 });
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [containerRef, fitView, nodes.length]);
+
   // Calculate and apply layout
   useLayoutEffect(() => {
+    hasUserInteracted.current = false;
+
     const applyLayout = async () => {
       const { flowNodes, flowEdges } = convertToReactFlow();
       const layoutResult = await calculateLayout(flowNodes, flowEdges);
@@ -176,6 +201,7 @@ const FlowLayout = ({
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       onNodeClick={handleNodeClick}
+      onMoveStart={handleMoveStart}
       proOptions={{ hideAttribution: true }}
       nodeTypes={nodeTypes}
       fitView
@@ -192,10 +218,11 @@ const FlowLayout = ({
 };
 
 export const DAGChart = ({ data, queryId, engineId, height = '100%' }: DAGProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   return (
-    <div style={{ width: '100%', height }}>
+    <div ref={containerRef} style={{ width: '100%', height }}>
       <ReactFlowProvider>
-        <FlowLayout data={data} queryId={queryId} engineId={engineId} />
+        <FlowLayout data={data} queryId={queryId} engineId={engineId} containerRef={containerRef} />
       </ReactFlowProvider>
     </div>
   );

--- a/ui/src/components/dag/DAGChart.tsx
+++ b/ui/src/components/dag/DAGChart.tsx
@@ -10,6 +10,7 @@ import {
   MarkerType,
   type Node,
   type Edge,
+  type OnMoveStart,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import type { DAGData } from '@/services/query-plan/types';
@@ -102,7 +103,7 @@ const FlowLayout = ({
   const navigate = useNavigate();
   const hasUserInteracted = useRef(false);
 
-  const handleMoveStart = useCallback((event: MouseEvent | TouchEvent) => {
+  const handleMoveStart = useCallback<OnMoveStart>((event) => {
     if (event !== null) {
       hasUserInteracted.current = true;
     }

--- a/ui/src/components/ui/resizable.tsx
+++ b/ui/src/components/ui/resizable.tsx
@@ -1,0 +1,40 @@
+import { GripVertical } from 'lucide-react';
+import * as ResizablePrimitive from 'react-resizable-panels';
+
+import { cn } from '@/lib/utils';
+
+const ResizablePanelGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) => (
+  <ResizablePrimitive.Group
+    className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
+    {...props}
+  />
+);
+
+const ResizablePanel = ResizablePrimitive.Panel;
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
+  withHandle?: boolean;
+}) => (
+  <ResizablePrimitive.Separator
+    className={cn(
+      'relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+      className
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </ResizablePrimitive.Separator>
+);
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/ui/src/routes/profile.engine.$engineId.tsx
+++ b/ui/src/routes/profile.engine.$engineId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, useMatch } from '@tanstack/react-router';
 import { QueryPlan } from '@/components/QueryPlan';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 
 export const Route = createFileRoute('/profile/engine/$engineId')({
   component: ProfileLayout,
@@ -20,8 +21,8 @@ function ProfileLayout() {
   const queryId = queryIndexMatch?.params?.queryId ?? queryNodeMatch?.params?.queryId;
 
   return (
-    <div className="grid grid-cols-[1fr_2fr] h-full">
-      <div className="border-r">
+    <ResizablePanelGroup orientation="horizontal" className="h-full">
+      <ResizablePanel defaultSize="33%" minSize="15%" collapsible collapsedSize="0%">
         {queryId && queryId !== '' ? (
           <QueryPlan queryId={queryId} engineId={engineId} />
         ) : (
@@ -29,10 +30,11 @@ function ProfileLayout() {
             Select a query to view the execution plan
           </div>
         )}
-      </div>
-      <div className="overflow-y-auto h-[calc(100vh-4rem)] w-full">
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize="67%" minSize="20%" collapsible collapsedSize="0%" className="overflow-y-auto h-[calc(100vh-4rem)]">
         <Outlet />
-      </div>
-    </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
   );
 }

--- a/ui/src/routes/profile.engine.$engineId.tsx
+++ b/ui/src/routes/profile.engine.$engineId.tsx
@@ -32,7 +32,13 @@ function ProfileLayout() {
         )}
       </ResizablePanel>
       <ResizableHandle withHandle />
-      <ResizablePanel defaultSize="67%" minSize="20%" collapsible collapsedSize="0%" className="overflow-y-auto h-[calc(100vh-4rem)]">
+      <ResizablePanel
+        defaultSize="67%"
+        minSize="20%"
+        collapsible
+        collapsedSize="0%"
+        className="overflow-y-auto h-[calc(100vh-4rem)]"
+      >
         <Outlet />
       </ResizablePanel>
     </ResizablePanelGroup>


### PR DESCRIPTION
This modifies both the query list and the entire left side panels to be re-sizable, utilizing shadcn's `resizable` components. Additionally adds a fix to ensure the `react-flow` container responds to the horizontal resizing (OOTB it was only responding to vertical resizing).

Also removes a stray `console.log` that somehow made it into master.

Additionally, addresses all review comments left on original gitlab PR.