### PR TITLE
feat: list engines with metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ts-rs",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "quent-attributes",
  "quent-events",
  "quent-query-engine-analyzer",
+ "quent-query-engine-events",
  "quent-query-engine-ui",
  "quent-simulator-events",
  "quent-simulator-ui",

--- a/domains/query_engine/analyzer/src/ui.rs
+++ b/domains/query_engine/analyzer/src/ui.rs
@@ -24,6 +24,22 @@ pub trait UiAnalyzer {
     where
         Self: Sized;
 
+    /// Extract engine metadata from an event stream without fully building the model.
+    ///
+    /// Iterates events until the engine init event is found, then returns a
+    /// partial [`Engine`](ui::Engine) (without `duration_s`).
+    ///
+    /// The common case is for this event to be on of the first events ever
+    /// flushed, so it will typically be found early.
+    // TODO(johanpel): still this function should be used with care. We need
+    // some form of an engine index.
+    fn extract_engine(
+        engine_id: Uuid,
+        events: impl Iterator<Item = Event<Self::Event>>,
+    ) -> AnalyzerResult<ui::Engine>
+    where
+        Self: Sized;
+
     /// Deliver a UI-friendly [`QueryBundle`] with all high-level yet
     /// non-volumous information related to this query.
     fn query_bundle(&self, query_id: Uuid) -> AnalyzerResult<ui::QueryBundle<Self::EntityRef>>;

--- a/domains/query_engine/server/src/cache.rs
+++ b/domains/query_engine/server/src/cache.rs
@@ -1,7 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
 use moka::future::Cache;
-use quent_analyzer::AnalyzerResult;
 use quent_events::Event;
 use quent_query_engine_analyzer::ui::UiAnalyzer;
 use tracing::info_span;
@@ -9,9 +8,11 @@ use uuid::Uuid;
 
 use crate::error::{ServerError, ServerResult};
 
-pub type ImporterFn<A> = dyn Fn(Uuid) -> AnalyzerResult<Box<dyn Iterator<Item = Event<<A as UiAnalyzer>::Event>>>>
+pub type ImporterFn<A> = dyn Fn(Uuid) -> ServerResult<Box<dyn Iterator<Item = Event<<A as UiAnalyzer>::Event>>>>
     + Send
     + Sync;
+
+pub type ListerFn = dyn Fn() -> ServerResult<Vec<Uuid>> + Send + Sync;
 
 pub struct AnalyzerCache<A>
 where
@@ -19,6 +20,7 @@ where
 {
     analyzers: Cache<Uuid, Arc<A>>,
     importer: Arc<ImporterFn<A>>,
+    lister: Arc<ListerFn>,
 }
 
 impl<A> Clone for AnalyzerCache<A>
@@ -29,6 +31,7 @@ where
         Self {
             analyzers: self.analyzers.clone(),
             importer: Arc::clone(&self.importer),
+            lister: Arc::clone(&self.lister),
         }
     }
 }
