### PR TITLE
feat: add rapids-bot config to quent repo

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,8 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+auto_merger: true
+branch_checker: true
+label_checker: true
+release_drafter: false
+forward_merger: false


### PR DESCRIPTION
this PR adds the required config to allow the rapids-bot to merge to `main` if all the checks are passing by using a comment with `/merge` in it. 

