### PR TITLE
fix(ui): resource type selector inert

### DIFF
--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -270,6 +270,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -1960,8 +1964,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3051,6 +3055,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4006,7 +4012,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -4706,10 +4712,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   fsevents@2.3.3:
     optional: true

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -176,9 +176,9 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
               }}
               availableFsmTypes={availableFsmTypes}
               selectedFsmType={selectedFsmTypes.get(item.id) ?? null}
-              onFsmChange={(itemId, fsmType) =>
-                setSelectedFsmTypes(prev => new Map(prev).set(itemId, fsmType))
-              }
+              onFsmChange={(itemId, fsmType) => {
+                setSelectedFsmTypes(prev => new Map(prev).set(itemId, fsmType));
+              }}
             />
           );
         },

--- a/ui/src/components/resource-tree/InlineSelector.tsx
+++ b/ui/src/components/resource-tree/InlineSelector.tsx
@@ -10,18 +10,18 @@ import { cn } from '@/lib/utils';
 interface InlineSelectorProps {
   id: string;
   label?: string;
-  selectedType: string;
-  availableResourceTypes: string[];
-  onTypeChange: (itemId: string, type: string) => void;
+  value: string;
+  options: string[];
+  onChange: (itemId: string, type: string) => void;
   className?: string;
 }
 
 export const InlineSelector = ({
   id,
   label = 'Type',
-  selectedType,
-  availableResourceTypes,
-  onTypeChange,
+  value,
+  options,
+  onChange,
   className,
 }: InlineSelectorProps): React.ReactNode => {
   return (
@@ -33,7 +33,7 @@ export const InlineSelector = ({
       <label id={`type-select-label-${id}`} className="text-xs text-muted-foreground shrink-0">
         {label}:
       </label>
-      <Select value={selectedType} onValueChange={value => onTypeChange(id, value)}>
+      <Select value={value} onValueChange={value => onChange(id, value)}>
         <SelectTrigger
           id={`type-select-${id}`}
           aria-labelledby={`type-select-label-${id}`}
@@ -50,13 +50,13 @@ export const InlineSelector = ({
           position="popper"
           className="max-h-[--radix-select-content-available-height] min-w-[var(--radix-select-trigger-width)]"
         >
-          {availableResourceTypes.map(typeOption => (
+          {options.map(option => (
             <SelectItem
-              key={typeOption}
-              value={typeOption}
+              key={option}
+              value={option}
               className="text-xs py-1.5 pl-8 pr-2 cursor-pointer"
             >
-              {typeOption}
+              {option}
             </SelectItem>
           ))}
         </SelectContent>

--- a/ui/src/components/resource-tree/ResourceGroupRow.tsx
+++ b/ui/src/components/resource-tree/ResourceGroupRow.tsx
@@ -40,9 +40,9 @@ export const ResourceGroupRow = ({
         <InlineSelector
           id={`${id}-resource-type`}
           label="Type"
-          selectedType={selectedType}
-          availableResourceTypes={availableResourceTypes}
-          onTypeChange={onTypeChange}
+          value={selectedType}
+          options={availableResourceTypes}
+          onChange={(_, value) => onTypeChange(id, value)}
           className="mt-1"
         />
       )}
@@ -55,9 +55,9 @@ export const ResourceGroupRow = ({
         <InlineSelector
           id={`${id}-fsm`}
           label="FSM"
-          selectedType={selectedFsmType ?? FSM_ALL}
-          availableResourceTypes={fsmOptions}
-          onTypeChange={(_itemId, value) => onFsmChange(id, value === FSM_ALL ? null : value)}
+          value={selectedFsmType ?? FSM_ALL}
+          options={fsmOptions}
+          onChange={(_, value) => onFsmChange(id, value === FSM_ALL ? null : value)}
           className="mt-1"
         />
       )}


### PR DESCRIPTION
[This ID change ](https://github.com/rapidsai/quent/pull/60#discussion_r2956361973) broke the resource type selector, the ID was used to keep track of what resource types were selected for which resources. Fix is to not use the ID param from the callback, but use the raw resource ID prop instead in the callback. 

Also fixes the `pnpm audit` errors, thought those were fixed already, but just require a pnpm lock update w existing dep versions. 

Bonus: Forgot to update the props to `InlineSelector` to make them also generic and not reference "type", instead they use `value`, `options`, and `onChange` generic props now. 


Before:

https://github.com/user-attachments/assets/f5681241-e6ba-4f16-a386-ce8c2bf1fae5


After:


https://github.com/user-attachments/assets/ae403a02-7fe0-46b4-80eb-14fedb5dfbbe

