### PR TITLE
feat(instrumentation)!: add noop exporter that short-circuits at the …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ members = [
     "examples/simulator/instrumentation",
     "examples/simulator/server",
     "examples/simulator/ui",
-    # Application-specific PoC crates
-    # ...
 ]
 
 [workspace.package]

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -7,7 +7,10 @@ use quent_exporter_msgpack::MsgpackExporter;
 use quent_exporter_ndjson::NdjsonExporter;
 use quent_exporter_postcard::PostcardExporter;
 use serde::Serialize;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use tokio::{
     runtime::{Handle, Runtime},
     sync::mpsc::{UnboundedSender, unbounded_channel},
@@ -31,20 +34,30 @@ pub enum ExporterOptions {
 /// (i.e. the noop exporter is selected), `send` is a no-op that avoids any
 /// channel or event-forwarding overhead.
 #[derive(Debug)]
-pub struct EventSender<T>(Option<UnboundedSender<Event<T>>>);
+pub struct EventSender<T> {
+    tx: Option<UnboundedSender<Event<T>>>,
+    /// Flag set to prevent potentially massive log spam from subseQUENT sender
+    /// errors after first.
+    disable_error_log: AtomicBool,
+}
 
 impl<T> Clone for EventSender<T> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            tx: self.tx.clone(),
+            disable_error_log: AtomicBool::new(self.disable_error_log.load(Ordering::Relaxed)),
+        }
     }
 }
 
 impl<T> EventSender<T> {
     pub fn send(&self, event: Event<T>) {
-        if let Some(tx) = &self.0
-            && let Err(e) = tx.send(event) {
-                warn!("unable to send event: {e}");
-            }
+        if let Some(tx) = &self.tx
+            && tx.send(event).is_err()
+            && !self.disable_error_log.swap(true, Ordering::Relaxed)
+        {
+            tracing::error!("unable to send event, suppressing further errors");
+        }
     }
 }
 
