### PR TITLE
fix(analyzer): don't include long entities outside the window

### DIFF
--- a/crates/analyzer/src/timeline/binned/resource.rs
+++ b/crates/analyzer/src/timeline/binned/resource.rs
@@ -71,6 +71,7 @@ impl<'a> ResourceTimelineBuilder<'a> {
 
         if let Some(threshold) = self.long_entities_threshold
             && usage.span().duration() > threshold
+            && usage.span().intersects(&self.aggregator.config.span)
         {
             self.long_entities.insert(usage.entity_id());
         }
@@ -133,6 +134,7 @@ where
 
         if let Some(threshold) = self.long_entities_threshold
             && usage.span().duration() > threshold
+            && usage.span().intersects(&self.aggregator.config.span)
         {
             self.long_entities.insert(usage.entity_id());
         }
@@ -784,5 +786,77 @@ mod tests {
                 42.0 * 1.0,
             ],
         );
+    }
+
+    /// Don't include long entities outside the window.
+    #[test]
+    fn test_long_entities_outside_window_excluded() {
+        let resource_id = Uuid::now_v7();
+
+        let mut resources = InMemoryResourcesBuilder::default();
+        resources
+            .try_extend(
+                root_resource_event()
+                    .into_iter()
+                    .chain(memory_events(resource_id)),
+            )
+            .unwrap();
+        let resources = resources.try_build().unwrap();
+
+        // Config window: [1000, 2000], threshold: 100 ns (all spans below exceed it)
+        let config = BinnedSpan::try_new(
+            SpanNanoSec::try_new(1000, 2000).unwrap(),
+            NonZero::try_from(10).unwrap(),
+        )
+        .unwrap();
+        let threshold = 100u64;
+
+        let resource_type = resources
+            .resource_type(resources.resource(resource_id).unwrap().type_name())
+            .unwrap();
+
+        let make_fsm = |start, end| {
+            RtFsm::try_new(
+                Uuid::now_v7(),
+                "test",
+                "test",
+                [
+                    RtFsmTransition {
+                        name: "using".into(),
+                        usages: vec![RtFsmStateUsage::new(
+                            resource_id,
+                            [CapacityValue::new("bytes", 1)],
+                        )],
+                        timestamp: start,
+                        attributes: vec![],
+                    },
+                    RtFsmTransition {
+                        name: "exit".into(),
+                        usages: vec![],
+                        timestamp: end,
+                        attributes: vec![],
+                    },
+                ],
+            )
+            .unwrap()
+        };
+
+        let mut outside_fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        outside_fsms.insert(make_fsm(0, 500));
+        outside_fsms.insert(make_fsm(2500, 3000));
+
+        let mut outside_builder =
+            ResourceTimelineBuilder::try_new(resource_type, config, Some(threshold)).unwrap();
+        outside_builder.try_extend(outside_fsms.usages()).unwrap();
+        assert!(!outside_builder.build().long_entities.contains(&resource_id));
+
+        let mut inside_fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        inside_fsms.insert(make_fsm(500, 1500));
+        inside_fsms.insert(make_fsm(1100, 1900));
+
+        let mut inside_builder =
+            ResourceTimelineBuilder::try_new(resource_type, config, Some(threshold)).unwrap();
+        inside_builder.try_extend(inside_fsms.usages()).unwrap();
+        assert!(inside_builder.build().long_entities.contains(&resource_id));
     }
 }

--- a/crates/time/src/lib.rs
+++ b/crates/time/src/lib.rs
@@ -69,6 +69,8 @@ pub fn to_nanosecs(time: TimeSec) -> TimeNanoSec {
 }
 
 /// Convert a nanosecond timestamp to seconds, relative to some epoch.
+///
+/// Does not allow the timestamp to fall before the epoch.
 pub fn try_to_secs_relative(timestamp: TimeNanoSec, epoch: TimeNanoSec) -> Result<TimeSec> {
     timestamp.checked_sub(epoch)
         .ok_or_else(|| {
@@ -77,6 +79,18 @@ pub fn try_to_secs_relative(timestamp: TimeNanoSec, epoch: TimeNanoSec) -> Resul
             ))
         })
         .map(to_secs)
+}
+
+/// Convert a nanosecond timestamp to seconds, relative to some epoch.
+///
+/// Allows the timestamp to fall before the epoch, in which case a negative
+/// value is returned.
+pub fn to_secs_relative(timestamp: TimeNanoSec, epoch: TimeNanoSec) -> TimeSec {
+    if timestamp >= epoch {
+        to_secs(timestamp - epoch)
+    } else {
+        -to_secs(epoch - timestamp)
+    }
 }
 
 pub trait Timestamp {

--- a/examples/simulator/analyzer/src/task.rs
+++ b/examples/simulator/analyzer/src/task.rs
@@ -9,7 +9,7 @@ use quent_simulator_events::task::{
     Allocating, Computing, Loading, Queueing, Sending, Spilling, TaskEvent,
 };
 use quent_time::{
-    TimeOrderedCollector, TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec, try_to_secs_relative,
+    TimeOrderedCollector, TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec, to_secs_relative,
 };
 use quent_ui::{FiniteStateMachine, FsmTransition, FsmUsage};
 use smallvec::{SmallVec, smallvec};
@@ -226,7 +226,7 @@ impl Task {
                                 .collect(),
                         })
                         .collect(),
-                    timestamp: try_to_secs_relative(t.timestamp(), epoch)?,
+                    timestamp: to_secs_relative(t.timestamp(), epoch),
                 })
             })
             .collect::<AnalyzerResult<Vec<_>>>()?;


### PR DESCRIPTION
In the query engine case, when the resource tree contains multiple resources used across multiple queries, long entities using that resource of another query can have negative timestamps relative to some other query. Negative timestamps were not allowed relative to query start, this PR allows them.

Also filter out any long entities that fall completely outside the window.