### PR TITLE
feat(ui): operator highlight by dimming

### DIFF
--- a/ui/src/components/query-plan/QueryPlanNode.tsx
+++ b/ui/src/components/query-plan/QueryPlanNode.tsx
@@ -17,7 +17,7 @@ export interface QueryPlanNodeData extends Record<string, unknown> {
 }
 
 const nodeVariants = cva(
-  'px-4 py-2 rounded-md border-1 min-w-[180px] max-w-[250px] transition-colors cursor-pointer text-foreground',
+  'px-4 py-2 rounded-md border-1 min-w-[180px] max-w-[250px] transition cursor-pointer text-foreground z-10',
   {
     variants: {
       operationType: {
@@ -54,8 +54,12 @@ const nodeVariants = cva(
           'bg-gray-100/15 border-gray-500 hover:bg-gray-100/30 [--glow-color:var(--color-gray-500)]',
       },
       selected: {
-        true: 'shadow-glow',
+        true: 'shadow-glow border-2 scale-110',
         false: 'shadow-md',
+      },
+      dimmed: {
+        true: 'opacity-30',
+        false: 'opacity-100',
       },
     },
     compoundVariants: [
@@ -84,6 +88,7 @@ const nodeVariants = cva(
     defaultVariants: {
       operationType: 'other',
       selected: false,
+      dimmed: false,
     },
   }
 );
@@ -123,15 +128,11 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
 
   const nodeContent = (
     <div
-      className={`${nodeVariants({
+      className={nodeVariants({
         operationType: resolveOperationType(data.operationType),
         selected: isSelected,
-      })} ${isSelected ? 'border-2 scale-110' : ''}`}
-      style={{
-        zIndex: 10,
-        opacity: isDimmed ? 0.3 : 1,
-        transition: 'opacity 0.15s, transform 0.15s',
-      }}
+        dimmed: isDimmed,
+      })}
     >
       {data.hasIncoming && (
         <Handle type="target" position={Position.Top} className="w-2 h-2" style={{ opacity: 0 }} />

--- a/ui/src/components/query-plan/QueryPlanNode.tsx
+++ b/ui/src/components/query-plan/QueryPlanNode.tsx
@@ -117,21 +117,31 @@ function resolveOperationType(type: string): OperationType {
 export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
   const selectedNodeIds = useAtomValue(selectedNodeIdsAtom);
   const isSelected = selectedNodeIds.has(data.metadata?.rawNode?.id ?? '');
+  const hasSelection = selectedNodeIds.size > 0;
+  const isDimmed = hasSelection && !isSelected;
   const statistics = parseCustomStatistics(data.metadata?.rawNode);
 
   const nodeContent = (
     <div
-      className={nodeVariants({
+      className={`${nodeVariants({
         operationType: resolveOperationType(data.operationType),
         selected: isSelected,
-      })}
-      style={{ zIndex: 10 }}
+      })} ${isSelected ? 'border-2 scale-110' : ''}`}
+      style={{
+        zIndex: 10,
+        opacity: isDimmed ? 0.3 : 1,
+        transition: 'opacity 0.15s, transform 0.15s',
+      }}
     >
       {data.hasIncoming && (
         <Handle type="target" position={Position.Top} className="w-2 h-2" style={{ opacity: 0 }} />
       )}
 
-      <div className="text-sm font-normal break-words text-center">{data.label}</div>
+      <div
+        className={`text-sm break-words text-center ${isSelected ? 'font-bold' : 'font-normal'}`}
+      >
+        {data.label}
+      </div>
 
       {data.hasOutgoing && (
         <Handle

--- a/ui/src/components/timeline/ResourceTimeline.tsx
+++ b/ui/src/components/timeline/ResourceTimeline.tsx
@@ -30,8 +30,6 @@ import type { QueryFilter } from '~quent/types/QueryFilter';
 import type { TaskFilter } from '~quent/types/TaskFilter';
 import type { CapacityDecl } from '~quent/types/CapacityDecl';
 import type { QuantitySpec } from '~quent/types/QuantitySpec';
-import { useTimelineChartColors } from './useTimelineChartColors';
-
 const Timeline = lazy(() => import('./Timeline').then(mod => ({ default: mod.Timeline })));
 
 type ResourceTimelineProps = {
@@ -90,7 +88,6 @@ export function ResourceTimeline({
   const operatorCacheKey = timelineCacheKey(resourceId, cacheResourceTypeName, operatorId);
   const operatorTimelineData = useAtomValue(timelineDataAtom(operatorCacheKey));
   const overlayPreloadedData = operatorId ? operatorTimelineData : undefined;
-  const { overlayLighten } = useTimelineChartColors();
 
   const {
     data: fetchedData,
@@ -179,10 +176,21 @@ export function ResourceTimeline({
           capacities,
           quantitySpecs
         );
+        // Dim long entity marks not present in the operator's long entities.
+        const opLongFsmIds = new Set(getLongFsms(overlayPreloadedData.data).map(f => f.id));
+        const dimmedMarks = timelineMarks?.map(m => {
+          const baseFsm = longFsms.find(f => (f.instance_name || f.id) === m.label);
+          const inOperator = baseFsm ? opLongFsmIds.has(baseFsm.id) : false;
+          return {
+            ...m,
+            isDimmed: !inOperator,
+            operatorName: inOperator ? (operatorLabel ?? undefined) : undefined,
+          };
+        });
         return {
           timestamps: base.timestamps,
-          series: mergeOverlaySeries(base.series, opResult.series, operatorLabel, overlayLighten),
-          marks: timelineMarks,
+          series: mergeOverlaySeries(base.series, opResult.series, operatorLabel),
+          marks: dimmedMarks,
         };
       }
     }
@@ -195,7 +203,6 @@ export function ResourceTimeline({
     overlayPreloadedData,
     startTime,
     operatorLabel,
-    overlayLighten,
     capacities,
     quantitySpecs,
   ]);

--- a/ui/src/components/timeline/ResourceTimeline.tsx
+++ b/ui/src/components/timeline/ResourceTimeline.tsx
@@ -162,7 +162,6 @@ export function ResourceTimeline({
     const longFsms = getLongFsms(data.data);
     const filterSet =
       resourceType === EntityTypeKey.Resource ? new Set([resourceId]) : new Set<string>();
-    const timelineMarks = buildTimelineMarks(longFsms, startTime, filterSet);
 
     if (overlayPreloadedData && operatorLabel) {
       const baseSpan = getTimelineConfig(data).span;
@@ -176,24 +175,16 @@ export function ResourceTimeline({
           capacities,
           quantitySpecs
         );
-        // Dim long entity marks not present in the operator's long entities.
         const opLongFsmIds = new Set(getLongFsms(overlayPreloadedData.data).map(f => f.id));
-        const dimmedMarks = timelineMarks?.map(m => {
-          const baseFsm = longFsms.find(f => (f.instance_name || f.id) === m.label);
-          const inOperator = baseFsm ? opLongFsmIds.has(baseFsm.id) : false;
-          return {
-            ...m,
-            isDimmed: !inOperator,
-            operatorName: inOperator ? (operatorLabel ?? undefined) : undefined,
-          };
-        });
         return {
           timestamps: base.timestamps,
           series: mergeOverlaySeries(base.series, opResult.series, operatorLabel),
-          marks: dimmedMarks,
+          marks: buildTimelineMarks(longFsms, startTime, filterSet, opLongFsmIds, operatorLabel),
         };
       }
     }
+
+    const timelineMarks = buildTimelineMarks(longFsms, startTime, filterSet);
 
     return { ...base, marks: timelineMarks };
   }, [
@@ -202,9 +193,11 @@ export function ResourceTimeline({
     operatorId,
     overlayPreloadedData,
     startTime,
-    operatorLabel,
     capacities,
     quantitySpecs,
+    resourceType,
+    resourceId,
+    operatorLabel,
   ]);
 
   if (!preloadedData && (!deferredReady || isLoading)) {

--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -273,6 +273,7 @@ export function Timeline({
                 name: p.seriesName,
                 value: p.data[1],
                 isOverlay: series[p.seriesName]?.isOverlay ?? false,
+                isDimmed: series[p.seriesName]?.isDimmed ?? false,
               };
             });
           const activeMarks = marks

--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -7,7 +7,7 @@ import type { LineSeriesOption } from 'echarts/charts';
 import type { EChartsInstance } from 'echarts-for-react';
 import { useAtomValue } from 'jotai';
 import { TooltipContent } from './TimelineTooltip';
-import { createStripePattern, getColorForKey, withOpacity } from '@/services/colors';
+import { withOpacity } from '@/services/colors';
 import type { TimelineSeriesEntry } from './types';
 import {
   TimelineSeries,
@@ -62,6 +62,7 @@ export function Timeline({
     const allSeries: LineSeriesOption[] = sortedEntries.map(([name, seriesData]) => {
       const color = seriesData.color;
       const isOverlay = seriesData.isOverlay ?? false;
+      const isDimmed = seriesData.isDimmed ?? false;
 
       return {
         name,
@@ -78,13 +79,8 @@ export function Timeline({
         lineStyle: { width: 0 },
         itemStyle: { color },
         areaStyle: {
-          color: isOverlay
-            ? {
-                image: createStripePattern(color),
-                repeat: 'repeat',
-              }
-            : color,
-          opacity: 1,
+          color,
+          opacity: isDimmed ? 0.25 : 1,
         },
         z: isOverlay ? 5 : 2,
         sampling: 'lttb',
@@ -101,7 +97,9 @@ export function Timeline({
     for (let i = 0; i < maxMarkCountRef.current; i++) {
       const m = marks?.[i];
       if (m) {
-        const stateColor = getColorForKey(m.stateName);
+        const stateColor = m.color;
+        const dimmed = m.isDimmed ?? false;
+        const dimOpacity = 0.15;
         allSeries.push({
           name: `__mark_${i}`,
           type: 'line',
@@ -111,13 +109,14 @@ export function Timeline({
             {
               value: [m.xStart, 1],
               label: {
-                show: true,
-                formatter: () => m.label,
+                show: !dimmed,
+                formatter: () =>
+                  `${m.label}\n${m.stateName}${m.operatorName ? `\n${m.operatorName}` : ''}`,
                 position: [0, -5],
                 fontSize: 9,
                 fontWeight: 500,
                 color: markLabelTextColor,
-                backgroundColor: withOpacity(stateColor, 1),
+                backgroundColor: withOpacity(stateColor, 0.85),
                 borderRadius: 1,
                 padding: [1, 2],
               },
@@ -129,11 +128,11 @@ export function Timeline({
           label: { show: false },
           symbolSize: 0,
           lineStyle: {
-            width: 1,
-            color: withOpacity(stateColor, markAreaBorderOpacity),
+            width: dimmed ? 0.5 : 1,
+            color: withOpacity(stateColor, dimmed ? dimOpacity : markAreaBorderOpacity),
           },
           areaStyle: {
-            color: withOpacity(stateColor, markAreaFillOpacity),
+            color: withOpacity(stateColor, dimmed ? dimOpacity : markAreaFillOpacity),
             opacity: 1,
           },
           tooltip: { show: false },

--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -277,7 +277,7 @@ export function Timeline({
             });
           const activeMarks = marks
             ?.filter(m => timestamp >= m.xStart && timestamp <= m.xEnd)
-            .map(m => ({ label: m.label, stateName: m.stateName }));
+            .map(m => ({ label: m.label, stateName: m.stateName, color: m.color }));
           const fmt = Object.values(series)[0]?.formatter;
           return renderToStaticMarkup(
             <TooltipContent

--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -24,6 +24,7 @@ import { useTimelineChartColors } from './useTimelineChartColors';
 import { zoomRangeAtom } from '@/atoms/timeline';
 
 export const CHART_GROUP = 'timeline-sync-group';
+const DIMMED_OPACITY = 0.25;
 
 export function Timeline({
   startTime,
@@ -83,7 +84,7 @@ export function Timeline({
         itemStyle: { color },
         areaStyle: {
           color,
-          opacity: isDimmed ? 0.25 : 1,
+          opacity: isDimmed ? DIMMED_OPACITY : 1,
         },
         z: isOverlay ? 5 : 2,
         sampling: 'lttb',
@@ -102,7 +103,6 @@ export function Timeline({
       if (m) {
         const stateColor = m.color;
         const dimmed = m.isDimmed ?? false;
-        const dimOpacity = 0.15;
         allSeries.push({
           name: `__mark_${i}`,
           type: 'line',
@@ -131,11 +131,11 @@ export function Timeline({
           label: { show: false },
           symbolSize: 0,
           lineStyle: {
-            width: dimmed ? 0.5 : 1,
-            color: withOpacity(stateColor, dimmed ? dimOpacity : markAreaBorderOpacity),
+            width: 1,
+            color: withOpacity(stateColor, dimmed ? DIMMED_OPACITY : markAreaBorderOpacity),
           },
           areaStyle: {
-            color: withOpacity(stateColor, dimmed ? dimOpacity : markAreaFillOpacity),
+            color: withOpacity(stateColor, dimmed ? DIMMED_OPACITY : markAreaFillOpacity),
             opacity: 1,
           },
           tooltip: { show: false },

--- a/ui/src/components/timeline/TimelineTooltip.tsx
+++ b/ui/src/components/timeline/TimelineTooltip.tsx
@@ -7,6 +7,7 @@ interface TooltipSeries {
   name: string;
   value: number;
   isOverlay?: boolean;
+  isDimmed?: boolean;
 }
 
 type ValueFormatter = (value: number) => string;
@@ -41,6 +42,7 @@ interface StateBar {
   baseValue: number;
   baseColor: string;
   overlays: OverlaySegment[];
+  isDimmed?: boolean;
 }
 
 interface SegmentedBarSegment {
@@ -87,7 +89,7 @@ function SegmentedBarRow({
                 className="min-w-0 flex items-center justify-center font-semibold truncate text-background"
                 title={seg.label}
               >
-                {pct >= 15 ? seg.label : ''}
+                {pct >= 25 ? seg.label : ''}
               </div>
             );
           })}
@@ -125,7 +127,7 @@ function buildBarSegments(
       value: Math.max(restValue, 0),
       color: bar.baseColor,
       label: fmt(Math.max(restValue, 0)),
-      isDimmed: segments.length > 0,
+      isDimmed: bar.isDimmed,
     });
   }
 
@@ -286,6 +288,7 @@ export function TooltipContent({
         state: base.name,
         baseValue: base.value,
         baseColor: base.color,
+        isDimmed: base.isDimmed,
         overlays: matchingOverlays.map(o => ({
           name: o.name,
           value: o.value,

--- a/ui/src/components/timeline/TimelineTooltip.tsx
+++ b/ui/src/components/timeline/TimelineTooltip.tsx
@@ -76,17 +76,24 @@ function SegmentedBarRow({
         <div className="flex h-full rounded-xs overflow-hidden">
           {segments.map((seg, i) => {
             const pct = total > 0 ? (seg.value / total) * 100 : 100;
+            // For dimmed segments, bake the alpha into the background so
+            // text stays fully opaque and readable.
+            const bgColor = seg.isDimmed
+              ? `color-mix(in srgb, ${seg.color} 30%, transparent)`
+              : seg.color;
+            const textColor = seg.isDimmed ? 'text-foreground' : 'text-background';
             const style: React.CSSProperties = {
               width: `${pct}%`,
-              backgroundColor: seg.color,
-              opacity: seg.isDimmed ? 0.3 : 1,
-              textShadow: '0 0 1px hsl(var(--foreground)), 0 0 1px hsl(var(--foreground))',
+              backgroundColor: bgColor,
             };
             return (
               <div
                 key={i}
                 style={style}
-                className="min-w-0 flex items-center justify-center font-semibold truncate text-background"
+                className={cn(
+                  'min-w-0 flex items-center justify-center font-semibold truncate',
+                  textColor
+                )}
                 title={seg.label}
               >
                 {pct >= 25 ? seg.label : ''}

--- a/ui/src/components/timeline/TimelineTooltip.tsx
+++ b/ui/src/components/timeline/TimelineTooltip.tsx
@@ -1,5 +1,4 @@
 import { formatDurationForWindow } from '@/services/formatters';
-import { getColorForKey } from '@/services/colors';
 import { cn } from '@/lib/utils';
 import { nanosToMs } from '@/lib/timeline.utils';
 
@@ -48,7 +47,8 @@ interface SegmentedBarSegment {
   value: number;
   color: string;
   label: string;
-  isOverlay?: boolean;
+  /** When true, this segment is the non-operator "rest" and is rendered at low opacity. */
+  isDimmed?: boolean;
 }
 
 function SegmentedBarRow({
@@ -74,19 +74,17 @@ function SegmentedBarRow({
         <div className="flex h-full rounded-xs overflow-hidden">
           {segments.map((seg, i) => {
             const pct = total > 0 ? (seg.value / total) * 100 : 100;
-            const style: React.CSSProperties & Record<`--${string}`, string> = {
+            const style: React.CSSProperties = {
               width: `${pct}%`,
+              backgroundColor: seg.color,
+              opacity: seg.isDimmed ? 0.3 : 1,
               textShadow: '0 0 1px hsl(var(--foreground)), 0 0 1px hsl(var(--foreground))',
-              ...(seg.isOverlay ? { '--stripe-color': seg.color } : { backgroundColor: seg.color }),
             };
             return (
               <div
                 key={i}
                 style={style}
-                className={cn(
-                  'min-w-0 flex items-center justify-center font-semibold truncate text-background',
-                  seg.isOverlay && 'bg-diagonal-stripe'
-                )}
+                className="min-w-0 flex items-center justify-center font-semibold truncate text-background"
                 title={seg.label}
               >
                 {pct >= 15 ? seg.label : ''}
@@ -119,7 +117,6 @@ function buildBarSegments(
         value: o.value,
         color: o.color,
         label: fmt(o.value),
-        isOverlay: true,
       });
     }
   }
@@ -128,6 +125,7 @@ function buildBarSegments(
       value: Math.max(restValue, 0),
       color: bar.baseColor,
       label: fmt(Math.max(restValue, 0)),
+      isDimmed: segments.length > 0,
     });
   }
 
@@ -139,7 +137,11 @@ function buildBarSegments(
   return { segments, overlayPct };
 }
 
-function ActiveMarksSection({ marks }: { marks: { label: string; stateName: string }[] }) {
+function ActiveMarksSection({
+  marks,
+}: {
+  marks: { label: string; stateName: string; color: string }[];
+}) {
   if (marks.length === 0) return null;
   return (
     <div className="mt-1 pt-1 border-t border-border">
@@ -148,8 +150,8 @@ function ActiveMarksSection({ marks }: { marks: { label: string; stateName: stri
           <span
             className="w-2 h-2 rounded-xs shrink-0 border"
             style={{
-              backgroundColor: getColorForKey(m.stateName) + '20',
-              borderColor: getColorForKey(m.stateName) + 'cc',
+              backgroundColor: m.color + '20',
+              borderColor: m.color + 'cc',
             }}
           />
           <span className="text-muted-foreground">{m.label}</span>
@@ -173,7 +175,7 @@ function OverlayBarTooltip({
   startTime: bigint;
   fmt: ValueFormatter;
   windowMs: number;
-  activeMarks?: { label: string; stateName: string }[];
+  activeMarks?: { label: string; stateName: string; color: string }[];
 }) {
   const visibleBars = bars
     .filter(b => b.baseValue > 0 || b.overlays.some(o => o.value > 0))
@@ -222,9 +224,8 @@ function OverlayBarTooltip({
             if (totalOverlay > 0) {
               segments.push({
                 value: totalOverlay,
-                color: 'var(--color-gray-300)',
+                color: 'var(--color-gray-400)',
                 label: fmt(totalOverlay),
-                isOverlay: true,
               });
             }
             if (totalRest > 0 || segments.length === 0) {
@@ -232,6 +233,7 @@ function OverlayBarTooltip({
                 value: Math.max(totalRest, 0),
                 color: 'var(--color-gray-400)',
                 label: fmt(Math.max(totalRest, 0)),
+                isDimmed: segments.length > 0,
               });
             }
 
@@ -270,7 +272,7 @@ export function TooltipContent({
   startTime: bigint;
   fmt?: ValueFormatter;
   windowMs: number;
-  activeMarks?: { label: string; stateName: string }[];
+  activeMarks?: { label: string; stateName: string; color: string }[];
 }) {
   const hasOverlays = series.some(s => s.isOverlay);
 

--- a/ui/src/components/timeline/types.ts
+++ b/ui/src/components/timeline/types.ts
@@ -4,6 +4,8 @@ export type TimelineSeriesEntry = {
   values: number[];
   color: string;
   isOverlay?: boolean;
+  /** When true, this series is dimmed to make overlay series stand out. */
+  isDimmed?: boolean;
 };
 
 export type TimelineSeries = Record<string, TimelineSeriesEntry>;
@@ -12,8 +14,13 @@ export type TimelineSeries = Record<string, TimelineSeriesEntry>;
 export type TimelineMark = {
   label: string;
   stateName: string;
+  color: string;
   xStart: number;
   xEnd: number;
+  /** When true, this mark is dimmed (e.g. not part of the selected operator's long entities). */
+  isDimmed?: boolean;
+  /** Operator instance name when this mark belongs to a selected operator's long entities. */
+  operatorName?: string;
 };
 
 export const DEFAULT_TIMELINE_HEIGHT = 75;

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -13,7 +13,7 @@ import type { CapacityDecl } from '~quent/types/CapacityDecl';
 import type { EChartsInstance } from 'echarts-for-react';
 import { connect, getInstanceByDom } from '@/lib/echarts';
 import { CHART_GROUP } from '@/components/timeline/Timeline';
-import { getColorForKey, lightenColor, WHITE, withOpacity } from '@/services/colors';
+import { getColorForKey, WHITE, withOpacity } from '@/services/colors';
 import type { BinnedSpanSec } from '~quent/types/BinnedSpanSec';
 import type { SingleTimelineResponse } from '~quent/types/SingleTimelineResponse';
 import type { FiniteStateMachine } from '~quent/types/FiniteStateMachine';
@@ -161,7 +161,13 @@ export function buildTimelineMarks(
         const next = fsm.transitions[i + 1];
         const xStart = startTimeMs + transition.timestamp * 1000;
         const xEnd = startTimeMs + next.timestamp * 1000;
-        return { label, stateName: transition.name, xStart, xEnd };
+        return {
+          label,
+          stateName: transition.name,
+          color: getColorForKey(transition.name),
+          xStart,
+          xEnd,
+        };
       })
       .filter((m): m is TimelineMark => m != null && m.xEnd > m.xStart);
   });
@@ -171,23 +177,26 @@ export function buildTimelineMarks(
 
 /**
  * Merge overlay series into base series for overlay rendering.
- * Each overlay series entry gets a lightened color, an `isOverlay` flag,
- * and a tooltip name of "{state} ({overlayLabel})".
+ * Base series are dimmed; overlay series keep original colors so the
+ * selected operator stands out clearly against the background.
  */
 export function mergeOverlaySeries(
   baseSeries: TimelineSeries,
   overlaySeries: TimelineSeries,
-  overlayLabel: string,
-  lightenAmount: number
+  overlayLabel: string
 ): TimelineSeries {
-  const merged: TimelineSeries = { ...baseSeries };
+  // Dim all base series to push them into the background.
+  const merged: TimelineSeries = {};
+  for (const [state, baseEntry] of Object.entries(baseSeries)) {
+    merged[state] = { ...baseEntry, isDimmed: true };
+  }
+  // Add overlay series at full intensity with original colors.
   for (const [state, overlayEntry] of Object.entries(overlaySeries)) {
     const baseEntry = baseSeries[state];
-    const baseColor = baseEntry?.color ?? overlayEntry.color;
     const overlayName = `${state} (${overlayLabel})`;
     merged[overlayName] = {
       ...overlayEntry,
-      color: lightenColor(baseColor, lightenAmount),
+      color: baseEntry?.color ?? overlayEntry.color,
       isOverlay: true,
     };
   }

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -141,7 +141,10 @@ export function getLongFsms(data: ResourceTimeline): FiniteStateMachine[] {
 export function buildTimelineMarks(
   longFsms: FiniteStateMachine[],
   startTime: bigint,
-  resourceIdsForFilter?: Set<string> | null
+  resourceIdsForFilter?: Set<string> | null,
+  /** When provided, marks whose FSM is in this set are highlighted; others are dimmed. */
+  overlayFsmIds?: Set<string>,
+  overlayLabel?: string
 ): TimelineMark[] | undefined {
   if (longFsms.length === 0) return undefined;
 
@@ -149,6 +152,7 @@ export function buildTimelineMarks(
 
   const marks = longFsms.flatMap(fsm => {
     const label = fsm.instance_name || fsm.id;
+    const inOverlay = overlayFsmIds ? overlayFsmIds.has(fsm.id) : undefined;
     return fsm.transitions
       .slice(0, -1)
       .map((transition, i) => {
@@ -167,6 +171,10 @@ export function buildTimelineMarks(
           color: getColorForKey(transition.name),
           xStart,
           xEnd,
+          ...(inOverlay !== undefined && {
+            isDimmed: !inOverlay,
+            operatorName: inOverlay ? overlayLabel : undefined,
+          }),
         };
       })
       .filter((m): m is TimelineMark => m != null && m.xEnd > m.xStart);


### PR DESCRIPTION
<img width="1727" height="606" alt="Screenshot 2026-03-18 at 4 36 01 PM" src="https://github.com/user-attachments/assets/a82e7312-4c39-4270-bfa2-e23759e26f7d" />

<img width="1510" height="586" alt="Screenshot 2026-03-18 at 4 36 32 PM" src="https://github.com/user-attachments/assets/df6cf72b-6075-4363-a24b-bed9a485c1aa" />


Blinking while selecting operators is very annoying but have an issue to track that down: https://github.com/rapidsai/quent/issues/61