@@ -78,7 +91,10 @@ where
                 debug!("using noop exporter");
                 return Ok(Context {
                     handle: None,
-                    events_sender: EventSender(None),
+                    events_sender: EventSender {
+                        tx: None,
+                        disable_error_log: AtomicBool::new(false),
+                    },
                     exporter: None,
                     cancellation_token: CancellationToken::new(),
                     forwarder_handle: None,
@@ -152,7 +168,10 @@ where
 
         Ok(Context {
             handle: Some(handle),
-            events_sender: EventSender(Some(events_sender)),
+            events_sender: EventSender {
+                tx: Some(events_sender),
+                disable_error_log: AtomicBool::new(false),
+            },
             exporter: Some(exporter),
             cancellation_token,
             forwarder_handle: Some(forwarder_handle),
@@ -182,9 +201,10 @@ where
 
             // Flush the exporter to ensure all events are sent
             if let Some(exporter) = &self.exporter
-                && let Err(e) = handle.block_on(exporter.force_flush()) {
-                    warn!("failed to flush exporter: {e}");
-                }
+                && let Err(e) = handle.block_on(exporter.force_flush())
+            {
+                warn!("failed to flush exporter: {e}");
+            }
         }
     }
 }
@@ -205,7 +225,7 @@ mod tests {
         assert!(ctx._runtime.is_none());
 
         let sender = ctx.events_sender();
-        assert!(sender.0.is_none());
+        assert!(sender.tx.is_none());
 
         sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
         sender.send(Event::new_now(Uuid::now_v7(), TestEvent));

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -25,15 +25,38 @@ pub enum ExporterOptions {
     Ndjson,
     Msgpack,
     Postcard,
+    Noop,
+}
+
+/// Wrapper around an optional channel sender. When the inner sender is `None`
+/// (i.e. the noop exporter is selected), `send` is a no-op that avoids any
+/// channel or event-forwarding overhead.
+#[derive(Debug)]
+pub struct EventSender<T>(Option<UnboundedSender<Event<T>>>);
+
+impl<T> Clone for EventSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> EventSender<T> {
+    pub fn send(&self, event: Event<T>) {
+        if let Some(tx) = &self.0 {
+            if let Err(e) = tx.send(event) {
+                warn!("unable to send event: {e}");
+            }
+        }
+    }
 }
 
 pub struct Context<T>
 where
     T: Serialize + Send + std::fmt::Debug + 'static,
 {
-    handle: Handle,
-    events_sender: UnboundedSender<Event<T>>,
-    exporter: Arc<dyn Exporter<T>>,
+    handle: Option<Handle>,
+    events_sender: EventSender<T>,
+    exporter: Option<Arc<dyn Exporter<T>>>,
     cancellation_token: CancellationToken,
     forwarder_handle: Option<JoinHandle<()>>,
 
@@ -52,6 +75,20 @@ where
         exporter: ExporterOptions,
         id: Uuid,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        // Early exit with a noop context entirely. There is no need to
+        // potentially spawn a runtime, etc.
+        if matches!(exporter, ExporterOptions::Noop) {
+            debug!("using noop exporter");
+            return Ok(Context {
+                handle: None,
+                events_sender: EventSender(None),
+                exporter: None,
+                cancellation_token: CancellationToken::new(),
+                forwarder_handle: None,
+                _runtime: None,
+            });
+        }
+
         let (runtime, handle) = if let Ok(handle) = Handle::try_current() {
             debug!("using existing async runtime");
             (None, handle)
@@ -75,6 +112,7 @@ where
             ExporterOptions::Ndjson => Arc::new(handle.block_on(NdjsonExporter::try_new(id))?),
             ExporterOptions::Msgpack => Arc::new(handle.block_on(MsgpackExporter::try_new(id))?),
             ExporterOptions::Postcard => Arc::new(handle.block_on(PostcardExporter::try_new(id))?),
+            ExporterOptions::Noop => unreachable!(),
         };
 
         let cancellation_token = CancellationToken::new();
@@ -115,24 +153,17 @@ where
         });
 
         Ok(Context {
-            handle,
-            events_sender,
-            exporter,
+            handle: Some(handle),
+            events_sender: EventSender(Some(events_sender)),
+            exporter: Some(exporter),
             cancellation_token,
             forwarder_handle: Some(forwarder_handle),
             _runtime: runtime,
         })
     }
 
-    pub fn events_sender(&self) -> UnboundedSender<Event<T>> {
+    pub fn events_sender(&self) -> EventSender<T> {
         self.events_sender.clone()
-    }
-
-    pub fn push_event(sender: &UnboundedSender<Event<T>>, event: Event<T>) {
-        match sender.send(event) {
-            Ok(_) => (),
-            Err(e) => warn!("unable to send event: {e}"),
-        }
     }
 }
 
