### PR TITLE
fix(ui): timeline controller filtered

### DIFF
--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1623,11 +1623,11 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4367,12 +4367,12 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4985,11 +4985,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   ms@2.1.3: {}
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -2379,12 +2379,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   postcss@8.5.8:
@@ -4320,7 +4320,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   argparse@2.0.1: {}
 
@@ -4693,9 +4693,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5073,9 +5073,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   postcss@8.5.8:
     dependencies:
@@ -5144,7 +5144,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   recast@0.23.11:
     dependencies:
@@ -5172,7 +5172,7 @@ snapshots:
   rollup-plugin-visualizer@6.0.11(rollup@4.59.0):
     dependencies:
       open: 8.4.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
@@ -5299,8 +5299,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.0.3: {}
 
@@ -5364,7 +5364,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   until-async@3.0.2: {}
@@ -5401,8 +5401,8 @@ snapshots:
   vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -5427,7 +5427,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2

--- a/ui/src/components/QueryResourceTree.test.tsx
+++ b/ui/src/components/QueryResourceTree.test.tsx
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { renderWithQuery } from '@/test/test-utils';
+import { Provider as JotaiProvider, createStore } from 'jotai';
+import { QueryResourceTree } from './QueryResourceTree';
+import { applyBulkTimelineResponse } from '@/hooks/useBulkTimelineFetch';
+import { timelineCacheKey, timelineDataAtom } from '@/atoms/timeline';
+import type { SingleTimelineResponse } from '~quent/types/SingleTimelineResponse';
+import type { QueryBundle } from '~quent/types/QueryBundle';
+import type { EntityRef } from '~quent/types/EntityRef';
+
+// ---------------------------------------------------------------------------
+// Mock heavy/visual dependencies so tests run without a real browser/canvas
+// ---------------------------------------------------------------------------
+
+vi.mock('@/hooks/useBulkTimelines', () => ({
+  useBulkTimelines: () => ({ handleZoomChange: vi.fn(), handleExpand: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useExpandedIds', () => ({
+  useExpandedIds: () => ({ expandedIds: new Set<string>(), handleExpandChange: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useHighlightedItemIds', () => ({
+  useHighlightedItemIds: () => new Set<string>(),
+}));
+
+// Capture the timelineData prop passed to TimelineController on every render
+let capturedTimelineData: SingleTimelineResponse | null | undefined = undefined;
+vi.mock('./timeline/TimelineController', () => ({
+  TimelineController: (props: { timelineData?: SingleTimelineResponse | null }) => {
+    capturedTimelineData = props.timelineData;
+    return null;
+  },
+}));
+
+// Render subHeaderContent so TimelineController is actually mounted
+vi.mock('@/components/ui/tree-table', () => ({
+  TreeTable: ({ columns }: { columns: Array<{ subHeaderContent?: React.ReactNode }> }) => {
+    const col = columns.find(c => c.subHeaderContent != null);
+    return <>{col?.subHeaderContent}</>;
+  },
+}));
+
+vi.mock('./resource-tree/ResourceColumn', () => ({ ResourceColumn: () => null }));
+vi.mock('./resource-tree/UsageColumn', () => ({ UsageColumn: () => null }));
+vi.mock('./timeline/TimelineToolbar', () => ({ TimelineToolbar: () => null }));
+
+import * as api from '@/services/api';
+vi.mock('@/services/api', async importOriginal => {
+  const actual = await importOriginal<typeof api>();
+  return { ...actual, fetchSingleTimeline: vi.fn(), fetchBulkTimelines: vi.fn() };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DURATION_S = 100;
+const ROOT_GROUP_ID = 'qg-1';
+const RESOURCE_ID = 'res-1';
+const RESOURCE_TYPE = 'GPU';
+
+/** Minimal QueryBundle that causes the root timeline query to be enabled. */
+const makeBundle = (): QueryBundle<EntityRef> =>
+  ({
+    query_id: 'test-query',
+    entities: {
+      engine: { id: 'engine-1' },
+      query_group: { id: ROOT_GROUP_ID },
+      query: { id: 'query-1' },
+      workers: {},
+      plans: {},
+      operators: {},
+      ports: {},
+      resource_types: { [RESOURCE_TYPE]: { used_by: ['task'], capacities: [] } },
+      resource_group_types: {},
+      resources: { [RESOURCE_ID]: { id: RESOURCE_ID, type_name: RESOURCE_TYPE } },
+      resource_groups: {},
+      fsm_types: {},
+    },
+    resource_tree: {
+      ResourceGroup: {
+        id: { QueryGroup: ROOT_GROUP_ID },
+        children: [{ Resource: { Resource: RESOURCE_ID } }],
+      },
+    },
+    plan_tree: { id: 'plan-1', worker: null, children: [] },
+    unique_operator_names: [],
+    quantity_specs: {},
+    start_time_unix_ns: 0n,
+    duration_s: DURATION_S,
+  }) as unknown as QueryBundle<EntityRef>;
+
+const makeTimeline = (start: number, end: number): SingleTimelineResponse =>
+  ({
+    config: { span: { start, end }, bin_duration: 1, num_bins: BigInt(end - start) },
+    data: { Binned: { series: {} } },
+  }) as unknown as SingleTimelineResponse;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('QueryResourceTree — TimelineController always shows full-range data', () => {
+  beforeEach(() => {
+    capturedTimelineData = undefined;
+    vi.mocked(api.fetchBulkTimelines).mockResolvedValue({ entries: {} } as never);
+  });
+
+  it('passes full-range timeline data to TimelineController', async () => {
+    const fullRange = makeTimeline(0, DURATION_S);
+    vi.mocked(api.fetchSingleTimeline).mockResolvedValue(fullRange);
+
+    const store = createStore();
+    renderWithQuery(
+      <JotaiProvider store={store}>
+        <QueryResourceTree engineId="engine-1" queryBundle={makeBundle()} />
+      </JotaiProvider>
+    );
+
+    await waitFor(() => expect(capturedTimelineData).toBe(fullRange));
+    expect(capturedTimelineData?.config.span.start).toBe(0);
+    expect(capturedTimelineData?.config.span.end).toBe(DURATION_S);
+  });
+
+  it('is unaffected when a zoom-bounded bulk fetch overwrites the same atom cache key', async () => {
+    const fullRange = makeTimeline(0, DURATION_S);
+    const zoomed = makeTimeline(25, 75);
+    vi.mocked(api.fetchSingleTimeline).mockResolvedValue(fullRange);
+
+    const store = createStore();
+    renderWithQuery(
+      <JotaiProvider store={store}>
+        <QueryResourceTree engineId="engine-1" queryBundle={makeBundle()} />
+      </JotaiProvider>
+    );
+
+    // Wait for the full-range data to appear in TimelineController
+    await waitFor(() => expect(capturedTimelineData).toBe(fullRange));
+
+    // Simulate what useBulkTimelines does when the user zooms: it calls
+    // applyBulkTimelineResponse which writes zoom-bounded data to timelineDataAtom
+    // under the same key that was previously used for the full-range data.
+    const idToMeta = new Map([
+      [
+        'bulk-id-1',
+        { resourceId: ROOT_GROUP_ID, resourceTypeName: RESOURCE_TYPE, operatorId: null, fsmTypeName: null },
+      ],
+    ]);
+    applyBulkTimelineResponse(
+      { entries: { 'bulk-id-1': { status: 'ok', data: zoomed.data, config: zoomed.config } as never } },
+      idToMeta,
+      store
+    );
+
+    // Confirm the atom was indeed overwritten with zoomed data
+    const cacheKey = timelineCacheKey({ resourceId: ROOT_GROUP_ID, resourceTypeName: RESOURCE_TYPE, fsmTypeName: null });
+    expect(store.get(timelineDataAtom(cacheKey))?.config.span.start).toBe(25);
+
+    // TimelineController must still show the full-range data — not the atom value
+    expect(capturedTimelineData?.config.span.start).toBe(0);
+    expect(capturedTimelineData?.config.span.end).toBe(DURATION_S);
+  });
+});

--- a/ui/src/components/QueryResourceTree.test.tsx
+++ b/ui/src/components/QueryResourceTree.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { waitFor } from '@testing-library/react';
+import { waitFor, act } from '@testing-library/react';
 import { renderWithQuery } from '@/test/test-utils';
 import { Provider as JotaiProvider, createStore } from 'jotai';
 import { QueryResourceTree } from './QueryResourceTree';
@@ -101,10 +101,6 @@ const makeTimeline = (start: number, end: number): SingleTimelineResponse =>
     data: { Binned: { series: {} } },
   }) as unknown as SingleTimelineResponse;
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe('QueryResourceTree — TimelineController always shows full-range data', () => {
   beforeEach(() => {
     capturedTimelineData = undefined;
@@ -145,23 +141,40 @@ describe('QueryResourceTree — TimelineController always shows full-range data'
     // Simulate what useBulkTimelines does when the user zooms: it calls
     // applyBulkTimelineResponse which writes zoom-bounded data to timelineDataAtom
     // under the same key that was previously used for the full-range data.
+    // Wrap in act() so any atom-subscription re-renders are flushed synchronously
+    // before we assert — this is what makes the test fail on the buggy code.
     const idToMeta = new Map([
       [
         'bulk-id-1',
-        { resourceId: ROOT_GROUP_ID, resourceTypeName: RESOURCE_TYPE, operatorId: null, fsmTypeName: null },
+        {
+          resourceId: ROOT_GROUP_ID,
+          resourceTypeName: RESOURCE_TYPE,
+          operatorId: null,
+          fsmTypeName: null,
+        },
       ],
     ]);
-    applyBulkTimelineResponse(
-      { entries: { 'bulk-id-1': { status: 'ok', data: zoomed.data, config: zoomed.config } as never } },
-      idToMeta,
-      store
-    );
+    await act(async () => {
+      applyBulkTimelineResponse(
+        {
+          entries: {
+            'bulk-id-1': { status: 'ok', data: zoomed.data, config: zoomed.config } as never,
+          },
+        },
+        idToMeta,
+        store
+      );
+    });
 
-    // Confirm the atom was indeed overwritten with zoomed data
-    const cacheKey = timelineCacheKey({ resourceId: ROOT_GROUP_ID, resourceTypeName: RESOURCE_TYPE, fsmTypeName: null });
+    // Confirm the atom was indeed overwritten with zoomed data (bug mechanism is intact)
+    const cacheKey = timelineCacheKey({
+      resourceId: ROOT_GROUP_ID,
+      resourceTypeName: RESOURCE_TYPE,
+      fsmTypeName: null,
+    });
     expect(store.get(timelineDataAtom(cacheKey))?.config.span.start).toBe(25);
 
-    // TimelineController must still show the full-range data — not the atom value
+    // TimelineController must still show the full-range data — not the atom value.
     expect(capturedTimelineData?.config.span.start).toBe(0);
     expect(capturedTimelineData?.config.span.end).toBe(DURATION_S);
   });

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Column, TreeTable } from '@/components/ui/tree-table';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { useAtomValue, useStore } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
 import { useHighlightedItemIds } from '@/hooks/useHighlightedItemIds';
 import { ResourceTree } from '~quent/types/ResourceTree';
@@ -23,13 +22,7 @@ import type { TaskFilter } from '~quent/types/TaskFilter';
 import { transformResourceTree, getAdaptiveNumBins, nanosToMs } from '@/lib/timeline.utils';
 import { useExpandedIds } from '@/hooks/useExpandedIds';
 import { useBulkTimelines } from '@/hooks/useBulkTimelines';
-import {
-  zoomRangeAtom,
-  debouncedZoomRangeAtom,
-  startTimeMsAtom,
-  timelineCacheKey,
-  timelineDataAtom,
-} from '@/atoms/timeline';
+import { zoomRangeAtom, debouncedZoomRangeAtom, startTimeMsAtom } from '@/atoms/timeline';
 import { TimelineToolbar } from './timeline/TimelineToolbar';
 
 function getRootResourceGroupId(resourceTree: ResourceTree<EntityRef>): string | null {
@@ -74,19 +67,6 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
   const [rootResourceType, setRootResourceType] = useState<string>(resourceTypeOptions[0] || '');
 
   const rootResourceGroupId = useMemo(() => getRootResourceGroupId(resourceTree), [resourceTree]);
-
-  // Atom cache key with fsmTypeName: null — TimelineController always shows the all-FSM aggregate
-  const rootTimelineCacheKey = useMemo(
-    () =>
-      timelineCacheKey({
-        resourceId: rootResourceGroupId ?? '',
-        resourceTypeName: rootResourceType,
-        fsmTypeName: null,
-      }),
-    [rootResourceGroupId, rootResourceType]
-  );
-
-  const store = useStore();
 
   const { expandedIds, handleExpandChange } = useExpandedIds(rootItem.id);
 
@@ -143,16 +123,6 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
     placeholderData: keepPreviousData,
   });
 
-  // Store fetched full-range data into the atom cache under the FSM_ALL key.
-  // Atom holds the previous value until overwritten, so keepPreviousData is unnecessary.
-  useEffect(() => {
-    if (fetchedRootTimeline) {
-      store.set(timelineDataAtom(rootTimelineCacheKey), fetchedRootTimeline);
-    }
-  }, [fetchedRootTimeline, rootTimelineCacheKey, store]);
-
-  const rootTimelineData = useAtomValue(timelineDataAtom(rootTimelineCacheKey));
-
   const treeData = useMemo(() => [rootItem], [rootItem]);
 
   const columns = useMemo(() => {
@@ -195,7 +165,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
             <TimelineController
               startTime={startTime}
               durationSeconds={durationSeconds}
-              timelineData={rootTimelineData}
+              timelineData={fetchedRootTimeline}
               onZoomChange={handleZoomChange}
             />
           </div>
@@ -216,7 +186,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
   }, [
     startTime,
     durationSeconds,
-    rootTimelineData,
+    fetchedRootTimeline,
     selectedTypes,
     selectedFsmTypes,
     entities,


### PR DESCRIPTION
Fixes: #72 

Timeline controller is filtering itself with datazoom:
<img width="1159" height="451" alt="Screenshot 2026-03-25 at 2 13 40 PM" src="https://github.com/user-attachments/assets/f9dce076-ed95-43d3-a977-aa2a09edad31" />

This was a cache issue, where the resource timeline was steamrolling the timeline controller data, so the timeline controller only showed the clipped data. TLDR; this was doing way too much trying to use the jotai cache, it already fetches with react query.

Bonus: 
* Clauded up a unit test to prevent regression, fails on main, passes here. QueryResourceTree will probably be one of the hardest to test (see how many mocks were needed), as the data coordinator for all of the timeline tree components.