### PR TITLE
feat(ui): multiple fsm handling

### DIFF
--- a/ui/src/atoms/timeline.ts
+++ b/ui/src/atoms/timeline.ts
@@ -5,16 +5,35 @@ import type { TimelineRequest } from '~quent/types/TimelineRequest';
 import type { TaskFilter } from '~quent/types/TaskFilter';
 import type { ZoomRange } from '@/components/timeline/TimelineController';
 
-/** Build a composite cache key for per-item timeline data */
-export function timelineCacheKey(
-  resourceId: string,
-  resourceTypeName: string,
-  operatorId: string | null = null
-): string {
-  return `${resourceId}|${resourceTypeName}|${operatorId ?? ''}`;
+/**
+ * All dimensions that distinguish a cached timeline entry.
+ *
+ * Extensibility: add an optional field here and include it in the join inside
+ * `timelineCacheKey`. Every call site passes a plain object, so the function
+ * signature never changes.
+ *
+ * Alternative (Idea B): replace the string key entirely by passing
+ * `TimelineCacheParams` as the `atomFamily` parameter with a custom
+ * `areEqual` comparator — no serialization needed, type-safe by construction.
+ */
+export interface TimelineCacheParams {
+  resourceId: string;
+  resourceTypeName: string;
+  operatorId?: string | null;
+  fsmTypeName?: string | null;
 }
 
-/** Per-item timeline data keyed by `timelineCacheKey(resourceId, resourceTypeName, operatorId)` */
+/** Build a composite cache key for per-item timeline data */
+export function timelineCacheKey(params: TimelineCacheParams): string {
+  return [
+    params.resourceId,
+    params.resourceTypeName,
+    params.operatorId ?? '',
+    params.fsmTypeName ?? '',
+  ].join('|');
+}
+
+/** Per-item timeline data keyed by `timelineCacheKey(...)` */
 export const timelineDataAtom = atomFamily(() =>
   atom<SingleTimelineResponse | undefined>(undefined)
 );

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -1,6 +1,7 @@
 import { Column, TreeTable } from '@/components/ui/tree-table';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useAtomValue, useStore } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
 import { useHighlightedItemIds } from '@/hooks/useHighlightedItemIds';
 import { ResourceTree } from '~quent/types/ResourceTree';
@@ -19,7 +20,13 @@ import type { TaskFilter } from '~quent/types/TaskFilter';
 import { transformResourceTree, getAdaptiveNumBins, nanosToMs } from '@/lib/timeline.utils';
 import { useExpandedIds } from '@/hooks/useExpandedIds';
 import { useBulkTimelines } from '@/hooks/useBulkTimelines';