@@ -143,16 +174,44 @@ where
     fn drop(&mut self) {
         self.cancellation_token.cancel();
 
-        // Wait for the forwarder to finish processing remaining events
-        if let Some(forwarder_handle) = self.forwarder_handle.take()
-            && let Err(e) = self.handle.block_on(forwarder_handle)
-        {
-            warn!("forwarder task failed: {e}");
-        }
+        if let Some(handle) = &self.handle {
+            // Wait for the forwarder to finish processing remaining events
+            if let Some(forwarder_handle) = self.forwarder_handle.take()
+                && let Err(e) = handle.block_on(forwarder_handle)
+            {
+                warn!("forwarder task failed: {e}");
+            }
 
-        // Flush the exporter to ensure all events are sent
-        if let Err(e) = self.handle.block_on(self.exporter.force_flush()) {
-            warn!("failed to flush exporter: {e}");
+            // Flush the exporter to ensure all events are sent
+            if let Some(exporter) = &self.exporter {
+                if let Err(e) = handle.block_on(exporter.force_flush()) {
+                    warn!("failed to flush exporter: {e}");
+                }
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, serde::Serialize)]
+    struct TestEvent;
+
+    #[test]
+    fn noop_exporter() {
+        let ctx = Context::<TestEvent>::try_new(ExporterOptions::Noop, Uuid::now_v7()).unwrap();
+        assert!(ctx.handle.is_none());
+        assert!(ctx.exporter.is_none());
+        assert!(ctx.forwarder_handle.is_none());
+        assert!(ctx._runtime.is_none());
+
+        let sender = ctx.events_sender();
+        assert!(sender.0.is_none());
+
+        sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
+        sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
+        drop(ctx);
     }
 }

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -36,16 +36,16 @@ pub enum ExporterOptions {
 #[derive(Debug)]
 pub struct EventSender<T> {
     tx: Option<UnboundedSender<Event<T>>>,
-    /// Flag set to prevent potentially massive log spam from subseQUENT sender
-    /// errors after first.
-    disable_error_log: AtomicBool,
+    /// Flag shared across clones to prevent potentially massive log spam from
+    /// subseQUENT sender errors after the first.
+    disable_error_log: Arc<AtomicBool>,
 }
 
 impl<T> Clone for EventSender<T> {
     fn clone(&self) -> Self {
         Self {
             tx: self.tx.clone(),
-            disable_error_log: AtomicBool::new(self.disable_error_log.load(Ordering::Relaxed)),
+            disable_error_log: Arc::clone(&self.disable_error_log),
         }
     }
 }
@@ -93,7 +93,7 @@ where
                     handle: None,
                     events_sender: EventSender {
                         tx: None,
-                        disable_error_log: AtomicBool::new(false),
+                        disable_error_log: Arc::new(AtomicBool::new(false)),
                     },
                     exporter: None,
                     cancellation_token: CancellationToken::new(),
@@ -170,7 +170,7 @@ where
             handle: Some(handle),
             events_sender: EventSender {
                 tx: Some(events_sender),
-                disable_error_log: AtomicBool::new(false),
+                disable_error_log: Arc::new(AtomicBool::new(false)),
             },
             exporter: Some(exporter),
             cancellation_token,

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -25,7 +25,6 @@ pub enum ExporterOptions {
     Ndjson,
     Msgpack,
     Postcard,
-    Noop,
 }
 
 /// Wrapper around an optional channel sender. When the inner sender is `None`
@@ -42,11 +41,10 @@ impl<T> Clone for EventSender<T> {
 
 impl<T> EventSender<T> {
     pub fn send(&self, event: Event<T>) {
-        if let Some(tx) = &self.0 {
-            if let Err(e) = tx.send(event) {
+        if let Some(tx) = &self.0
+            && let Err(e) = tx.send(event) {
                 warn!("unable to send event: {e}");
             }
-        }
     }
 }
 
@@ -72,22 +70,23 @@ where
     T: Serialize + Send + std::fmt::Debug + 'static,
 {
     pub fn try_new(
-        exporter: ExporterOptions,
+        exporter: Option<ExporterOptions>,
         id: Uuid,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Early exit with a noop context entirely. There is no need to
-        // potentially spawn a runtime, etc.
-        if matches!(exporter, ExporterOptions::Noop) {
-            debug!("using noop exporter");
-            return Ok(Context {
-                handle: None,
-                events_sender: EventSender(None),
-                exporter: None,
-                cancellation_token: CancellationToken::new(),
-                forwarder_handle: None,
-                _runtime: None,
-            });
-        }
+        let exporter = match exporter {
+            None => {
+                debug!("using noop exporter");
+                return Ok(Context {
+                    handle: None,
+                    events_sender: EventSender(None),
+                    exporter: None,
+                    cancellation_token: CancellationToken::new(),
+                    forwarder_handle: None,
+                    _runtime: None,
+                });
+            }
+            Some(exporter) => exporter,
+        };
 
         let (runtime, handle) = if let Ok(handle) = Handle::try_current() {
             debug!("using existing async runtime");
@@ -112,7 +111,6 @@ where
             ExporterOptions::Ndjson => Arc::new(handle.block_on(NdjsonExporter::try_new(id))?),
             ExporterOptions::Msgpack => Arc::new(handle.block_on(MsgpackExporter::try_new(id))?),
             ExporterOptions::Postcard => Arc::new(handle.block_on(PostcardExporter::try_new(id))?),
-            ExporterOptions::Noop => unreachable!(),
         };
 
         let cancellation_token = CancellationToken::new();
@@ -183,11 +181,10 @@ where
             }
 
             // Flush the exporter to ensure all events are sent
-            if let Some(exporter) = &self.exporter {
-                if let Err(e) = handle.block_on(exporter.force_flush()) {
+            if let Some(exporter) = &self.exporter
+                && let Err(e) = handle.block_on(exporter.force_flush()) {
                     warn!("failed to flush exporter: {e}");
                 }
-            }
         }
     }
 }
@@ -201,7 +198,7 @@ mod tests {
 
     #[test]
     fn noop_exporter() {
-        let ctx = Context::<TestEvent>::try_new(ExporterOptions::Noop, Uuid::now_v7()).unwrap();
+        let ctx = Context::<TestEvent>::try_new(None, Uuid::now_v7()).unwrap();
         assert!(ctx.handle.is_none());
         assert!(ctx.exporter.is_none());
         assert!(ctx.forwarder_handle.is_none());

--- a/crates/instrumentation/src/resource.rs
+++ b/crates/instrumentation/src/resource.rs
@@ -1,81 +1,61 @@
 use quent_events::{Event, resource};
 use serde::Serialize;
-use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
-use crate::Context;
+use crate::EventSender;
 
 #[derive(Clone)]
 pub struct MemoryResourceObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    tx: UnboundedSender<Event<T>>,
+    tx: EventSender<T>,
 }
 
 impl<T> MemoryResourceObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    pub fn new(tx: UnboundedSender<Event<T>>) -> Self {
+    pub fn new(tx: EventSender<T>) -> Self {
         Self { tx }
     }
 
     pub fn init(&self, id: Uuid, init: resource::memory::Init) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Init(init)).into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Init(init)).into(),
+        ))
     }
 
     pub fn operating(&self, id: Uuid, operating: resource::memory::Operating) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Operating(
-                    operating,
-                ))
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Operating(operating))
                 .into(),