@@ -37,14 +40,19 @@ impl<A> AnalyzerCache<A>
 where
     A: UiAnalyzer + Send + Sync + 'static,
 {
-    pub(crate) fn new(importer: Box<ImporterFn<A>>) -> Self {
+    pub(crate) fn new(importer: Box<ImporterFn<A>>, lister: Box<ListerFn>) -> Self {
         Self {
             analyzers: Cache::builder()
                 .max_capacity(32)
                 .time_to_idle(Duration::from_hours(24))
                 .build(),
             importer: Arc::from(importer),
+            lister: Arc::from(lister),
         }
+    }
+
+    pub(crate) fn list(&self) -> ServerResult<Vec<Uuid>> {
+        (self.lister)()
     }
 
     pub(crate) async fn get(&self, engine_id: Uuid) -> ServerResult<Arc<A>> {

--- a/domains/query_engine/server/src/cache.rs
+++ b/domains/query_engine/server/src/cache.rs
@@ -3,6 +3,7 @@ use std::{sync::Arc, time::Duration};
 use moka::future::Cache;
 use quent_events::Event;
 use quent_query_engine_analyzer::ui::UiAnalyzer;
+use quent_query_engine_ui as ui;
 use tracing::info_span;
 use uuid::Uuid;
 
@@ -53,6 +54,22 @@ where
 
     pub(crate) fn list(&self) -> ServerResult<Vec<Uuid>> {
         (self.lister)()
+    }
+
+    pub(crate) async fn list_with_metadata(&self) -> ServerResult<Vec<ui::Engine>> {
+        let ids = self.list()?;
+        let importer = Arc::clone(&self.importer);
+        tokio::task::spawn_blocking(move || {
+            let _span = info_span!("list_with_metadata").entered();
+            ids.into_iter()
+                .map(|id| {
+                    let events = importer(id)?;
+                    Ok(A::extract_engine(id, events)?)
+                })
+                .collect()
+        })
+        .await
+        .map_err(|e| ServerError::Cache(format!("blocking task panicked: {e}")))?
     }
 
     pub(crate) async fn get(&self, engine_id: Uuid) -> ServerResult<Arc<A>> {

--- a/domains/query_engine/server/src/error.rs
+++ b/domains/query_engine/server/src/error.rs
@@ -4,7 +4,7 @@ use quent_exporter_types::ImporterError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub(crate) enum ServerError {
+pub enum ServerError {
     #[error("analyzer error: {0}")]
     Analyzer(#[from] AnalyzerError),
     #[error("importer error: {0}")]
@@ -15,7 +15,7 @@ pub(crate) enum ServerError {
     Cache(String),
 }
 
-pub(crate) type ServerResult<T> = std::result::Result<T, ServerError>;
+pub type ServerResult<T> = std::result::Result<T, ServerError>;
 
 impl From<ServerError> for StatusCode {
     fn from(value: ServerError) -> Self {

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use tonic::transport::{Server as GrpcServer, server::Router};
 use tower_http::cors::CorsLayer;
 
-mod cache;
-mod error;
+pub mod cache;
+pub mod error;
 mod ui;
 
 pub fn initialize_tracing(log_level: &str) {
@@ -48,6 +48,7 @@ where
 
 pub fn analyzer_service_router<A>(
     importer: Box<cache::ImporterFn<A>>,
+    lister: Box<cache::ListerFn>,
     cors: Option<String>,
 ) -> Result<AxumRouter, Box<dyn std::error::Error>>
 where
@@ -58,7 +59,7 @@ where
     for<'de> <A as UiAnalyzer>::TimelineGlobalParams: serde::Deserialize<'de>,
     for<'de> <A as UiAnalyzer>::TimelineParams: serde::Deserialize<'de>,
 {
-    let cache = AnalyzerCache::<A>::new(importer);
+    let cache = AnalyzerCache::<A>::new(importer, lister);
 
     let mut http_routes = axum::Router::new().nest("/analyzer", ui::routes(cache));
 

--- a/domains/query_engine/server/src/ui.rs
+++ b/domains/query_engine/server/src/ui.rs
@@ -11,50 +11,19 @@ use quent_ui::timeline::{
     request::{BulkTimelineRequest, SingleTimelineRequest},
     response::{BulkTimelinesResponse, SingleTimelineResponse},
 };
-use tracing::error;
 use uuid::Uuid;
 
 use crate::{cache::AnalyzerCache, error::ServerResult};
 
 // TODO(johanpel): pagination
 #[tracing::instrument(skip_all, err)]
-async fn list_engines() -> ServerResult<Json<Vec<Uuid>>> {
-    let entries = match std::fs::read_dir("data") {
-        Ok(entries) => entries,
-        Err(e) => {
-            error!("unable read directory: {e}");
-            Err(e)?
-        }
-    };
-
-    let mut ids = Vec::new();
-    for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(e) => {
-                error!("entry error: {e}");
-                Err(e)?
-            }
-        };
-        let path = entry.path();
-
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|e| e.to_str()) != Some("ndjson") {
-            continue;
-        }
-        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-            match Uuid::parse_str(stem) {
-                Ok(uuid) => ids.push(uuid),
-                Err(_) => {
-                    continue;
-                }
-            }
-        }
-    }
-
-    Ok(Json(ids))
+async fn list_engines<A>(
+    State(state): State<AnalyzerCache<A>>,
+) -> ServerResult<Json<Vec<Uuid>>>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+{
+    Ok(Json(state.list()?))
 }
 
 #[tracing::instrument(skip_all, err)]

--- a/domains/query_engine/server/src/ui.rs
+++ b/domains/query_engine/server/src/ui.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json, Router,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     routing::{get, post},
 };
 
@@ -11,19 +11,32 @@ use quent_ui::timeline::{
     request::{BulkTimelineRequest, SingleTimelineRequest},
     response::{BulkTimelinesResponse, SingleTimelineResponse},
 };
+use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{cache::AnalyzerCache, error::ServerResult};
+
+#[derive(Deserialize)]
+struct ListEnginesQuery {
+    #[serde(default)]
+    with_metadata: bool,
+}
 
 // TODO(johanpel): pagination
 #[tracing::instrument(skip_all, err)]
 async fn list_engines<A>(
     State(state): State<AnalyzerCache<A>>,
-) -> ServerResult<Json<Vec<Uuid>>>
+    Query(query): Query<ListEnginesQuery>,
+) -> ServerResult<Json<Vec<ui::Engine>>>
 where
     A: UiAnalyzer + Send + Sync + 'static,
 {
-    Ok(Json(state.list()?))
+    if query.with_metadata {
+        Ok(Json(state.list_with_metadata().await?))
+    } else {
+        let ids = state.list()?;
+        Ok(Json(ids.into_iter().map(ui::Engine::new).collect()))
+    }
 }
 
 #[tracing::instrument(skip_all, err)]

--- a/domains/query_engine/ui/src/lib.rs
+++ b/domains/query_engine/ui/src/lib.rs
@@ -37,13 +37,29 @@ pub struct Engine {
     /// The ID of this [`Engine`].
     pub id: Uuid,
     /// The timestamp at which this [`Engine`] started.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time_unix_ns: Option<TimeUnixNanoSec>,
     /// The duration for which this [`Engine`] was alive.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_s: Option<TimeSec>,
     /// The name of this [`Engine`] instance.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub instance_name: Option<String>,
     /// Details about the Engine implementation.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub implementation: Option<EngineImplementationAttributes>,
+}
+
+impl Engine {
+    pub fn new(id: Uuid) -> Self {
+        Self {
+            id,
+            start_time_unix_ns: None,
+            duration_s: None,
+            instance_name: None,
+            implementation: None,
+        }
+    }
 }
 
 /// A group of [`Query`]s.

--- a/examples/simulator/analyzer/Cargo.toml
+++ b/examples/simulator/analyzer/Cargo.toml
@@ -8,6 +8,7 @@ quent-analyzer = { path = "../../../crates/analyzer" }
 quent-attributes = { path = "../../../crates/attributes" }
 quent-events = { path = "../../../crates/events" }
 quent-query-engine-analyzer = { path = "../../../domains/query_engine/analyzer" }
+quent-query-engine-events = { path = "../../../domains/query_engine/events" }
 quent-query-engine-ui = { path = "../../../domains/query_engine/ui" }
 quent-simulator-events = { path = "../events" }
 quent-simulator-ui = { path = "../ui" }

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -52,6 +52,31 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
     type TimelineGlobalParams = QueryFilter;
     type TimelineParams = TaskFilter;
 
+    fn extract_engine(
+        engine_id: Uuid,
+        events: impl Iterator<Item = Event<SimulatorEvent>>,
+    ) -> AnalyzerResult<quent_query_engine_ui::Engine> {
+        use quent_query_engine_events::{QueryEngineEvent, engine::EngineEvent};
+        for event in events {
+            if let SimulatorEvent::QueryEngineEvent(QueryEngineEvent::Engine(EngineEvent::Init(
+                init,
+            ))) = event.data
+            {
+                return Ok(quent_query_engine_ui::Engine {
+                    id: engine_id,
+                    start_time_unix_ns: Some(event.timestamp),
+                    duration_s: None,
+                    instance_name: init.instance_name,
+                    implementation: init
+                        .implementation
+                        .as_ref()
+                        .map(quent_query_engine_ui::EngineImplementationAttributes::from),
+                });
+            }
+        }
+        Ok(quent_query_engine_ui::Engine::new(engine_id))
+    }
+
     fn try_new(
         engine_id: Uuid,
         events: impl Iterator<Item = Event<SimulatorEvent>>,

--- a/examples/simulator/server/Cargo.toml
+++ b/examples/simulator/server/Cargo.toml
@@ -13,6 +13,7 @@ quent-simulator-analyzer = { path = "../analyzer" }
 quent-simulator-events = { path = "../events" }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"]}
 tracing.workspace = true
+uuid.workspace = true
 
 [build-dependencies]
 ts-rs = {workspace = true, features = ["uuid-impl", "serde-json-impl"] }

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -156,8 +156,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let analyzer = async {
         axum::serve(
             TcpListener::bind(analyzer_addr).await?,
-            analyzer_service_router::<SimulatorUiAnalyzer>(Box::new(importer), Box::new(lister), cors_address)?
-                .into_make_service(),
+            analyzer_service_router::<SimulatorUiAnalyzer>(
+                Box::new(importer),
+                Box::new(lister),
+                cors_address,
+            )?
+            .into_make_service(),
         )
         .await?;
         Ok::<(), Box<dyn std::error::Error>>(())

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -1,5 +1,7 @@
 use std::{net::ToSocketAddrs, path::PathBuf};
 
+use uuid::Uuid;
+
 use clap::Parser;
 use quent_collector::server::CollectorServiceOptions;
 use quent_exporter::{
@@ -85,6 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or_else(|| format!("unable to resolve socket address: {collector_address}"))?;
 
     let importer_output_dir = output_dir.clone();
+    let lister_output_dir = output_dir.clone();
 
     let exporter_kind = match exporter.as_str() {
         "ndjson" => ExporterOptions::Ndjson(NdjsonExporterOptions { output_dir }),
@@ -108,6 +111,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .next()
         .ok_or_else(|| format!("unable to resolve socket address: {analyzer_address}"))?;
 
+    let lister = move || {
+        let extensions = ["ndjson", "msgpack", "postcard"];
+        let mut ids = std::collections::HashSet::new();
+        for entry in std::fs::read_dir(&lister_output_dir)? {
+            let path = entry?.path();
+            if !path.is_file() {
+                continue;
+            }
+            let has_known_ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|ext| extensions.contains(&ext));
+            if !has_known_ext {
+                continue;
+            }
+            if let Some(id) = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| Uuid::parse_str(s).ok())
+            {
+                ids.insert(id);
+            }
+        }
+        Ok(ids.into_iter().collect())
+    };
+
     let importer = move |engine_id| {
         let postcard_path = importer_output_dir.join(format!("{engine_id}.postcard"));
         let msgpack_path = importer_output_dir.join(format!("{engine_id}.msgpack"));
@@ -127,7 +156,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let analyzer = async {
         axum::serve(
             TcpListener::bind(analyzer_addr).await?,
-            analyzer_service_router::<SimulatorUiAnalyzer>(Box::new(importer), cors_address)?
+            analyzer_service_router::<SimulatorUiAnalyzer>(Box::new(importer), Box::new(lister), cors_address)?
                 .into_make_service(),
         )
         .await?;

--- a/ui/src/components/NavBarNavigator.tsx
+++ b/ui/src/components/NavBarNavigator.tsx
@@ -150,7 +150,7 @@ export function NavBarNavigator() {
       <BreadcrumbDropdown
         label={engine}
         activeId={engineId}
-        items={engines?.map(id => ({ id, label: id }))}
+        items={engines?.map(e => ({ id: e.id, label: e.instance_name ?? e.id }))}
         onSelect={handleEngineChange}
       />
       <ChevronRight className="h-3.5 w-3.5 shrink-0" />

--- a/ui/src/pages/EngineSelectionPage.tsx
+++ b/ui/src/pages/EngineSelectionPage.tsx
@@ -79,8 +79,8 @@ export function EngineSelectionPage() {
                 </SelectItem>
               ) : (
                 enginesList.data?.map(engine => (
-                  <SelectItem key={engine} value={engine}>
-                    {engine}
+                  <SelectItem key={engine.id} value={engine.id}>
+                    {engine.instance_name ?? engine.id}
                   </SelectItem>
                 ))
               )}

--- a/ui/src/routes/profile.index.test.tsx
+++ b/ui/src/routes/profile.index.test.tsx
@@ -10,7 +10,11 @@ describe('EngineSelectionPage', () => {
     // Set up default handlers for the profile page API endpoints
     server.use(
       http.get(`${API_BASE}/engines`, () => {
-        return HttpResponse.json(['engine-1', 'engine-2', 'engine-3']);
+        return HttpResponse.json([
+          { id: 'engine-1', instance_name: 'engine-1' },
+          { id: 'engine-2', instance_name: 'engine-2' },
+          { id: 'engine-3', instance_name: 'engine-3' },
+        ]);
       }),
       http.get(`${API_BASE}/engines/:engineId/query-groups`, ({ params }) => {
         const { engineId } = params;

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -13,6 +13,7 @@ import type { BulkTimelineRequest } from '~quent/types/BulkTimelineRequest';
 import type { QueryFilter } from '~quent/types/QueryFilter';
 import type { TaskFilter } from '~quent/types/TaskFilter';
 import type { EntityRef } from '~quent/types/EntityRef';
+import type { Engine } from '~quent/types/Engine';
 
 // Use relative URL by default to leverage Vite's proxy (both dev and preview)
 // Set VITE_API_BASE_URL to override (e.g., for direct API access without proxy)
@@ -157,8 +158,8 @@ export async function fetchQueryBundle(
   return apiFetch<QueryBundle<EntityRef>>(`/engines/${engineId}/query/${queryId}`);
 }
 
-export async function fetchListEngines(): Promise<string[]> {
-  return apiFetch<string[]>('/engines');
+export async function fetchListEngines(): Promise<Engine[]> {
+  return apiFetch<Engine[]>('/engines', { params: { with_metadata: true } });
 }
 
 export async function fetchListCoordinators(engineId: string): Promise<QueryGroup[]> {

--- a/webserver/tests/test_engines.py
+++ b/webserver/tests/test_engines.py
@@ -18,7 +18,7 @@ def test_list_engines(client, mock_rust_client, sample_engine_data):
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["id"] == "engine-1"
-    mock_rust_client.get.assert_called_once_with("/analyzer/list_engines")
+    mock_rust_client.get.assert_called_once_with("/analyzer/list_engines", params={"with_metadata": "false"})
 
 
 @pytest.mark.unit

--- a/webserver/webserver/routers/engines.py
+++ b/webserver/webserver/routers/engines.py
@@ -17,11 +17,11 @@ router = APIRouter(prefix="/engines", tags=["engines"])
 
 
 @router.get("/")
-async def list_engines() -> Any:
+async def list_engines(with_metadata: bool = Query(False, description="Include engine metadata")) -> Any:
     """
     List all available engines.
     """
-    return rust_client.get("/analyzer/list_engines")
+    return rust_client.get("/analyzer/list_engines", params={"with_metadata": str(with_metadata).lower()})
 
 
 @router.get("/{engine_id}")


### PR DESCRIPTION
This PR provides `list_engines` route with a `?with_metadata=true` parameter which will cause the event data to be loaded until the engine init event is found. This is commonly cheap as its the first event in the file. But it can potentially be expensive in the current shape of the project, as in the worst case that event is at the end and the whole file needs to be scanned. It's also not perfect yet because we don't have pagination. It's a stopgap solution until we have an engine indexing system.

`list_engines` in the query engine server crate still had a hardcoded path to `./data`, and it also only scanned for `ndjson` files instead of also `postcard` and `msgpack`. This PR fixes that too.