### PR TITLE
experiment(ui): load adjacent timeline data for smoother UX

### DIFF
--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -73,6 +73,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
     expandedIds,
     selectedTypes,
     entities,
+    durationSeconds,
   });
 
   const onExpandChange = useCallback(

--- a/ui/src/components/timeline/ResourceTimeline.tsx
+++ b/ui/src/components/timeline/ResourceTimeline.tsx
@@ -7,6 +7,7 @@ import {
   hideTasksAtom,
   timelineCacheKey,
   timelineDataAtom,
+  zoomRangeAtom,
 } from '@/atoms/timeline';
 import { selectedNodeIdsAtom, selectedOperatorLabelAtom } from '@/atoms/dag';
 import { useDeferredReady } from '@/hooks/useDeferredReady';
@@ -75,6 +76,7 @@ export function ResourceTimeline({
 }: ResourceTimelineProps) {
   const deferredReady = useDeferredReady();
   const zoomRange = useAtomValue(debouncedZoomRangeAtom);
+  const viewportRange = useAtomValue(zoomRangeAtom);
   const bulkInitialized = useAtomValue(bulkInitializedAtom);
   const operatorLabel = useAtomValue(selectedOperatorLabelAtom);
   const hideTasks = useAtomValue(hideTasksAtom);
@@ -155,12 +157,14 @@ export function ResourceTimeline({
     if (!data || (operatorId != null && !overlayPreloadedData))
       return { timestamps: [], series: EMPTY_TIMELINE_SERIES };
 
+    const viewport = { start: viewportRange.start, end: viewportRange.end };
     const base = buildBinnedTimelineSeries(
       data.data,
       data.config,
       startTime,
       capacities,
-      quantitySpecs
+      quantitySpecs,
+      viewport
     );
     const longFsms = getLongFsms(data.data);
     const timelineMarks = buildTimelineMarks(longFsms, startTime);
@@ -175,7 +179,8 @@ export function ResourceTimeline({
           overlayPreloadedData.config,
           startTime,
           capacities,
-          quantitySpecs
+          quantitySpecs,
+          viewport
         );
         return {
           timestamps: base.timestamps,
@@ -192,6 +197,7 @@ export function ResourceTimeline({
     operatorId,
     overlayPreloadedData,
     startTime,
+    viewportRange,
     operatorLabel,
     overlayLighten,
     capacities,

--- a/ui/src/hooks/useBulkTimelines.ts
+++ b/ui/src/hooks/useBulkTimelines.ts
@@ -36,6 +36,7 @@ export function useBulkTimelines({
   expandedIds,
   selectedTypes,
   entities,
+  durationSeconds,
 }: {
   engineId: string;
   queryId: string;
@@ -43,6 +44,7 @@ export function useBulkTimelines({
   expandedIds: Set<string>;
   selectedTypes: Map<string, string>;
   entities: QueryEntities;
+  durationSeconds: number;
 }) {
   const store = useStore();
   const queryClient = useQueryClient();
@@ -57,14 +59,18 @@ export function useBulkTimelines({
   }, []);
 
   const debouncedZoomRange = useAtomValue(debouncedZoomRangeAtom);
-  const bulkConfig = useMemo(
-    () => ({
-      num_bins: getAdaptiveNumBins(),
-      start: debouncedZoomRange.start,
-      end: debouncedZoomRange.end,
-    }),
-    [debouncedZoomRange]
-  );
+  // Request 2x window (centered) with 2x bins so viewport keeps same bin density; pre-loads adjacent data for pan
+  const bulkConfig = useMemo(() => {
+    const start = debouncedZoomRange.start;
+    const end = debouncedZoomRange.end;
+    const windowSec = end - start;
+    const halfMargin = windowSec / 2;
+    return {
+      num_bins: getAdaptiveNumBins() * 2,
+      start: Math.max(0, start - halfMargin),
+      end: Math.min(durationSeconds, end + halfMargin),
+    };
+  }, [debouncedZoomRange, durationSeconds]);
 
   const baseVisibleEntries = useMemo(
     () => collectVisibleEntries([rootItem], expandedIds, selectedTypes, entities, bulkConfig),

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -21,7 +21,7 @@ import type { TimelineRequest } from '~quent/types/TimelineRequest';
 import type { TaskFilter } from '~quent/types/TaskFilter';
 import type { TimelineConfig } from '~quent/types/TimelineConfig';
 
-const MAX_TIMELINE_BINS = 400;
+const MAX_TIMELINE_BINS = 250;
 const LONG_ENTITIES_BIN_MULTIPLIER = 30;
 
 /** Convert a nanosecond-precision bigint epoch to milliseconds, preserving sub-ms precision. */
@@ -43,12 +43,19 @@ export function getLongEntitiesThreshold(windowSeconds: number): number {
   return LONG_ENTITIES_BIN_MULTIPLIER * (windowSeconds / numBins);
 }
 
+/** Viewport range in seconds (same base as config.span) for slicing displayed bins */
+export interface ViewportSec {
+  start: number;
+  end: number;
+}
+
 export function buildBinnedTimelineSeries(
   data: ResourceTimeline,
   config: BinnedSpanSec,
   startTime: bigint,
   capacities?: CapacityDecl[],
-  quantitySpecs?: { [key in string]?: QuantitySpec }
+  quantitySpecs?: { [key in string]?: QuantitySpec },
+  viewportSec?: ViewportSec
 ): {
   timestamps: number[];
   series: TimelineSeries;
@@ -116,6 +123,40 @@ export function buildBinnedTimelineSeries(
       values: [],
     };
   }
+
+  // Slice to viewport so we display only bins overlapping [viewportSec.start, viewportSec.end]
+  if (viewportSec != null) {
+    const startTimeMs = nanosToMs(startTime);
+    const viewportStartMs = startTimeMs + viewportSec.start * 1_000;
+    const viewportEndMs = startTimeMs + viewportSec.end * 1_000;
+    const startIdx = Math.max(0, Math.floor((viewportStartMs - firstBinMs) / binDurationMs));
+    const endIdx = Math.min(
+      numBinsNumber - 1,
+      Math.ceil((viewportEndMs - firstBinMs) / binDurationMs)
+    );
+    if (startIdx > endIdx) {
+      return {
+        timestamps: [],
+        series: Object.fromEntries(
+          Object.entries(series).map(([k, s]) => [k, { ...s, values: [] as number[] }])
+        ),
+      };
+    }
+    const len = endIdx - startIdx + 1;
+    const slicedTimestamps = new Array<number>(len);
+    for (let i = 0; i < len; i++) {
+      slicedTimestamps[i] = timestamps[startIdx + i];
+    }
+    const slicedSeries: TimelineSeries = {};
+    for (const [name, s] of Object.entries(series)) {
+      slicedSeries[name] = {
+        ...s,
+        values: s.values.slice(startIdx, endIdx + 1),
+      };
+    }
+    return { timestamps: slicedTimestamps, series: slicedSeries };
+  }
+
   return { timestamps, series };
 }
 


### PR DESCRIPTION
🔬 Experiment

Load a 1x buffer on each side of the timelines. This allows for a much smoother timeline scrolling/zooming experience unless zooming or panning very fast, in which case it ends up being the same as before (blank until data loaded.

https://github.com/user-attachments/assets/dab2d279-5879-4784-b1d4-f3f10dbc545c

This is a tradeoff because it's not happening in the background, it is happening in the main bulk request so request time could be increased up front on first load. Less impact on future round trips since we have data to work with already in the timeline.


Before (for reference):

https://github.com/user-attachments/assets/148b736f-55b7-40e4-b1e8-d9ecd2ae9187