-            ),
-        )
+        ))
     }
 
     pub fn resizing(&self, id: Uuid, resizing: resource::memory::Resizing) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Resizing(resizing))
-                    .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Resizing(resizing))
+                .into(),
+        ))
     }
 
     pub fn finalizing(&self, id: Uuid, finalizing: resource::memory::Finalizing) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Finalizing(
-                    finalizing,
-                ))
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Finalizing(finalizing))
                 .into(),
-            ),
-        )
+        ))
     }
 
     pub fn exit(&self, id: Uuid, exit: resource::memory::Exit) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Exit(exit)).into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Memory(resource::memory::MemoryEvent::Exit(exit)).into(),
+        ))
     }
 }
 
@@ -84,63 +64,51 @@ pub struct ProcessorResourceObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    tx: UnboundedSender<Event<T>>,
+    tx: EventSender<T>,
 }
 
 impl<T> ProcessorResourceObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    pub fn new(tx: UnboundedSender<Event<T>>) -> Self {
+    pub fn new(tx: EventSender<T>) -> Self {
         Self { tx }
     }
 
     pub fn init(&self, id: Uuid, init: resource::processor::Init) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Processor(resource::processor::ProcessorEvent::Init(init))
-                    .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Processor(resource::processor::ProcessorEvent::Init(init))
+                .into(),
+        ))
     }
 
     pub fn operating(&self, id: Uuid, operating: resource::processor::Operating) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Processor(resource::processor::ProcessorEvent::Operating(
-                    operating,
-                ))
-                .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Processor(resource::processor::ProcessorEvent::Operating(
+                operating,
+            ))
+            .into(),
+        ))
     }
 
     pub fn finalizing(&self, id: Uuid, finalizing: resource::processor::Finalizing) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Processor(
-                    resource::processor::ProcessorEvent::Finalizing(finalizing),
-                )
-                .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Processor(
+                resource::processor::ProcessorEvent::Finalizing(finalizing),
+            )
+            .into(),
+        ))
     }
 
     pub fn exit(&self, id: Uuid, exit: resource::processor::Exit) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Processor(resource::processor::ProcessorEvent::Exit(exit))
