### PR TITLE
perf(ui): consolidate bulk fetching

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -39,3 +39,5 @@ coverage
 junit*
 
 stats.html
+# For now ignore agents md, add official one later
+AGENTS.md

--- a/ui/src/hooks/useBulkTimelineFetch.ts
+++ b/ui/src/hooks/useBulkTimelineFetch.ts
@@ -6,8 +6,8 @@ import type { ZoomRange } from '@/components/timeline/TimelineController';
 import type { TimelineRequest } from '~quent/types/TimelineRequest';
 import type { TaskFilter } from '~quent/types/TaskFilter';
 import { getResourceTypeName, setOperatorOnEntry } from '@/lib/timeline.utils';
+import type { BulkTimelinesResponse } from '~quent/types/BulkTimelinesResponse';
 import { timelineCacheKey, timelineDataAtom } from '@/atoms/timeline';
-import { BulkTimelinesResponse } from '~quent/types/BulkTimelinesResponse';
 
 export interface BulkTimelineIdMeta {
   resourceId: string;
@@ -19,6 +19,27 @@ export interface MergedBulkEntries {
   entries: Record<string, TimelineRequest<TaskFilter>>;
   idToMeta: Map<string, BulkTimelineIdMeta>;
   requestKey: string;
+}
+
+/**
+ * Distributes a bulk timeline response into per-item Jotai atoms.
+ * Skips entries whose status is not 'ok' or whose id has no meta mapping.
+ */
+export function applyBulkTimelineResponse(
+  response: BulkTimelinesResponse,
+  idToMeta: Map<string, BulkTimelineIdMeta>,
+  store: ReturnType<typeof import('jotai').useStore>
+): void {
+  for (const [id, entry] of Object.entries(response.entries)) {
+    if (entry?.status !== 'ok') continue;
+    const meta = idToMeta.get(id);
+    if (!meta) continue;
+    const key = timelineCacheKey(meta.resourceId, meta.resourceTypeName, meta.operatorId);
+    store.set(timelineDataAtom(key), {
+      data: entry.data,
+      config: entry.config,
+    });
+  }
 }
 
 /**
@@ -103,16 +124,7 @@ export function useBulkTimelineFetch({
 
   useEffect(() => {
     if (!data) return;
-    for (const [id, entry] of Object.entries(data.entries)) {
-      if (entry?.status !== 'ok') continue;
-      const meta = idToMeta.get(id);
-      if (!meta) continue;
-      const key = timelineCacheKey(meta.resourceId, meta.resourceTypeName, meta.operatorId);
-      store.set(timelineDataAtom(key), {
-        data: entry.data,
-        config: entry.config,
-      });
-    }
+    applyBulkTimelineResponse(data, idToMeta, store);
   }, [data, store, idToMeta]);
 
   return data;

--- a/ui/src/hooks/useBulkTimelineFetch.ts
+++ b/ui/src/hooks/useBulkTimelineFetch.ts
@@ -5,7 +5,7 @@ import { fetchBulkTimelines, DEFAULT_STALE_TIME } from '@/services/api';
 import type { ZoomRange } from '@/components/timeline/TimelineController';
 import type { TimelineRequest } from '~quent/types/TimelineRequest';
 import type { TaskFilter } from '~quent/types/TaskFilter';
-import { getResourceTypeName, setOperatorOnEntries } from '@/lib/timeline.utils';
+import { getResourceTypeName, setOperatorOnEntry } from '@/lib/timeline.utils';
 import { timelineCacheKey, timelineDataAtom } from '@/atoms/timeline';
 import { BulkTimelinesResponse } from '~quent/types/BulkTimelinesResponse';
 
@@ -43,7 +43,7 @@ export function buildMergedBulkEntries(
     });
     if (operatorId) {
       const opUuid = crypto.randomUUID();
-      const withOperator = setOperatorOnEntries({ [resourceId]: params }, operatorId)[resourceId];
+      const withOperator = setOperatorOnEntry(params, operatorId);
       entries[opUuid] = withOperator;
       idToMeta.set(opUuid, {
         resourceId,

--- a/ui/src/hooks/useBulkTimelineFetch.ts
+++ b/ui/src/hooks/useBulkTimelineFetch.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useStore } from 'jotai';
 import { fetchBulkTimelines, DEFAULT_STALE_TIME } from '@/services/api';
@@ -9,16 +9,69 @@ import { getResourceTypeName, setOperatorOnEntries } from '@/lib/timeline.utils'
 import { timelineCacheKey, timelineDataAtom } from '@/atoms/timeline';
 import { BulkTimelinesResponse } from '~quent/types/BulkTimelinesResponse';
 
+export interface BulkTimelineIdMeta {
+  resourceId: string;
+  resourceTypeName: string;
+  operatorId: string | null;
+}
+
+export interface MergedBulkEntries {
+  entries: Record<string, TimelineRequest<TaskFilter>>;
+  idToMeta: Map<string, BulkTimelineIdMeta>;
+  requestKey: string;
+}
+
 /**
- * Fetches bulk timeline data and distributes results to per-item Jotai atoms.
- * When operatorId is provided, entries are transformed to include the operator filter.
+ * Builds a single bulk request: each resource appears once (base) and once with
+ * operatorId when provided. Returns UUID-keyed entries, idToMeta map, and a stable requestKey.
+ */
+export function buildMergedBulkEntries(
+  baseEntries: Record<string, TimelineRequest<TaskFilter>>,
+  operatorId: string | null | undefined
+): MergedBulkEntries {
+  const entries: Record<string, TimelineRequest<TaskFilter>> = {};
+  const idToMeta = new Map<string, BulkTimelineIdMeta>();
+
+  for (const [resourceId, params] of Object.entries(baseEntries)) {
+    const resourceTypeName = getResourceTypeName(params);
+    const baseUuid = crypto.randomUUID();
+    entries[baseUuid] = params;
+    idToMeta.set(baseUuid, {
+      resourceId,
+      resourceTypeName,
+      operatorId: null,
+    });
+    if (operatorId) {
+      const opUuid = crypto.randomUUID();
+      const withOperator = setOperatorOnEntries({ [resourceId]: params }, operatorId)[resourceId];
+      entries[opUuid] = withOperator;
+      idToMeta.set(opUuid, {
+        resourceId,
+        resourceTypeName,
+        operatorId,
+      });
+    }
+  }
+
+  const requestKey = JSON.stringify({
+    keys: Object.keys(baseEntries).sort(),
+    operatorId: operatorId ?? null,
+  });
+
+  return { entries, idToMeta, requestKey };
+}
+
+/**
+ * Fetches bulk timeline data. Accepts base entries (keyed by resourceId) and optional
+ * operatorId; builds merged entries (base + operator variants) internally and distributes
+ * results to per-item Jotai atoms.
  */
 export function useBulkTimelineFetch({
   engineId,
   queryId,
   debouncedZoomRange,
   entries,
-  operatorId,
+  operatorId = null,
   enabled = true,
 }: {
   engineId: string;
@@ -30,15 +83,19 @@ export function useBulkTimelineFetch({
 }) {
   const store = useStore();
 
+  const {
+    entries: mergedEntries,
+    idToMeta,
+    requestKey,
+  } = useMemo(() => buildMergedBulkEntries(entries, operatorId), [entries, operatorId]);
+
   const { data } = useQuery<BulkTimelinesResponse>({
-    queryKey: ['bulkTimelines', engineId, queryId, debouncedZoomRange, operatorId, entries],
-    queryFn: () => {
-      const _entries = operatorId ? setOperatorOnEntries(entries, operatorId) : entries;
-      return fetchBulkTimelines(engineId, {
-        entries: _entries,
+    queryKey: ['bulkTimelines', engineId, queryId, debouncedZoomRange, requestKey],
+    queryFn: () =>
+      fetchBulkTimelines(engineId, {
+        entries: mergedEntries,
         app_params: { query_id: queryId },
-      });
-    },
+      }),
     staleTime: DEFAULT_STALE_TIME,
     enabled,
     placeholderData: keepPreviousData,
@@ -47,15 +104,16 @@ export function useBulkTimelineFetch({
   useEffect(() => {
     if (!data) return;
     for (const [id, entry] of Object.entries(data.entries)) {
-      if (entry?.status === 'ok') {
-        const resourceTypeName = getResourceTypeName(entries[id]);
-        store.set(timelineDataAtom(timelineCacheKey(id, resourceTypeName, operatorId)), {
-          data: entry.data,
-          config: entry.config,
-        });
-      }
+      if (entry?.status !== 'ok') continue;
+      const meta = idToMeta.get(id);
+      if (!meta) continue;
+      const key = timelineCacheKey(meta.resourceId, meta.resourceTypeName, meta.operatorId);
+      store.set(timelineDataAtom(key), {
+        data: entry.data,
+        config: entry.config,
+      });
     }
-  }, [data, store, operatorId, entries]);
+  }, [data, store, idToMeta]);
 
   return data;
 }

--- a/ui/src/hooks/useBulkTimelines.ts
+++ b/ui/src/hooks/useBulkTimelines.ts
@@ -23,7 +23,11 @@ import {
   visibleEntriesAtom,
 } from '@/atoms/timeline';
 import { selectedNodeIdsAtom } from '@/atoms/dag';
-import { useBulkTimelineFetch, buildMergedBulkEntries } from './useBulkTimelineFetch';
+import {
+  useBulkTimelineFetch,
+  buildMergedBulkEntries,
+  applyBulkTimelineResponse,
+} from './useBulkTimelineFetch';
 
 const ZOOM_DEBOUNCE_MS = 150;
 
@@ -145,16 +149,7 @@ export function useBulkTimelines({
           staleTime: DEFAULT_STALE_TIME,
         });
 
-        for (const [id, entry] of Object.entries(response.entries)) {
-          if (entry?.status !== 'ok') continue;
-          const meta = expandIdToMeta.get(id);
-          if (!meta) continue;
-          const key = timelineCacheKey(meta.resourceId, meta.resourceTypeName, meta.operatorId);
-          store.set(timelineDataAtom(key), {
-            data: entry.data,
-            config: entry.config,
-          });
-        }
+        applyBulkTimelineResponse(response, expandIdToMeta, store);
       } catch {
         // Individual ResourceTimeline components will fall back to self-fetch
       }

--- a/ui/src/hooks/useBulkTimelines.ts
+++ b/ui/src/hooks/useBulkTimelines.ts
@@ -13,7 +13,6 @@ import {
   collectVisibleEntries,
   getAdaptiveNumBins,
   getResourceTypeName,
-  setOperatorOnEntries,
 } from '@/lib/timeline.utils';
 import {
   timelineCacheKey,
@@ -24,7 +23,7 @@ import {
   visibleEntriesAtom,
 } from '@/atoms/timeline';
 import { selectedNodeIdsAtom } from '@/atoms/dag';
-import { useBulkTimelineFetch } from './useBulkTimelineFetch';
+import { useBulkTimelineFetch, buildMergedBulkEntries } from './useBulkTimelineFetch';
 
 const ZOOM_DEBOUNCE_MS = 150;
 
@@ -74,32 +73,19 @@ export function useBulkTimelines({
     store.set(visibleEntriesAtom, baseVisibleEntries);
   }, [baseVisibleEntries, store]);
 
-  // Base bulk fetch (unfiltered, operator_id: null)
-  const baseBulkData = useBulkTimelineFetch({
-    engineId,
-    queryId,
-    debouncedZoomRange,
-    entries: baseVisibleEntries,
-  });
-
-  // Operator bulk fetch (filtered, only when an operator is selected)
-  const operatorBulkData = useBulkTimelineFetch({
+  const bulkData = useBulkTimelineFetch({
     engineId,
     queryId,
     debouncedZoomRange,
     entries: baseVisibleEntries,
     operatorId,
-    enabled: operatorId != null,
   });
 
-  /* Once our base data is loaded and operator data if we have an operator id set
-   * we can make the bulk data initialized true (allows single timelines to fetch themselves)
-   */
   useEffect(() => {
-    if (baseBulkData && (operatorId != null ? operatorBulkData : true)) {
+    if (bulkData) {
       store.set(bulkInitializedAtom, true);
     }
-  }, [baseBulkData, operatorId, operatorBulkData, store]);
+  }, [bulkData, store]);
 
   // Zoom change handler — stable, uses store imperatively
   const handleZoomChange = useCallback(
@@ -142,50 +128,32 @@ export function useBulkTimelines({
 
       if (Object.keys(newBaseEntries).length === 0) return;
 
+      const {
+        entries: expandEntries,
+        idToMeta: expandIdToMeta,
+        requestKey: expandRequestKey,
+      } = buildMergedBulkEntries(newBaseEntries, operatorId);
+
       try {
-        const baseRequest = queryClient.fetchQuery({
-          queryKey: ['bulkTimelines', engineId, queryId, zoom, null, newBaseEntries],
+        const response = await queryClient.fetchQuery({
+          queryKey: ['bulkTimelines', engineId, queryId, zoom, expandRequestKey],
           queryFn: () =>
             fetchBulkTimelines(engineId, {
-              entries: newBaseEntries,
+              entries: expandEntries,
               app_params: { query_id: queryId },
             }),
           staleTime: DEFAULT_STALE_TIME,
         });
 
-        const operatorRequest = operatorId
-          ? queryClient.fetchQuery({
-              queryKey: ['bulkTimelines', engineId, queryId, zoom, operatorId, newBaseEntries],
-              queryFn: () =>
-                fetchBulkTimelines(engineId, {
-                  entries: setOperatorOnEntries(newBaseEntries, operatorId),
-                  app_params: { query_id: queryId },
-                }),
-              staleTime: DEFAULT_STALE_TIME,
-            })
-          : null;
-
-        const [baseResponse, operatorResponse] = await Promise.all([baseRequest, operatorRequest]);
-
-        for (const [id, entry] of Object.entries(baseResponse.entries)) {
-          if (entry?.status === 'ok') {
-            const resourceTypeName = getResourceTypeName(newBaseEntries[id]);
-            const key = timelineCacheKey(id, resourceTypeName);
-            store.set(timelineDataAtom(key), { data: entry.data, config: entry.config });
-          }
-        }
-
-        if (operatorResponse && operatorId) {
-          for (const [id, entry] of Object.entries(operatorResponse.entries)) {
-            if (entry?.status === 'ok') {
-              const resourceTypeName = getResourceTypeName(newBaseEntries[id]);
-              const key = timelineCacheKey(id, resourceTypeName, operatorId);
-              store.set(timelineDataAtom(key), {
-                data: entry.data,
-                config: entry.config,
-              });
-            }
-          }
+        for (const [id, entry] of Object.entries(response.entries)) {
+          if (entry?.status !== 'ok') continue;
+          const meta = expandIdToMeta.get(id);
+          if (!meta) continue;
+          const key = timelineCacheKey(meta.resourceId, meta.resourceTypeName, meta.operatorId);
+          store.set(timelineDataAtom(key), {
+            data: entry.data,
+            config: entry.config,
+          });
         }
       } catch {
         // Individual ResourceTimeline components will fall back to self-fetch

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -193,29 +193,33 @@ export function getResourceTypeName(params: TimelineRequest<TaskFilter> | undefi
 }
 
 /** Clone entries and set operator_id on each TimelineRequest */
+export function setOperatorOnEntry(
+  entry: TimelineRequest<TaskFilter>,
+  operatorId: string
+): TimelineRequest<TaskFilter> {
+  if ('ResourceGroup' in entry) {
+    return {
+      ResourceGroup: {
+        ...entry.ResourceGroup,
+        app_params: { ...entry.ResourceGroup.app_params, operator_id: operatorId },
+      },
+    };
+  }
+  return {
+    Resource: {
+      ...entry.Resource,
+      application: { ...entry.Resource.application, operator_id: operatorId },
+    },
+  };
+}
+
 export function setOperatorOnEntries(
   baseEntries: Record<string, TimelineRequest<TaskFilter>>,
   operatorId: string
 ): Record<string, TimelineRequest<TaskFilter>> {
-  const result: Record<string, TimelineRequest<TaskFilter>> = {};
-  for (const [id, entry] of Object.entries(baseEntries)) {
-    if ('ResourceGroup' in entry) {
-      result[id] = {
-        ResourceGroup: {
-          ...entry.ResourceGroup,
-          app_params: { ...entry.ResourceGroup.app_params, operator_id: operatorId },
-        },
-      };
-    } else {
-      result[id] = {
-        Resource: {
-          ...entry.Resource,
-          application: { ...entry.Resource.application, operator_id: operatorId },
-        },
-      };
-    }
-  }
-  return result;
+  return Object.fromEntries(
+    Object.entries(baseEntries).map(([id, entry]) => [id, setOperatorOnEntry(entry, operatorId)])
+  );
 }
 
 const SECOND_MS = 1_000;


### PR DESCRIPTION
Previously we were keying on resourceId for bulk requests, so couldn't make > 1 request for a resource (one with operator one without)

This creates a separate UI uuid for each request, and maps that back to a resource/operator combo. This allows us to make just one bulk request for all timelines on the page (operator specific and plain old resource timelines)