### PR TITLE
test: add more simulated operator stats

### DIFF
--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -807,39 +807,108 @@ impl Worker {
         }
 
         // Set some stats
+        macro_rules! attr {
+            (u64 $name:expr, $range:expr) => { Attribute::u64($name, rng().random_range($range)) };
+            (u32 $name:expr, $val:expr) => { Attribute::u32($name, $val) };
+            (f64 $name:expr, $range:expr) => { Attribute::f64($name, rng().random_range($range)) };
+            (str $name:expr, $val:expr) => { Attribute::string($name, $val) };
+            (pick $name:expr, $($choice:expr),+) => {
+                Attribute::string($name, *rng().sample(Choose::new(&[$($choice),+]).unwrap()))
+            };
+        }
+
         let op_obs = context.operator_observer();
         let port_obs = context.port_observer();
         for node_idx in nodes.iter() {
             let op = &physical_plan.dag[*node_idx];
-            let mut attributes = vec![Attribute::u64(
-                "tasks_processed",
-                op.tasks_processed.load(Ordering::Relaxed),
-            )];
+            let tasks_processed = op.tasks_processed.load(Ordering::Relaxed);
+
+            // Common metrics for all operators
+            let mut attributes = vec![
+                Attribute::u64("tasks_processed", tasks_processed),
+                attr!(u64 "wall_time_ns",       100_000..5_000_000_000),
+                attr!(u64 "cpu_time_ns",        50_000..4_000_000_000),
+                attr!(u64 "peak_memory_bytes",  1024..512 * 1024 * 1024),
+                attr!(u64 "output_rows",        0..10_000_000),
+                attr!(u64 "output_bytes",       0..2u64 * 1024 * 1024 * 1024),
+                attr!(u64 "input_rows",         0..50_000_000),
+                attr!(u64 "input_bytes",        0..4u64 * 1024 * 1024 * 1024),
+                attr!(u64 "num_batches",        1..2048),
+                attr!(f64 "avg_batch_rows",     64.0..65536.0),
+            ];
 
             match op.kind {
-                Physical::FileSystemScan => {
-                    attributes.push(Attribute::string("file_name", "/dev/null"))
-                }
-                Physical::JoinPartition => {
-                    attributes.push(Attribute::u64(
-                        "average_partition_size_bytes",
-                        rng().random_range(1..1024 * 1024 * 1024),
-                    ));
-                    attributes.push(Attribute::string(
-                        "join_strategy",
-                        *rng().sample(Choose::new(&["broadcast", "hash partition"]).unwrap()),
-                    ))
-                }
-                Physical::JoinLocal => (),
-                Physical::Sort => attributes.push(Attribute::string(
-                    "direction",
-                    *rng().sample(Choose::new(&["asc", "desc"]).unwrap()),
-                )),
-                Physical::Limit => attributes.push(Attribute::u32("amount", 42)),
-                Physical::Output => attributes.push(Attribute::string(
-                    "sink",
-                    *rng().sample(Choose::new(&["file", "memory"]).unwrap()),
-                )),
+                Physical::FileSystemScan => attributes.extend([
+                    attr!(str "file_name",              "/dev/null"),
+                    attr!(u64 "files_scanned",          1..256),
+                    attr!(u64 "bytes_read",             1024..8u64 * 1024 * 1024 * 1024),
+                    attr!(u64 "row_groups_read",        1..1024),
+                    attr!(u64 "row_groups_skipped",     0..512),
+                    attr!(u64 "pages_read",             1..8192),
+                    attr!(u64 "pages_decompressed",     1..8192),
+                    attr!(u64 "io_wait_ns",             10_000..2_000_000_000),
+                    attr!(f64 "io_throughput_mbs",      50.0..6000.0),
+                    attr!(u64 "decompress_time_ns",     10_000..500_000_000),
+                    attr!(u64 "predicate_filter_time_ns", 0..100_000_000),
+                    attr!(f64 "predicate_selectivity",  0.001..1.0),
+                    attr!(u64 "null_count",             0..100_000),
+                    attr!(u64 "columns_projected",      1..64),
+                ]),
+                Physical::JoinPartition => attributes.extend([
+                    attr!(u64  "average_partition_size_bytes", 1..1024 * 1024 * 1024),
+                    attr!(pick "join_strategy",          "broadcast", "hash partition"),
+                    attr!(u64  "num_partitions",         2..256),
+                    attr!(u64  "partition_time_ns",      100_000..1_000_000_000),
+                    attr!(u64  "hash_time_ns",           50_000..500_000_000),
+                    attr!(f64  "partition_skew",         0.0..5.0),
+                    attr!(u64  "max_partition_rows",     100..1_000_000),
+                    attr!(u64  "min_partition_rows",     0..10_000),
+                    attr!(u64  "build_side_bytes",       1024..2u64 * 1024 * 1024 * 1024),
+                    attr!(u64  "probe_side_bytes",       1024..4u64 * 1024 * 1024 * 1024),
+                    attr!(u64  "network_bytes_sent",     0..2u64 * 1024 * 1024 * 1024),
+                    attr!(u64  "network_time_ns",        0..2_000_000_000),
+                ]),
+                Physical::JoinLocal => attributes.extend([
+                    attr!(u64 "hash_table_size_bytes",   1024..2u64 * 1024 * 1024 * 1024),
+                    attr!(u64 "hash_table_entries",      100..50_000_000),
+                    attr!(u64 "build_time_ns",           100_000..2_000_000_000),
+                    attr!(u64 "probe_time_ns",           100_000..3_000_000_000),
+                    attr!(u64 "build_rows",              100..10_000_000),
+                    attr!(u64 "probe_rows",              100..50_000_000),
+                    attr!(u64 "match_rows",              0..10_000_000),
+                    attr!(f64 "hash_collision_rate",     0.0..0.3),
+                    attr!(u64 "spill_count",             0..32),
+                    attr!(u64 "spill_bytes",             0..4u64 * 1024 * 1024 * 1024),
+                    attr!(u64 "bloom_filter_size_bytes", 0..64 * 1024 * 1024),
+                    attr!(f64 "bloom_filter_fpr",        0.001..0.1),
+                ]),
+                Physical::Sort => attributes.extend([
+                    attr!(pick "direction",              "asc", "desc"),
+                    attr!(u64  "sort_keys",              1..8),
+                    attr!(u64  "comparison_count",       1000..500_000_000),
+                    attr!(u64  "merge_passes",           1..16),
+                    attr!(u64  "run_count",              1..512),
+                    attr!(u64  "spill_count",            0..64),
+                    attr!(u64  "spill_bytes",            0..4u64 * 1024 * 1024 * 1024),
+                    attr!(u64  "merge_time_ns",          100_000..2_000_000_000),
+                    attr!(f64  "avg_key_length_bytes",   4.0..256.0),
+                    attr!(f64  "presorted_fraction",     0.0..1.0),
+                ]),
+                Physical::Limit => attributes.extend([
+                    attr!(u32 "amount",                  42),
+                    attr!(u64 "rows_inspected",          42..10_000_000),
+                    attr!(u64 "rows_emitted",            1..43),
+                    attr!(f64 "early_termination_ratio", 0.0..1.0),
+                ]),
+                Physical::Output => attributes.extend([
+                    attr!(pick "sink",                   "file", "memory"),
+                    attr!(u64  "rows_written",           0..10_000_000),
+                    attr!(u64  "bytes_written",          0..4u64 * 1024 * 1024 * 1024),
+                    attr!(u64  "flush_count",            1..128),
+                    attr!(u64  "flush_time_ns",          10_000..500_000_000),
+                    attr!(f64  "compression_ratio",      0.1..0.9),
+                    attr!(u64  "serialization_time_ns",  10_000..1_000_000_000),
+                ]),
             }
             op_obs.statistics(
                 op.id,

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -856,15 +856,28 @@ impl Worker {
                         attr!(u64 "null_count",             0..100_000),
                         attr!(u64 "columns_projected",      1..64),
                         // Per-file byte counts
-                        Attribute::list("per_file_bytes_read", List::U64(
-                            (0..num_files).map(|_| rng().random_range(1024..1024 * 1024 * 1024)).collect()
-                        )),
+                        Attribute::list(
+                            "per_file_bytes_read",
+                            List::U64(
+                                (0..num_files)
+                                    .map(|_| rng().random_range(1024..1024 * 1024 * 1024))
+                                    .collect(),
+                            ),
+                        ),
                         // Column projection info
-                        Attribute::list("projected_column_names", List::String(
-                            ["id", "name", "ts", "amount", "region", "status", "category", "score"]
-                                .iter().take(rng().random_range(1..8))
-                                .map(|s| s.to_string()).collect()
-                        )),
+                        Attribute::list(
+                            "projected_column_names",
+                            List::String(
+                                [
+                                    "id", "name", "ts", "amount", "region", "status", "category",
+                                    "score",
+                                ]
+                                .iter()
+                                .take(rng().random_range(1..8))
+                                .map(|s| s.to_string())
+                                .collect(),
+                            ),
+                        ),
                     ]);
                 }
                 Physical::JoinPartition => {
@@ -883,9 +896,14 @@ impl Worker {
                         attr!(u64  "network_bytes_sent",     0..2u64 * 1024 * 1024 * 1024),
                         attr!(u64  "network_time_ns",        0..2_000_000_000),
                         // Row count per partition
-                        Attribute::list("partition_row_counts", List::U64(
-                            (0..num_partitions).map(|_| rng().random_range(0..1_000_000)).collect()
-                        )),
+                        Attribute::list(
+                            "partition_row_counts",
+                            List::U64(
+                                (0..num_partitions)
+                                    .map(|_| rng().random_range(0..1_000_000))
+                                    .collect(),
+                            ),
+                        ),
                     ]);
                 }
                 Physical::JoinLocal => attributes.extend([
@@ -902,19 +920,37 @@ impl Worker {
                     attr!(u64 "bloom_filter_size_bytes", 0..64 * 1024 * 1024),
                     attr!(f64 "bloom_filter_fpr",        0.001..0.1),
                     // Join key columns
-                    Attribute::list("join_keys", List::String(
-                        vec!["id", "region_id", "ts"]
-                            .into_iter().take(rng().random_range(1..4))
-                            .map(|s| s.to_string()).collect()
-                    )),
+                    Attribute::list(
+                        "join_keys",
+                        List::String(
+                            vec!["id", "region_id", "ts"]
+                                .into_iter()
+                                .take(rng().random_range(1..4))
+                                .map(|s| s.to_string())
+                                .collect(),
+                        ),
+                    ),
                     // Per-spill detail: list of structs with bytes + time
-                    Attribute::list("spill_events", List::Struct(
-                        (0..rng().random_range(0u64..4)).map(|_| Struct(vec![
-                            Attribute::u64("bytes", rng().random_range(1024..1024 * 1024 * 1024)),
-                            Attribute::u64("time_ns", rng().random_range(10_000..500_000_000)),
-                            Attribute::u64("rows", rng().random_range(1000..1_000_000)),
-                        ])).collect()
-                    )),
+                    Attribute::list(
+                        "spill_events",
+                        List::Struct(
+                            (0..rng().random_range(0u64..4))
+                                .map(|_| {
+                                    Struct(vec![
+                                        Attribute::u64(
+                                            "bytes",
+                                            rng().random_range(1024..1024 * 1024 * 1024),
+                                        ),
+                                        Attribute::u64(
+                                            "time_ns",
+                                            rng().random_range(10_000..500_000_000),
+                                        ),
+                                        Attribute::u64("rows", rng().random_range(1000..1_000_000)),
+                                    ])
+                                })
+                                .collect(),
+                        ),
+                    ),
                 ]),
                 Physical::Sort => {
                     let num_keys: usize = rng().random_range(1..8);
@@ -930,16 +966,31 @@ impl Worker {
                         attr!(f64  "avg_key_length_bytes",   4.0..256.0),
                         attr!(f64  "presorted_fraction",     0.0..1.0),
                         // Per sort-key specification
-                        Attribute::list("key_specs", List::Struct(
-                            ["ts", "amount", "id", "score", "name", "region", "category", "status"]
-                                .iter().take(num_keys).map(|col| Struct(vec![
-                                    Attribute::string("column", *col),
-                                    Attribute::string("direction",
-                                        *rng().sample(Choose::new(&["asc", "desc"]).unwrap())),
-                                    Attribute::string("nulls",
-                                        *rng().sample(Choose::new(&["first", "last"]).unwrap())),
-                                ])).collect()
-                        )),
+                        Attribute::list(
+                            "key_specs",
+                            List::Struct(
+                                [
+                                    "ts", "amount", "id", "score", "name", "region", "category",
+                                    "status",
+                                ]
+                                .iter()
+                                .take(num_keys)
+                                .map(|col| {
+                                    Struct(vec![
+                                        Attribute::string("column", *col),
+                                        Attribute::string(
+                                            "direction",
+                                            *rng().sample(Choose::new(&["asc", "desc"]).unwrap()),
+                                        ),
+                                        Attribute::string(
+                                            "nulls",
+                                            *rng().sample(Choose::new(&["first", "last"]).unwrap()),
+                                        ),
+                                    ])
+                                })
+                                .collect(),
+                            ),
+                        ),
                     ]);
                 }
                 Physical::Limit => attributes.extend([
@@ -959,9 +1010,14 @@ impl Worker {
                         attr!(f64  "compression_ratio",      0.1..0.9),
                         attr!(u64  "serialization_time_ns",  10_000..1_000_000_000),
                         // Per-flush durations
-                        Attribute::list("per_flush_time_ns", List::U64(
-                            (0..flush_count).map(|_| rng().random_range(1000..10_000_000)).collect()
-                        )),
+                        Attribute::list(
+                            "per_flush_time_ns",
+                            List::U64(
+                                (0..flush_count)
+                                    .map(|_| rng().random_range(1000..10_000_000))
+                                    .collect(),
+                            ),
+                        ),
                     ]);
                 }
             }

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 
 use clap::Parser;
 use petgraph::{Directed, Direction, Graph, graph::NodeIndex, visit::EdgeRef};