-                    .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Processor(resource::processor::ProcessorEvent::Exit(exit))
+                .into(),
+        ))
     }
 }
 
@@ -149,63 +117,49 @@ pub struct ChannelResourceObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    tx: UnboundedSender<Event<T>>,
+    tx: EventSender<T>,
 }
 
 impl<T> ChannelResourceObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    pub fn new(tx: UnboundedSender<Event<T>>) -> Self {
+    pub fn new(tx: EventSender<T>) -> Self {
         Self { tx }
     }
 
     pub fn init(&self, id: Uuid, init: resource::channel::Init) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Init(init))
-                    .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Init(init)).into(),
+        ))
     }
 
     pub fn operating(&self, id: Uuid, operating: resource::channel::Operating) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Operating(
-                    operating,
-                ))
-                .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Operating(
+                operating,
+            ))
+            .into(),
+        ))
     }
 
     pub fn finalizing(&self, id: Uuid, finalizing: resource::channel::Finalizing) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Finalizing(
-                    finalizing,
-                ))
-                .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Finalizing(
+                finalizing,
+            ))
+            .into(),
+        ))
     }
 
     pub fn exit(&self, id: Uuid, exit: resource::channel::Exit) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Exit(exit))
-                    .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Exit(exit)).into(),
+        ))
     }
 }
 
@@ -214,21 +168,19 @@ pub struct ResourceGroupObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    tx: UnboundedSender<Event<T>>,
+    tx: EventSender<T>,
 }
 
 impl<T> ResourceGroupObserver<T>
 where
     T: From<resource::ResourceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    pub fn new(tx: UnboundedSender<Event<T>>) -> Self {
+    pub fn new(tx: EventSender<T>) -> Self {
         Self { tx }
     }
 
     pub fn group(&self, id: Uuid, group: resource::GroupEvent) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(id, resource::ResourceEvent::Group(group).into()),
-        )
+        self.tx
+            .send(Event::new_now(id, resource::ResourceEvent::Group(group).into()))
     }
 }

--- a/crates/instrumentation/src/resource.rs
+++ b/crates/instrumentation/src/resource.rs
@@ -96,9 +96,9 @@ where
     pub fn finalizing(&self, id: Uuid, finalizing: resource::processor::Finalizing) {
         self.tx.send(Event::new_now(
             id,
-            resource::ResourceEvent::Processor(
-                resource::processor::ProcessorEvent::Finalizing(finalizing),
-            )
+            resource::ResourceEvent::Processor(resource::processor::ProcessorEvent::Finalizing(
+                finalizing,
+            ))
             .into(),
         ))
     }
@@ -138,10 +138,8 @@ where
     pub fn operating(&self, id: Uuid, operating: resource::channel::Operating) {
         self.tx.send(Event::new_now(
             id,
-            resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Operating(
-                operating,
-            ))
-            .into(),
+            resource::ResourceEvent::Channel(resource::channel::ChannelEvent::Operating(operating))
+                .into(),
         ))
     }
 
@@ -180,7 +178,9 @@ where
     }
 
     pub fn group(&self, id: Uuid, group: resource::GroupEvent) {
-        self.tx
-            .send(Event::new_now(id, resource::ResourceEvent::Group(group).into()))
+        self.tx.send(Event::new_now(
+            id,
+            resource::ResourceEvent::Group(group).into(),
+        ))
     }
 }