-import { zoomRangeAtom, debouncedZoomRangeAtom, startTimeMsAtom } from '@/atoms/timeline';
+import {
+  zoomRangeAtom,
+  debouncedZoomRangeAtom,
+  startTimeMsAtom,
+  timelineCacheKey,
+  timelineDataAtom,
+} from '@/atoms/timeline';
 import { TimelineToolbar } from './timeline/TimelineToolbar';
 
 function getRootResourceGroupId(resourceTree: ResourceTree<EntityRef>): string | null {
@@ -65,6 +72,19 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
 
   const rootResourceGroupId = useMemo(() => getRootResourceGroupId(resourceTree), [resourceTree]);
 
+  // Atom cache key with fsmTypeName: null — TimelineController always shows the all-FSM aggregate
+  const rootTimelineCacheKey = useMemo(
+    () =>
+      timelineCacheKey({
+        resourceId: rootResourceGroupId ?? '',
+        resourceTypeName: rootResourceType,
+        fsmTypeName: null,
+      }),
+    [rootResourceGroupId, rootResourceType]
+  );
+
+  const store = useStore();
+
   const { expandedIds, handleExpandChange } = useExpandedIds(rootItem.id);
 
   const { handleZoomChange, handleExpand } = useBulkTimelines({
@@ -85,7 +105,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
     [handleExpandChange, handleExpand]
   );
 
-  const { data: rootTimelineData } = useQuery({
+  const { data: fetchedRootTimeline } = useQuery({
     queryKey: [
       'resourceGroupTimeline',
       'root',
@@ -119,6 +139,16 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
     enabled: rootResourceGroupId != null && !!rootResourceType,
     placeholderData: keepPreviousData,
   });
+
+  // Store fetched full-range data into the atom cache under the FSM_ALL key.
+  // Atom holds the previous value until overwritten, so keepPreviousData is unnecessary.
+  useEffect(() => {
+    if (fetchedRootTimeline) {
+      store.set(timelineDataAtom(rootTimelineCacheKey), fetchedRootTimeline);
+    }
+  }, [fetchedRootTimeline, rootTimelineCacheKey, store]);
+
+  const rootTimelineData = useAtomValue(timelineDataAtom(rootTimelineCacheKey));
 
   const treeData = useMemo(() => [rootItem], [rootItem]);
 

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -40,6 +40,7 @@ export function QueryResourceTree(props: QueryResourceTreeProps) {
 function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreeProps) {
   const { entities, resource_tree: resourceTree } = queryBundle;
   const [selectedTypes, setSelectedTypes] = useState<Map<string, string>>(new Map());
+  const [selectedFsmTypes, setSelectedFsmTypes] = useState<Map<string, string | null>>(new Map());
 
   const startTime = queryBundle.start_time_unix_ns;
   const durationSeconds = queryBundle.duration_s;
@@ -72,6 +73,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
     rootItem,
     expandedIds,
     selectedTypes,
+    groupFsmFilters: selectedFsmTypes,
     entities,
   });
 
@@ -127,18 +129,30 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
         label: 'Resource',
         widthIndex: 0,
         isFirst: true,
-        render: ({ item }: { item: TreeTableItem; level: number }) => (
-          <ResourceColumn
-            item={item}
-            selectedType={selectedTypes.get(item.id) || item.availableResourceTypes?.[0] || ''}
-            onTypeChange={(itemId, newType) => {
-              setSelectedTypes(prev => new Map(prev).set(itemId, newType));
-              if (itemId === rootItem.id) {
-                setRootResourceType(newType);
+        render: ({ item }: { item: TreeTableItem; level: number }) => {
+          const selectedType =
+            selectedTypes.get(item.id) || item.availableResourceTypes?.[0] || '';
+          const availableFsmTypes = selectedType
+            ? entities.resource_types[selectedType]?.used_by
+            : undefined;
+          return (
+            <ResourceColumn
+              item={item}
+              selectedType={selectedType}
+              onTypeChange={(itemId, newType) => {
+                setSelectedTypes(prev => new Map(prev).set(itemId, newType));
+                if (itemId === rootItem.id) {
+                  setRootResourceType(newType);
+                }
+              }}
+              availableFsmTypes={availableFsmTypes}
+              selectedFsmType={selectedFsmTypes.get(item.id) ?? null}
+              onFsmChange={(itemId, fsmType) =>
+                setSelectedFsmTypes(prev => new Map(prev).set(itemId, fsmType))
               }
-            }}
-          />
-        ),
+            />
+          );
+        },
       },
       {
         key: 'usage',
@@ -160,6 +174,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
             engineId={engineId}
             queryBundle={queryBundle}
             selectedTypes={selectedTypes}
+            selectedFsmTypes={selectedFsmTypes}
             startTime={startTime}
             durationSeconds={durationSeconds}
           />
@@ -171,6 +186,8 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
     durationSeconds,
     rootTimelineData,
     selectedTypes,
+    selectedFsmTypes,
+    entities,
     rootItem,
     engineId,
     queryBundle,

--- a/ui/src/components/resource-tree/InlineSelector.tsx
+++ b/ui/src/components/resource-tree/InlineSelector.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
-interface ResourceTypeSelectorProps {
+interface InlineSelectorProps {
   id: string;
   label?: string;
   selectedType: string;
@@ -16,14 +16,14 @@ interface ResourceTypeSelectorProps {
   className?: string;
 }
 
-export const ResourceTypeSelector = ({
+export const InlineSelector = ({
   id,
   label = 'Type',
   selectedType,
   availableResourceTypes,
   onTypeChange,
   className,
-}: ResourceTypeSelectorProps): React.ReactNode => {
+}: InlineSelectorProps): React.ReactNode => {
   return (
     <div
       className={cn('flex items-center gap-1.5', className)}

--- a/ui/src/components/resource-tree/ResourceColumn.tsx
+++ b/ui/src/components/resource-tree/ResourceColumn.tsx
@@ -9,6 +9,9 @@ type ResourceColumnProps = {
   item: TreeTableItem;
   selectedType: string;
   onTypeChange: (itemId: string, type: string) => void;
+  availableFsmTypes?: string[];
+  selectedFsmType?: string | null;
+  onFsmChange?: (itemId: string, fsmType: string | null) => void;
   className?: string;
   verbose?: boolean;
 };
@@ -17,6 +20,9 @@ export function ResourceColumn({
   item,
   selectedType,
   onTypeChange,
+  availableFsmTypes,
+  selectedFsmType,
+  onFsmChange,
   className,
 }: ResourceColumnProps): React.ReactNode {
   return (
@@ -30,6 +36,9 @@ export function ResourceColumn({
             availableResourceTypes={item.availableResourceTypes}
             selectedType={selectedType}
             onTypeChange={onTypeChange}
+            availableFsmTypes={availableFsmTypes}
+            selectedFsmType={selectedFsmType}
+            onFsmChange={onFsmChange}
           />
         ) : (
           <ResourceRow resource={item.entity as Resource} />

--- a/ui/src/components/resource-tree/ResourceGroupRow.tsx
+++ b/ui/src/components/resource-tree/ResourceGroupRow.tsx
@@ -26,7 +26,9 @@ export const ResourceGroupRow = ({
   onFsmChange,
 }: ResourceGroupRowProps): React.ReactNode => {
   const hasMultipleChildTypes = (availableResourceTypes?.length ?? 0) > 1;
-  const hasMultipleFsms = (availableFsmTypes?.length ?? 0) > 1;
+  const fsmCount = availableFsmTypes?.length ?? 0;
+  const hasOneFsm = fsmCount === 1;
+  const hasMultipleFsms = fsmCount > 1;
   const fsmOptions = hasMultipleFsms ? [FSM_ALL, ...(availableFsmTypes ?? [])] : [];
 
   return (
@@ -43,6 +45,11 @@ export const ResourceGroupRow = ({
           onTypeChange={onTypeChange}
           className="mt-1"
         />
+      )}
+      {hasOneFsm && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          FSM: <span className="text-foreground">{availableFsmTypes![0]}</span>
+        </p>
       )}
       {hasMultipleFsms && onFsmChange && fsmOptions.length > 0 && (
         <InlineSelector

--- a/ui/src/components/resource-tree/ResourceGroupRow.tsx
+++ b/ui/src/components/resource-tree/ResourceGroupRow.tsx
@@ -38,7 +38,7 @@ export const ResourceGroupRow = ({
       </div>
       {hasMultipleChildTypes && selectedType && onTypeChange && availableResourceTypes && (
         <InlineSelector
-          id={id}
+          id={`${id}-resource-type`}
           label="Type"
           selectedType={selectedType}
           availableResourceTypes={availableResourceTypes}

--- a/ui/src/components/resource-tree/ResourceGroupRow.tsx
+++ b/ui/src/components/resource-tree/ResourceGroupRow.tsx
@@ -1,5 +1,5 @@
 import { ResourceGroup } from '~quent/types/ResourceGroup';
-import { ResourceTypeSelector } from './ResourceTypeSelector';
+import { InlineSelector } from './InlineSelector';
 
 const FSM_ALL = 'All';
 
@@ -35,7 +35,7 @@ export const ResourceGroupRow = ({
         <span className="text-sm font-bold">{group.instance_name}</span>
       </div>
       {hasMultipleChildTypes && selectedType && onTypeChange && availableResourceTypes && (
-        <ResourceTypeSelector
+        <InlineSelector
           id={id}
           label="Type"
           selectedType={selectedType}
@@ -45,7 +45,7 @@ export const ResourceGroupRow = ({
         />
       )}
       {hasMultipleFsms && onFsmChange && fsmOptions.length > 0 && (
-        <ResourceTypeSelector
+        <InlineSelector
           id={`${id}-fsm`}
           label="FSM"
           selectedType={selectedFsmType ?? FSM_ALL}

--- a/ui/src/components/resource-tree/ResourceGroupRow.tsx
+++ b/ui/src/components/resource-tree/ResourceGroupRow.tsx
@@ -1,12 +1,17 @@
 import { ResourceGroup } from '~quent/types/ResourceGroup';
 import { ResourceTypeSelector } from './ResourceTypeSelector';
 
+const FSM_ALL = 'All';
+
 interface ResourceGroupRowProps {
   group: ResourceGroup;
   id: string;
   availableResourceTypes?: string[];
   selectedType?: string;
   onTypeChange?: (itemId: string, type: string) => void;
+  availableFsmTypes?: string[];
+  selectedFsmType?: string | null;
+  onFsmChange?: (itemId: string, fsmType: string | null) => void;
   verbose?: boolean;
 }
 
@@ -16,21 +21,36 @@ export const ResourceGroupRow = ({
   availableResourceTypes,
   selectedType,
   onTypeChange,
+  availableFsmTypes,
+  selectedFsmType,
+  onFsmChange,
 }: ResourceGroupRowProps): React.ReactNode => {
   const hasMultipleChildTypes = (availableResourceTypes?.length ?? 0) > 1;
+  const hasMultipleFsms = (availableFsmTypes?.length ?? 0) > 1;
+  const fsmOptions = hasMultipleFsms ? [FSM_ALL, ...(availableFsmTypes ?? [])] : [];
 
   return (
     <div>
       <div>
-        <span className="text-xs font-bold">{group.instance_name}</span>
+        <span className="text-sm font-bold">{group.instance_name}</span>
       </div>
-      <div className="text-xs text-muted-foreground">{group.id}</div>
       {hasMultipleChildTypes && selectedType && onTypeChange && availableResourceTypes && (
         <ResourceTypeSelector
           id={id}
+          label="Type"
           selectedType={selectedType}
           availableResourceTypes={availableResourceTypes}
           onTypeChange={onTypeChange}
+          className="mt-1"
+        />
+      )}
+      {hasMultipleFsms && onFsmChange && fsmOptions.length > 0 && (
+        <ResourceTypeSelector
+          id={`${id}-fsm`}
+          label="FSM"
+          selectedType={selectedFsmType ?? FSM_ALL}
+          availableResourceTypes={fsmOptions}
+          onTypeChange={(_itemId, value) => onFsmChange(id, value === FSM_ALL ? null : value)}
           className="mt-1"
         />
       )}

--- a/ui/src/components/resource-tree/ResourceRow.tsx
+++ b/ui/src/components/resource-tree/ResourceRow.tsx
@@ -15,7 +15,6 @@ export const ResourceRow = ({ resource }: ResourceRowProps): React.ReactNode => 
             : ''}
         </span>
       </div>
-      <div className="text-xs text-muted-foreground">{resource.id}</div>
     </div>
   );
 };

--- a/ui/src/components/resource-tree/ResourceTypeSelector.tsx
+++ b/ui/src/components/resource-tree/ResourceTypeSelector.tsx
@@ -1,8 +1,15 @@
-import { ChevronDown } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
 interface ResourceTypeSelectorProps {
   id: string;
+  label?: string;
   selectedType: string;
   availableResourceTypes: string[];
   onTypeChange: (itemId: string, type: string) => void;
@@ -11,6 +18,7 @@ interface ResourceTypeSelectorProps {
 
 export const ResourceTypeSelector = ({
   id,
+  label = 'Type',
   selectedType,
   availableResourceTypes,
   onTypeChange,
@@ -22,40 +30,37 @@ export const ResourceTypeSelector = ({
       onClick={e => e.stopPropagation()}
       onMouseDown={e => e.stopPropagation()}
     >
-      <label htmlFor={`type-select-${id}`} className="text-xs text-muted-foreground shrink-0">
-        Type:
+      <label id={`type-select-label-${id}`} className="text-xs text-muted-foreground shrink-0">
+        {label}:
       </label>
-      <span className="inline-flex items-center gap-1 max-w-80 min-w-0">
-        <span className="relative w-fit max-w-full min-w-0 shrink inline-block">
-          {/* Invisible sizer so the trigger is only as wide as the selected value text */}
-          <span className="invisible whitespace-nowrap text-xs py-px" aria-hidden>
-            {selectedType}
-          </span>
-          <select
-            id={`type-select-${id}`}
-            value={selectedType}
-            onChange={e => {
-              e.stopPropagation();
-              onTypeChange(id, e.target.value);
-            }}
-            className={cn(
-              'absolute left-0 top-0 w-full h-full text-xs text-foreground bg-transparent border-none border-b border-dashed border-muted-foreground/60',
-              'cursor-pointer focus:outline-none focus:border-muted-foreground',
-              'appearance-none py-px pr-0'
-            )}
-          >
-            {availableResourceTypes.map(typeOption => (
-              <option key={typeOption} value={typeOption}>
-                {typeOption}
-              </option>
-            ))}
-          </select>
-        </span>
-        <ChevronDown
-          className="h-3 w-3 shrink-0 text-muted-foreground pointer-events-none"
-          aria-hidden
-        />
-      </span>
+      <Select value={selectedType} onValueChange={value => onTypeChange(id, value)}>
+        <SelectTrigger
+          id={`type-select-${id}`}
+          aria-labelledby={`type-select-label-${id}`}
+          className={cn(
+            'h-auto w-auto min-w-0 max-w-80 border-0 border-b border-dashed border-muted-foreground/60 rounded-none bg-transparent px-0 py-px text-xs shadow-none cursor-pointer',
+            'focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0',
+            'data-[placeholder]:text-muted-foreground',
+            '[&>svg]:h-3 [&>svg]:w-3 [&>svg]:opacity-70'
+          )}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent
+          position="popper"
+          className="max-h-[--radix-select-content-available-height] min-w-[var(--radix-select-trigger-width)]"
+        >
+          {availableResourceTypes.map(typeOption => (
+            <SelectItem
+              key={typeOption}
+              value={typeOption}
+              className="text-xs py-1.5 pl-8 pr-2 cursor-pointer"
+            >
+              {typeOption}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </div>
   );
 };

--- a/ui/src/components/resource-tree/ResourceTypeSelector.tsx
+++ b/ui/src/components/resource-tree/ResourceTypeSelector.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ResourceTypeSelectorProps {
@@ -17,28 +18,44 @@ export const ResourceTypeSelector = ({
 }: ResourceTypeSelectorProps): React.ReactNode => {
   return (
     <div
-      className={cn('flex items-center gap-2', className)}
+      className={cn('flex items-center gap-1.5', className)}
       onClick={e => e.stopPropagation()}
       onMouseDown={e => e.stopPropagation()}
     >
-      <label htmlFor={`type-select-${id}`} className="text-xs text-muted-foreground">
+      <label htmlFor={`type-select-${id}`} className="text-xs text-muted-foreground shrink-0">
         Type:
       </label>
-      <select
-        id={`type-select-${id}`}
-        value={selectedType}
-        onChange={e => {
-          e.stopPropagation();
-          onTypeChange(id, e.target.value);
-        }}
-        className="text-xs bg-background border border-border rounded px-1 py-0.5 text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-      >
-        {availableResourceTypes.map(typeOption => (
-          <option key={typeOption} value={typeOption}>
-            {typeOption}
-          </option>
-        ))}
-      </select>
+      <span className="inline-flex items-center gap-1 max-w-80 min-w-0">
+        <span className="relative w-fit max-w-full min-w-0 shrink inline-block">
+          {/* Invisible sizer so the trigger is only as wide as the selected value text */}
+          <span className="invisible whitespace-nowrap text-xs py-px" aria-hidden>
+            {selectedType}
+          </span>
+          <select
+            id={`type-select-${id}`}
+            value={selectedType}
+            onChange={e => {
+              e.stopPropagation();
+              onTypeChange(id, e.target.value);
+            }}
+            className={cn(
+              'absolute left-0 top-0 w-full h-full text-xs text-foreground bg-transparent border-none border-b border-dashed border-muted-foreground/60',
+              'cursor-pointer focus:outline-none focus:border-muted-foreground',
+              'appearance-none py-px pr-0'
+            )}
+          >
+            {availableResourceTypes.map(typeOption => (
+              <option key={typeOption} value={typeOption}>
+                {typeOption}
+              </option>
+            ))}
+          </select>
+        </span>
+        <ChevronDown
+          className="h-3 w-3 shrink-0 text-muted-foreground pointer-events-none"
+          aria-hidden
+        />
+      </span>
     </div>
   );
 };

--- a/ui/src/components/resource-tree/UsageColumn.tsx
+++ b/ui/src/components/resource-tree/UsageColumn.tsx
@@ -11,6 +11,7 @@ type UsageColumnProps = {
   engineId: string;
   queryBundle: QueryBundle<EntityRef>;
   selectedTypes: Map<string, string>;
+  selectedFsmTypes?: Map<string, string | null>;
   startTime: bigint;
   durationSeconds: number;
 };
@@ -20,6 +21,7 @@ export function UsageColumn({
   engineId,
   queryBundle,
   selectedTypes,
+  selectedFsmTypes,
   startTime,
   durationSeconds,
 }: UsageColumnProps): React.ReactNode {
@@ -36,7 +38,13 @@ export function UsageColumn({
   const resourceTypeDecl = resourceTypeName
     ? queryBundle.entities.resource_types[resourceTypeName]
     : undefined;
-  const fsmTypeName = resourceTypeDecl?.used_by?.[0];
+  const usedBy = resourceTypeDecl?.used_by;
+  const fsmTypeName =
+    usedBy?.length === 1
+      ? usedBy[0]
+      : resourceType === EntityTypeKey.ResourceGroup
+        ? (selectedFsmTypes?.get(item.id) ?? undefined)
+        : undefined;
   const capacities = resourceTypeDecl?.capacities;
   return (
     <div

--- a/ui/src/components/resource-tree/UsageColumn.tsx
+++ b/ui/src/components/resource-tree/UsageColumn.tsx
@@ -39,12 +39,12 @@ export function UsageColumn({
     ? queryBundle.entities.resource_types[resourceTypeName]
     : undefined;
   const usedBy = resourceTypeDecl?.used_by;
-  const fsmTypeName =
-    usedBy?.length === 1
-      ? usedBy[0]
-      : resourceType === EntityTypeKey.ResourceGroup
-        ? (selectedFsmTypes?.get(item.id) ?? undefined)
-        : undefined;
+  let fsmTypeName: string | undefined;
+  if (usedBy?.length === 1) {
+    fsmTypeName = usedBy[0];
+  } else if (resourceType === EntityTypeKey.ResourceGroup) {
+    fsmTypeName = selectedFsmTypes?.get(item.id) ?? undefined;
+  }
   const capacities = resourceTypeDecl?.capacities;
   return (
     <div

--- a/ui/src/components/timeline/ResourceTimeline.tsx
+++ b/ui/src/components/timeline/ResourceTimeline.tsx
@@ -84,10 +84,19 @@ export function ResourceTimeline({
 
   const cacheResourceTypeName =
     resourceType === EntityTypeKey.ResourceGroup ? (resourceTypeName ?? '') : '';
-  const baseCacheKey = timelineCacheKey(resourceId, cacheResourceTypeName);
+  const baseCacheKey = timelineCacheKey({
+    resourceId,
+    resourceTypeName: cacheResourceTypeName,
+    fsmTypeName,
+  });
   const preloadedData = useAtomValue(timelineDataAtom(baseCacheKey));
 
-  const operatorCacheKey = timelineCacheKey(resourceId, cacheResourceTypeName, operatorId);
+  const operatorCacheKey = timelineCacheKey({
+    resourceId,
+    resourceTypeName: cacheResourceTypeName,
+    fsmTypeName,
+    operatorId,
+  });
   const operatorTimelineData = useAtomValue(timelineDataAtom(operatorCacheKey));
   const overlayPreloadedData = operatorId ? operatorTimelineData : undefined;
   const { overlayLighten } = useTimelineChartColors();

--- a/ui/src/hooks/useBulkTimelineFetch.ts
+++ b/ui/src/hooks/useBulkTimelineFetch.ts
@@ -5,14 +5,18 @@ import { fetchBulkTimelines, DEFAULT_STALE_TIME } from '@/services/api';
 import type { ZoomRange } from '@/components/timeline/TimelineController';
 import type { TimelineRequest } from '~quent/types/TimelineRequest';
 import type { TaskFilter } from '~quent/types/TaskFilter';
-import { getResourceTypeName, setOperatorOnEntry } from '@/lib/timeline.utils';
+import { getResourceTypeName, getFsmTypeName, setOperatorOnEntry } from '@/lib/timeline.utils';
 import type { BulkTimelinesResponse } from '~quent/types/BulkTimelinesResponse';
 import { timelineCacheKey, timelineDataAtom } from '@/atoms/timeline';
-
+/**
+ * Mirrors TimelineCacheParams so meta can be passed directly to timelineCacheKey.
+ * Add new cache dimensions to TimelineCacheParams; this type follows automatically.
+ */
 export interface BulkTimelineIdMeta {
   resourceId: string;
   resourceTypeName: string;
   operatorId: string | null;
+  fsmTypeName: string | null;
 }
 
 export interface MergedBulkEntries {
@@ -34,7 +38,7 @@ export function applyBulkTimelineResponse(
     if (entry?.status !== 'ok') continue;
     const meta = idToMeta.get(id);
     if (!meta) continue;
-    const key = timelineCacheKey(meta.resourceId, meta.resourceTypeName, meta.operatorId);
+    const key = timelineCacheKey(meta);
     store.set(timelineDataAtom(key), {
       data: entry.data,
       config: entry.config,
@@ -55,22 +59,15 @@ export function buildMergedBulkEntries(
 
   for (const [resourceId, params] of Object.entries(baseEntries)) {
     const resourceTypeName = getResourceTypeName(params);
+    const fsmTypeName = getFsmTypeName(params);
     const baseUuid = crypto.randomUUID();
     entries[baseUuid] = params;
-    idToMeta.set(baseUuid, {
-      resourceId,
-      resourceTypeName,
-      operatorId: null,
-    });
+    idToMeta.set(baseUuid, { resourceId, resourceTypeName, operatorId: null, fsmTypeName });
     if (operatorId) {
       const opUuid = crypto.randomUUID();
       const withOperator = setOperatorOnEntry(params, operatorId);
       entries[opUuid] = withOperator;
-      idToMeta.set(opUuid, {
-        resourceId,
-        resourceTypeName,
-        operatorId,
-      });
+      idToMeta.set(opUuid, { resourceId, resourceTypeName, operatorId, fsmTypeName });
     }
   }
 

--- a/ui/src/hooks/useBulkTimelines.ts
+++ b/ui/src/hooks/useBulkTimelines.ts
@@ -79,7 +79,6 @@ export function useBulkTimelines({
         selectedTypes,
         entities,
         bulkConfig,
-        null,
         groupFsmFilters
       ),
     [rootItem, expandedIds, selectedTypes, entities, bulkConfig, groupFsmFilters]
@@ -138,7 +137,6 @@ export function useBulkTimelines({
           selectedTypes,
           entities,
           expandConfig,
-          null,
           groupFsmFilters
         );
         const resourceTypeName = getResourceTypeName(params);

--- a/ui/src/hooks/useBulkTimelines.ts
+++ b/ui/src/hooks/useBulkTimelines.ts
@@ -13,6 +13,7 @@ import {
   collectVisibleEntries,
   getAdaptiveNumBins,
   getResourceTypeName,
+  getFsmTypeName,
 } from '@/lib/timeline.utils';
 import {
   timelineCacheKey,
@@ -140,7 +141,8 @@ export function useBulkTimelines({
           groupFsmFilters
         );
         const resourceTypeName = getResourceTypeName(params);
-        const key = timelineCacheKey(child.id, resourceTypeName);
+        const fsmTypeName = getFsmTypeName(params);
+        const key = timelineCacheKey({ resourceId: child.id, resourceTypeName, fsmTypeName });
         if (!store.get(timelineDataAtom(key))) {
           newBaseEntries[child.id] = params;
         }

--- a/ui/src/hooks/useBulkTimelines.ts
+++ b/ui/src/hooks/useBulkTimelines.ts
@@ -35,6 +35,7 @@ export function useBulkTimelines({
   rootItem,
   expandedIds,
   selectedTypes,
+  groupFsmFilters,
   entities,
 }: {
   engineId: string;
@@ -42,6 +43,7 @@ export function useBulkTimelines({
   rootItem: TreeTableItem;
   expandedIds: Set<string>;
   selectedTypes: Map<string, string>;
+  groupFsmFilters?: Map<string, string | null>;
   entities: QueryEntities;
 }) {
   const store = useStore();
@@ -67,8 +69,17 @@ export function useBulkTimelines({
   );
 
   const baseVisibleEntries = useMemo(
-    () => collectVisibleEntries([rootItem], expandedIds, selectedTypes, entities, bulkConfig),
-    [rootItem, expandedIds, selectedTypes, entities, bulkConfig]
+    () =>
+      collectVisibleEntries(
+        [rootItem],
+        expandedIds,
+        selectedTypes,
+        entities,
+        bulkConfig,
+        null,
+        groupFsmFilters
+      ),
+    [rootItem, expandedIds, selectedTypes, entities, bulkConfig, groupFsmFilters]
   );
   useEffect(() => {
     store.set(visibleEntriesAtom, baseVisibleEntries);
@@ -132,7 +143,14 @@ export function useBulkTimelines({
 
       const newBaseEntries: Record<string, TimelineRequest<TaskFilter>> = {};
       for (const child of item.children) {
-        const params = buildBulkParamsForItem(child, selectedTypes, entities, expandConfig);
+        const params = buildBulkParamsForItem(
+          child,
+          selectedTypes,
+          entities,
+          expandConfig,
+          null,
+          groupFsmFilters
+        );
         const resourceTypeName = getResourceTypeName(params);
         const key = timelineCacheKey(child.id, resourceTypeName);
         if (!store.get(timelineDataAtom(key))) {
@@ -191,7 +209,7 @@ export function useBulkTimelines({
         // Individual ResourceTimeline components will fall back to self-fetch
       }
     },
-    [rootItem, store, selectedTypes, entities, queryClient, engineId, queryId, operatorId]
+    [rootItem, store, selectedTypes, groupFsmFilters, entities, queryClient, engineId, queryId, operatorId]
   );
 
   return { handleZoomChange, handleExpand } as const;

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -201,6 +201,12 @@ export function getResourceTypeName(params: TimelineRequest<TaskFilter> | undefi
   return '';
 }
 
+/** Extract the entity_type_name (FSM filter) from a TimelineRequest */
+export function getFsmTypeName(params: TimelineRequest<TaskFilter>): string | null {
+  if ('ResourceGroup' in params) return params.ResourceGroup.entity_filter.entity_type_name;
+  return params.Resource.entity_filter.entity_type_name;
+}
+
 /** Clone entries and set operator_id on each TimelineRequest */
 export function setOperatorOnEntry(
   entry: TimelineRequest<TaskFilter>,

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -515,32 +515,52 @@ export function findItemById(root: TreeTableItem, id: string): TreeTableItem | u
   return undefined;
 }
 
-/** Look up the FSM type name for a tree item from the query entities */
+/** Look up the FSM type name for a leaf resource from the query entities.
+ *  If exactly 1 FSM uses this resource type, return that FSM name.
+ *  If >1 FSM types use it, return null (all FSMs). */
 function lookupFsmTypeName(item: TreeTableItem, entities: QueryEntities): string | null {
-  const entity = item.entity;
-  const entityTypeName = 'type_name' in entity ? (entity.type_name as string) : undefined;
-  const usedBy = entityTypeName ? entities.resource_types[entityTypeName]?.used_by : undefined;
-  return usedBy?.[0] ?? null;
+  const typeName =
+    item.entity && 'type_name' in item.entity ? (item.entity.type_name as string) : undefined;
+  const usedBy = typeName ? entities.resource_types[typeName]?.used_by : undefined;
+  if (usedBy && usedBy.length === 1) return usedBy[0]!;
+  return null;
 }
 
-/** Build TimelineRequest params for a single tree item */
+/** Build TimelineRequest params for a single tree item.
+ *  @param groupFsmFilters — per-item FSM filter for resource groups.
+ *    Map value: null = aggregate all FSMs, string = filter to that FSM type.
+ *    Missing key = fall back to first `used_by` entry (single-FSM) or null (multi-FSM).
+ */
 export function buildBulkParamsForItem(
   item: TreeTableItem,
   selectedTypes: Map<string, string>,
   entities: QueryEntities,
   config: TimelineConfig,
-  operatorId: string | null = null
+  operatorId: string | null = null,
+  groupFsmFilters?: Map<string, string | null>
 ): TimelineRequest<TaskFilter> {
-  const fsmTypeName = lookupFsmTypeName(item, entities);
   const isGroup = item.type !== EntityTypeKey.Resource;
+  const resourceTypeName = isGroup
+    ? selectedTypes.get(item.id) || item.availableResourceTypes?.[0] || ''
+    : undefined;
+  const usedBy = resourceTypeName
+    ? entities.resource_types[resourceTypeName]?.used_by
+    : undefined;
+  let fsmTypeName: string | null;
+  if (usedBy?.length === 1) {
+    fsmTypeName = usedBy[0]!;
+  } else if (isGroup) {
+    fsmTypeName = groupFsmFilters?.has(item.id) ? (groupFsmFilters.get(item.id) ?? null) : null;
+  } else {
+    fsmTypeName = lookupFsmTypeName(item, entities);
+  }
   const threshold = getLongEntitiesThreshold(config.end - config.start);
 
   if (isGroup) {
-    const resourceTypeName = selectedTypes.get(item.id) || item.availableResourceTypes?.[0] || '';
     return {
       ResourceGroup: {
         resource_group_id: item.id,
-        resource_type_name: resourceTypeName,
+        resource_type_name: resourceTypeName || '',
         long_entities_threshold_s: null,
         entity_filter: { entity_type_name: fsmTypeName },
         app_params: { operator_id: operatorId },
@@ -570,12 +590,20 @@ export function collectVisibleEntries(
   selectedTypes: Map<string, string>,
   entities: QueryEntities,
   config: TimelineConfig,
-  operatorId: string | null = null
+  operatorId: string | null = null,
+  groupFsmFilters?: Map<string, string | null>
 ): Record<string, TimelineRequest<TaskFilter>> {
   const result: Record<string, TimelineRequest<TaskFilter>> = {};
 
   function walk(item: TreeTableItem) {
-    result[item.id] = buildBulkParamsForItem(item, selectedTypes, entities, config, operatorId);
+    result[item.id] = buildBulkParamsForItem(
+      item,
+      selectedTypes,
+      entities,
+      config,
+      operatorId,
+      groupFsmFilters
+    );
 
     if (item.children && expandedIds.has(item.id)) {
       for (const child of item.children) {

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -540,8 +540,8 @@ export function buildBulkParamsForItem(
   selectedTypes: Map<string, string>,
   entities: QueryEntities,
   config: TimelineConfig,
-  operatorId: string | null = null,
-  groupFsmFilters?: Map<string, string | null>
+  groupFsmFilters?: Map<string, string | null>,
+  operatorId: string | null = null
 ): TimelineRequest<TaskFilter> {
   const isGroup = item.type !== EntityTypeKey.Resource;
   const resourceTypeName = isGroup
@@ -592,8 +592,8 @@ export function collectVisibleEntries(
   selectedTypes: Map<string, string>,
   entities: QueryEntities,
   config: TimelineConfig,
-  operatorId: string | null = null,
-  groupFsmFilters?: Map<string, string | null>
+  groupFsmFilters?: Map<string, string | null>,
+  operatorId: string | null = null
 ): Record<string, TimelineRequest<TaskFilter>> {
   const result: Record<string, TimelineRequest<TaskFilter>> = {};
 
@@ -603,8 +603,8 @@ export function collectVisibleEntries(
       selectedTypes,
       entities,
       config,
-      operatorId,
-      groupFsmFilters
+      groupFsmFilters,
+      operatorId
     );
 
     if (item.children && expandedIds.has(item.id)) {


### PR DESCRIPTION
* When > 1 fsm exists, display another select dropdown to select
* When only 1 exists, show static display of that 1
* Updates the cache key to include fsm type now that it can change  
* Removes resource/group ids from title columns to make room 
* Rename `ResourceTypeSelector` to generic `InlineSelector`


https://github.com/user-attachments/assets/95c6c76d-2dcb-42db-bc4d-f7156d76f2ed