-use quent_attributes::Attribute;
+use quent_attributes::{Attribute, List, Struct};
 use quent_events::resource::{self, channel, memory};
 use quent_exporter::{
     CollectorExporterOptions, ExporterOptions, MsgpackExporterOptions, NdjsonExporterOptions,
@@ -838,36 +838,56 @@ impl Worker {
             ];
 
             match op.kind {
-                Physical::FileSystemScan => attributes.extend([
-                    attr!(str "file_name",              "/dev/null"),
-                    attr!(u64 "files_scanned",          1..256),
-                    attr!(u64 "bytes_read",             1024..8u64 * 1024 * 1024 * 1024),
-                    attr!(u64 "row_groups_read",        1..1024),
-                    attr!(u64 "row_groups_skipped",     0..512),
-                    attr!(u64 "pages_read",             1..8192),
-                    attr!(u64 "pages_decompressed",     1..8192),
-                    attr!(u64 "io_wait_ns",             10_000..2_000_000_000),
-                    attr!(f64 "io_throughput_mbs",      50.0..6000.0),
-                    attr!(u64 "decompress_time_ns",     10_000..500_000_000),
-                    attr!(u64 "predicate_filter_time_ns", 0..100_000_000),
-                    attr!(f64 "predicate_selectivity",  0.001..1.0),
-                    attr!(u64 "null_count",             0..100_000),
-                    attr!(u64 "columns_projected",      1..64),
-                ]),
-                Physical::JoinPartition => attributes.extend([
-                    attr!(u64  "average_partition_size_bytes", 1..1024 * 1024 * 1024),
-                    attr!(pick "join_strategy",          "broadcast", "hash partition"),
-                    attr!(u64  "num_partitions",         2..256),
-                    attr!(u64  "partition_time_ns",      100_000..1_000_000_000),
-                    attr!(u64  "hash_time_ns",           50_000..500_000_000),
-                    attr!(f64  "partition_skew",         0.0..5.0),
-                    attr!(u64  "max_partition_rows",     100..1_000_000),
-                    attr!(u64  "min_partition_rows",     0..10_000),
-                    attr!(u64  "build_side_bytes",       1024..2u64 * 1024 * 1024 * 1024),
-                    attr!(u64  "probe_side_bytes",       1024..4u64 * 1024 * 1024 * 1024),
-                    attr!(u64  "network_bytes_sent",     0..2u64 * 1024 * 1024 * 1024),
-                    attr!(u64  "network_time_ns",        0..2_000_000_000),
-                ]),
+                Physical::FileSystemScan => {
+                    let num_files: u64 = rng().random_range(1..256);
+                    attributes.extend([
+                        attr!(str "file_name",              "/dev/null"),
+                        Attribute::u64("files_scanned", num_files),
+                        attr!(u64 "bytes_read",             1024..8u64 * 1024 * 1024 * 1024),
+                        attr!(u64 "row_groups_read",        1..1024),
+                        attr!(u64 "row_groups_skipped",     0..512),
+                        attr!(u64 "pages_read",             1..8192),
+                        attr!(u64 "pages_decompressed",     1..8192),
+                        attr!(u64 "io_wait_ns",             10_000..2_000_000_000),
+                        attr!(f64 "io_throughput_mbs",      50.0..6000.0),
+                        attr!(u64 "decompress_time_ns",     10_000..500_000_000),
+                        attr!(u64 "predicate_filter_time_ns", 0..100_000_000),
+                        attr!(f64 "predicate_selectivity",  0.001..1.0),
+                        attr!(u64 "null_count",             0..100_000),
+                        attr!(u64 "columns_projected",      1..64),
+                        // Per-file byte counts
+                        Attribute::list("per_file_bytes_read", List::U64(
+                            (0..num_files).map(|_| rng().random_range(1024..1024 * 1024 * 1024)).collect()
+                        )),
+                        // Column projection info
+                        Attribute::list("projected_column_names", List::String(
+                            ["id", "name", "ts", "amount", "region", "status", "category", "score"]
+                                .iter().take(rng().random_range(1..8))
+                                .map(|s| s.to_string()).collect()
+                        )),
+                    ]);
+                }
+                Physical::JoinPartition => {
+                    let num_partitions: u64 = rng().random_range(2..256);
+                    attributes.extend([
+                        attr!(u64  "average_partition_size_bytes", 1..1024 * 1024 * 1024),
+                        attr!(pick "join_strategy",          "broadcast", "hash partition"),
+                        Attribute::u64("num_partitions", num_partitions),
+                        attr!(u64  "partition_time_ns",      100_000..1_000_000_000),
+                        attr!(u64  "hash_time_ns",           50_000..500_000_000),
+                        attr!(f64  "partition_skew",         0.0..5.0),
+                        attr!(u64  "max_partition_rows",     100..1_000_000),
+                        attr!(u64  "min_partition_rows",     0..10_000),
+                        attr!(u64  "build_side_bytes",       1024..2u64 * 1024 * 1024 * 1024),
+                        attr!(u64  "probe_side_bytes",       1024..4u64 * 1024 * 1024 * 1024),
+                        attr!(u64  "network_bytes_sent",     0..2u64 * 1024 * 1024 * 1024),
+                        attr!(u64  "network_time_ns",        0..2_000_000_000),
+                        // Row count per partition
+                        Attribute::list("partition_row_counts", List::U64(
+                            (0..num_partitions).map(|_| rng().random_range(0..1_000_000)).collect()
+                        )),
+                    ]);
+                }
                 Physical::JoinLocal => attributes.extend([
                     attr!(u64 "hash_table_size_bytes",   1024..2u64 * 1024 * 1024 * 1024),
                     attr!(u64 "hash_table_entries",      100..50_000_000),
@@ -881,34 +901,69 @@ impl Worker {
                     attr!(u64 "spill_bytes",             0..4u64 * 1024 * 1024 * 1024),
                     attr!(u64 "bloom_filter_size_bytes", 0..64 * 1024 * 1024),
                     attr!(f64 "bloom_filter_fpr",        0.001..0.1),
+                    // Join key columns
+                    Attribute::list("join_keys", List::String(
+                        vec!["id", "region_id", "ts"]
+                            .into_iter().take(rng().random_range(1..4))
+                            .map(|s| s.to_string()).collect()
+                    )),
+                    // Per-spill detail: list of structs with bytes + time
+                    Attribute::list("spill_events", List::Struct(
+                        (0..rng().random_range(0u64..4)).map(|_| Struct(vec![
+                            Attribute::u64("bytes", rng().random_range(1024..1024 * 1024 * 1024)),
+                            Attribute::u64("time_ns", rng().random_range(10_000..500_000_000)),
+                            Attribute::u64("rows", rng().random_range(1000..1_000_000)),
+                        ])).collect()
+                    )),
                 ]),
-                Physical::Sort => attributes.extend([
-                    attr!(pick "direction",              "asc", "desc"),
-                    attr!(u64  "sort_keys",              1..8),
-                    attr!(u64  "comparison_count",       1000..500_000_000),
-                    attr!(u64  "merge_passes",           1..16),
-                    attr!(u64  "run_count",              1..512),
-                    attr!(u64  "spill_count",            0..64),
-                    attr!(u64  "spill_bytes",            0..4u64 * 1024 * 1024 * 1024),
-                    attr!(u64  "merge_time_ns",          100_000..2_000_000_000),
-                    attr!(f64  "avg_key_length_bytes",   4.0..256.0),
-                    attr!(f64  "presorted_fraction",     0.0..1.0),
-                ]),
+                Physical::Sort => {
+                    let num_keys: usize = rng().random_range(1..8);
+                    attributes.extend([
+                        attr!(pick "direction",              "asc", "desc"),
+                        Attribute::u64("sort_keys", num_keys as u64),
+                        attr!(u64  "comparison_count",       1000..500_000_000),
+                        attr!(u64  "merge_passes",           1..16),
+                        attr!(u64  "run_count",              1..512),
+                        attr!(u64  "spill_count",            0..64),
+                        attr!(u64  "spill_bytes",            0..4u64 * 1024 * 1024 * 1024),
+                        attr!(u64  "merge_time_ns",          100_000..2_000_000_000),
+                        attr!(f64  "avg_key_length_bytes",   4.0..256.0),
+                        attr!(f64  "presorted_fraction",     0.0..1.0),
+                        // Per sort-key specification
+                        Attribute::list("key_specs", List::Struct(
+                            ["ts", "amount", "id", "score", "name", "region", "category", "status"]
+                                .iter().take(num_keys).map(|col| Struct(vec![
+                                    Attribute::string("column", *col),
+                                    Attribute::string("direction",
+                                        *rng().sample(Choose::new(&["asc", "desc"]).unwrap())),
+                                    Attribute::string("nulls",
+                                        *rng().sample(Choose::new(&["first", "last"]).unwrap())),
+                                ])).collect()
+                        )),
+                    ]);
+                }
                 Physical::Limit => attributes.extend([
                     attr!(u32 "amount",                  42),
                     attr!(u64 "rows_inspected",          42..10_000_000),
                     attr!(u64 "rows_emitted",            1..43),
                     attr!(f64 "early_termination_ratio", 0.0..1.0),
                 ]),
-                Physical::Output => attributes.extend([
-                    attr!(pick "sink",                   "file", "memory"),
-                    attr!(u64  "rows_written",           0..10_000_000),
-                    attr!(u64  "bytes_written",          0..4u64 * 1024 * 1024 * 1024),
-                    attr!(u64  "flush_count",            1..128),
-                    attr!(u64  "flush_time_ns",          10_000..500_000_000),
-                    attr!(f64  "compression_ratio",      0.1..0.9),
-                    attr!(u64  "serialization_time_ns",  10_000..1_000_000_000),
-                ]),
+                Physical::Output => {
+                    let flush_count: u64 = rng().random_range(1..128);
+                    attributes.extend([
+                        attr!(pick "sink",                   "file", "memory"),
+                        attr!(u64  "rows_written",           0..10_000_000),
+                        attr!(u64  "bytes_written",          0..4u64 * 1024 * 1024 * 1024),
+                        Attribute::u64("flush_count", flush_count),
+                        attr!(u64  "flush_time_ns",          10_000..500_000_000),
+                        attr!(f64  "compression_ratio",      0.1..0.9),
+                        attr!(u64  "serialization_time_ns",  10_000..1_000_000_000),
+                        // Per-flush durations
+                        Attribute::list("per_flush_time_ns", List::U64(
+                            (0..flush_count).map(|_| rng().random_range(1000..10_000_000)).collect()
+                        )),
+                    ]);
+                }
             }
             op_obs.statistics(
                 op.id,


### PR DESCRIPTION
Useful for UI dev, e.g. operator/edge heatmaps in plans, testing hover boxes, etc.

Example from simulator run:

<img width="573" height="821" alt="image" src="https://github.com/user-attachments/assets/da6d9d33-cb55-4a23-b30c-384e07c6a116" />