--- a/crates/instrumentation/src/trace.rs
+++ b/crates/instrumentation/src/trace.rs
@@ -6,17 +6,16 @@ use std::sync::{
 use quent_attributes::Attribute;
 use quent_events::{Event, trace};
 use serde::Serialize;
-use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
-use crate::Context;
+use crate::EventSender;
 
 #[derive(Clone)]
 pub struct TraceObserver<T>
 where
     T: From<trace::TraceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    tx: UnboundedSender<Event<T>>,
+    tx: EventSender<T>,
     next_span_id: Arc<AtomicU64>,
 }
 
@@ -24,14 +23,11 @@ impl<T> TraceObserver<T>
 where
     T: From<trace::TraceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    pub fn new(tx: UnboundedSender<Event<T>>, entity_id: Uuid) -> Self {
-        Context::push_event(
-            &tx,
-            Event::new_now(
-                entity_id,
-                trace::TraceEvent::Init(trace::TraceInit { entity_id }).into(),
-            ),
-        );
+    pub fn new(tx: EventSender<T>, entity_id: Uuid) -> Self {
+        tx.send(Event::new_now(
+            entity_id,
+            trace::TraceEvent::Init(trace::TraceInit { entity_id }).into(),
+        ));
         Self {
             tx,
             next_span_id: Arc::new(AtomicU64::new(1)),
@@ -44,19 +40,16 @@ where
 
     pub fn span(&self, id: Uuid, name: String, parent_id: Option<trace::SpanId>) -> SpanHandle<T> {
         let span_id = self.alloc_span_id();
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                id,
-                trace::TraceEvent::Span(trace::SpanInit {
-                    id: span_id,
-                    name,
-                    parent_id,
-                    attributes: vec![],
-                })
-                .into(),
-            ),
-        );
+        self.tx.send(Event::new_now(
+            id,
+            trace::TraceEvent::Span(trace::SpanInit {
+                id: span_id,
+                name,
+                parent_id,
+                attributes: vec![],
+            })
+            .into(),
+        ));
         SpanHandle {
             tx: self.tx.clone(),
             trace_id: id,
@@ -69,7 +62,7 @@ pub struct SpanHandle<T>
 where
     T: From<trace::TraceEvent> + Serialize + Send + std::fmt::Debug + 'static,
 {
-    tx: UnboundedSender<Event<T>>,
+    tx: EventSender<T>,
     trace_id: Uuid,
     span_id: trace::SpanId,
 }
@@ -83,44 +76,35 @@ where
     }
 
     pub fn enter(&self, attributes: Vec<Attribute>) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                self.trace_id,
-                trace::TraceEvent::Enter(trace::SpanEnter {
-                    id: self.span_id,
-                    attributes,
-                })
-                .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            self.trace_id,
+            trace::TraceEvent::Enter(trace::SpanEnter {
+                id: self.span_id,
+                attributes,
+            })
+            .into(),
+        ))
     }
 
     pub fn exit(&self, attributes: Vec<Attribute>) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                self.trace_id,
