### PR TITLE
fix(ui): explicit y-axis bounds

### DIFF
--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -88,6 +88,9 @@ export function Timeline({
   const yAxisOptions = useMemo(
     () => ({
       type: 'value',
+      min: 0,
+      // Adds a 10% padding to the top of the bars
+      max: (value: { max: number }) => value.max * 1.1 || 1,
       splitNumber: 1,
       show: true,
       axisLine: {


### PR DESCRIPTION
Define the yaxis min/max to avoid echarts determining it itself. This prevents y-axis bounds jumping 

Before:

https://github.com/user-attachments/assets/7801a0e8-704b-4272-9cf0-d148a7fb456c


After:

https://github.com/user-attachments/assets/f9a6a5ff-05d8-48c3-a84a-60be20f4b7ae