-                trace::TraceEvent::Exit(trace::SpanExit {
-                    id: self.span_id,
-                    attributes,
-                })
-                .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            self.trace_id,
+            trace::TraceEvent::Exit(trace::SpanExit {
+                id: self.span_id,
+                attributes,
+            })
+            .into(),
+        ))
     }
 
     pub fn close(self) {
-        Context::push_event(
-            &self.tx,
-            Event::new_now(
-                self.trace_id,
-                trace::TraceEvent::Close(trace::SpanClose {
-                    id: self.span_id,
-                    attributes: vec![],
-                })
-                .into(),
-            ),
-        )
+        self.tx.send(Event::new_now(
+            self.trace_id,
+            trace::TraceEvent::Close(trace::SpanClose {
+                id: self.span_id,
+                attributes: vec![],
+            })
+            .into(),
+        ))
     }
 }

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -1132,15 +1132,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut engine = Engine::new();
 
     let exporter = match args.exporter.as_str() {
-        "postcard" => ExporterOptions::Postcard,
-        "messagepack" => ExporterOptions::Msgpack,
-        "ndjson" => ExporterOptions::Ndjson,
-        "collector" => ExporterOptions::Collector(CollectorExporterOptions {
+        "postcard" => Some(ExporterOptions::Postcard),
+        "messagepack" => Some(ExporterOptions::Msgpack),
+        "ndjson" => Some(ExporterOptions::Ndjson),
+        "collector" => Some(ExporterOptions::Collector(CollectorExporterOptions {
             address: args.collector_address,
-        }),
+        })),
+        "none" => None,
         _ => {
             return Err(format!(
-                "invalid exporter '{}': must be postcard, messagepack, ndjson, or collector",
+                "invalid exporter '{}': must be postcard, messagepack, ndjson, collector, or none",
                 args.exporter
             )
             .into());

--- a/examples/simulator/instrumentation/src/lib.rs
+++ b/examples/simulator/instrumentation/src/lib.rs
@@ -22,7 +22,7 @@ pub struct SimulatorContext {
 }
 
 impl SimulatorContext {
-    pub fn try_new(exporter: ExporterOptions, id: Uuid) -> Result<Self, Box<dyn Error>> {
+    pub fn try_new(exporter: Option<ExporterOptions>, id: Uuid) -> Result<Self, Box<dyn Error>> {
         Context::try_new(exporter, id).map(|inner| Self { inner })
     }
 

--- a/examples/simulator/instrumentation/src/lib.rs
+++ b/examples/simulator/instrumentation/src/lib.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use quent_events::Event;
 use quent_instrumentation::{
-    Context, ExporterOptions,
+    Context, EventSender, ExporterOptions,
     resource::{
         ChannelResourceObserver, MemoryResourceObserver, ProcessorResourceObserver,
         ResourceGroupObserver,
@@ -94,16 +94,13 @@ impl SimulatorContext {
     }
 }
 
-fn push_event(
-    tx: &tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
-    event: Event<SimulatorEvent>,
-) {
-    Context::push_event(tx, event)
+fn push_event(tx: &EventSender<SimulatorEvent>, event: Event<SimulatorEvent>) {
+    tx.send(event)
 }
 
 #[derive(Clone)]
 pub struct EngineObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl EngineObserver {
@@ -134,7 +131,7 @@ impl EngineObserver {
 
 #[derive(Clone)]
 pub struct QueryGroupObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl QueryGroupObserver {
@@ -151,7 +148,7 @@ impl QueryGroupObserver {
 
 #[derive(Clone)]
 pub struct WorkerObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl WorkerObserver {
@@ -182,7 +179,7 @@ impl WorkerObserver {
 
 #[derive(Clone)]
 pub struct QueryObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl QueryObserver {
@@ -235,7 +232,7 @@ impl QueryObserver {
 
 #[derive(Clone)]
 pub struct PlanObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl PlanObserver {
@@ -252,7 +249,7 @@ impl PlanObserver {
 
 #[derive(Clone)]
 pub struct OperatorObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl OperatorObserver {
@@ -283,7 +280,7 @@ impl OperatorObserver {
 
 #[derive(Clone)]
 pub struct PortObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl PortObserver {
@@ -314,7 +311,7 @@ impl PortObserver {
 
 #[derive(Clone)]
 pub struct TaskObserver {
-    tx: tokio::sync::mpsc::UnboundedSender<Event<SimulatorEvent>>,
+    tx: EventSender<SimulatorEvent>,
 }
 
 impl TaskObserver {


### PR DESCRIPTION
…send site

Introduce EventSender<T> wrapping Option<UnboundedSender<Event<T>>> so that selecting ExporterOptions::Noop skips creating a runtime, channel, forwarder, and exporter entirely. Sends become a branch on None with zero channel overhead.

BREAKING CHANGE: Context::events_sender() now returns EventSender<T> instead of UnboundedSender<Event<T>>, and Context::push_event() has been removed in favor of EventSender::send().