### PR TITLE
feat(ui): url persisted state

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -51,10 +51,12 @@
     "jotai": "^2.18.0",
     "jotai-family": "^1.0.1",
     "lucide-react": "^0.564.0",
+    "lz-string": "^1.5.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-resizable-panels": "^4.7.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.4)
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -80,6 +83,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.3
@@ -2912,6 +2918,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
   zrender@5.6.1:
     resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
@@ -5518,6 +5527,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}
 
   zrender@5.6.1:
     dependencies:

--- a/ui/src/atoms/resourceTree.ts
+++ b/ui/src/atoms/resourceTree.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { atom } from 'jotai';
+
+/** Set of expanded item IDs in the resource tree */
+export const expandedIdsAtom = atom<Set<string>>(new Set<string>());
+
+/** Per-item selected resource type in the resource tree */
+export const selectedTypesAtom = atom<Map<string, string>>(new Map<string, string>());
+
+/** Per-item selected FSM filter type in the resource tree */
+export const selectedFsmTypesAtom = atom<Map<string, string | null>>(
+  new Map<string, string | null>()
+);

--- a/ui/src/components/NavBarNavigator.tsx
+++ b/ui/src/components/NavBarNavigator.tsx
@@ -115,6 +115,13 @@ export function NavBarNavigator() {
         navigate({
           to: '/profile/engine/$engineId/query/$queryId',
           params: { engineId: newEngineId, queryId: firstQuery.id },
+          search: {
+            planId: undefined,
+            operatorId: undefined,
+            zoomStart: undefined,
+            zoomEnd: undefined,
+            hideTasks: undefined,
+          },
         });
       }
     } catch {
@@ -134,6 +141,13 @@ export function NavBarNavigator() {
         navigate({
           to: '/profile/engine/$engineId/query/$queryId',
           params: { engineId: engineId!, queryId: firstQuery.id },
+          search: {
+            planId: undefined,
+            operatorId: undefined,
+            zoomStart: undefined,
+            zoomEnd: undefined,
+            hideTasks: undefined,
+          },
         });
       }
     } catch {
@@ -146,6 +160,13 @@ export function NavBarNavigator() {
     navigate({
       to: '/profile/engine/$engineId/query/$queryId',
       params: { engineId, queryId: newQueryId },
+      search: {
+        planId: undefined,
+        operatorId: undefined,
+        zoomStart: undefined,
+        zoomEnd: undefined,
+        hideTasks: undefined,
+      },
     });
   };
 

--- a/ui/src/components/NavBarNavigator.tsx
+++ b/ui/src/components/NavBarNavigator.tsx
@@ -118,9 +118,11 @@ export function NavBarNavigator() {
           search: {
             planId: undefined,
             operatorId: undefined,
+            operatorLabel: undefined,
             zoomStart: undefined,
             zoomEnd: undefined,
             hideTasks: undefined,
+            treeState: undefined,
           },
         });
       }
@@ -144,9 +146,11 @@ export function NavBarNavigator() {
           search: {
             planId: undefined,
             operatorId: undefined,
+            operatorLabel: undefined,
             zoomStart: undefined,
             zoomEnd: undefined,
             hideTasks: undefined,
+            treeState: undefined,
           },
         });
       }
@@ -163,9 +167,11 @@ export function NavBarNavigator() {
       search: {
         planId: undefined,
         operatorId: undefined,
+        operatorLabel: undefined,
         zoomStart: undefined,
         zoomEnd: undefined,
         hideTasks: undefined,
+        treeState: undefined,
       },
     });
   };

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, lazy, Suspense } from 'react';
-import { useAtom, useSetAtom } from 'jotai';
+import { useAtom, useSetAtom, useStore } from 'jotai';
 import { useQueryBundle } from '@/hooks/useQueryBundle';
 import { useQueryPlanVisualization } from '@/hooks/useQueryPlanVisualization';
 import { TreeView } from '@/components/ui/tree-view';
@@ -20,6 +20,7 @@ const DAGChart = lazy(() =>
 export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: string }) {
   const [planId, setPlanId] = useAtom(selectedPlanIdAtom);
   const setHoveredWorkerId = useSetAtom(hoveredWorkerIdAtom);
+  const store = useStore();
 
   const {
     data: queryBundle,
@@ -35,12 +36,15 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
     }
   };
 
-  // TODO: Currently fetching root plan when bundle loads - is this correct?
+  // Set the default plan only when the atom is empty at effect-run time.
+  // Reading via store.get() instead of the closure-captured planId ensures we see any
+  // value that useHydrateAtoms in the child route may have written during the same
+  // render cycle, preventing it from being overridden by the root-plan default.
   useEffect(() => {
-    if (queryBundle && !planId) {
+    if (queryBundle && !store.get(selectedPlanIdAtom)) {
       setPlanId(queryBundle.plan_tree.id);
     }
-  }, [queryBundle, planId, setPlanId]);
+  }, [queryBundle, setPlanId, store]);
 
   // handle loading and error states
   if (queryBundleLoading) {

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Column, TreeTable } from '@/components/ui/tree-table';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
+import { useNavigate } from '@tanstack/react-router';
 import { useHighlightedItemIds } from '@/hooks/useHighlightedItemIds';
 import { ResourceTree } from '~quent/types/ResourceTree';
 import { TimelineController } from './timeline/TimelineController';
@@ -23,7 +25,10 @@ import { transformResourceTree, getAdaptiveNumBins, nanosToMs } from '@/lib/time
 import { useExpandedIds } from '@/hooks/useExpandedIds';
 import { useBulkTimelines } from '@/hooks/useBulkTimelines';
 import { zoomRangeAtom, debouncedZoomRangeAtom, startTimeMsAtom } from '@/atoms/timeline';
+import { expandedIdsAtom, selectedTypesAtom, selectedFsmTypesAtom } from '@/atoms/resourceTree';
 import { TimelineToolbar } from './timeline/TimelineToolbar';
+import { encodeTreeState } from '@/lib/treeStateParam';
+import type { TreeState } from '@/lib/treeStateParam';
 
 function getRootResourceGroupId(resourceTree: ResourceTree<EntityRef>): string | null {
   if (!('ResourceGroup' in resourceTree)) return null;
@@ -35,32 +40,67 @@ interface QueryResourceTreeProps {
   engineId: string;
   queryBundle: QueryBundle<EntityRef>;
   initialZoom?: { start: number; end: number };
+  initialTreeState?: TreeState | null;
 }
 
 export function QueryResourceTree(props: QueryResourceTreeProps) {
   return <QueryResourceTreeContent {...props} />;
 }
 
-function QueryResourceTreeContent({ queryBundle, engineId, initialZoom }: QueryResourceTreeProps) {
+function QueryResourceTreeContent({
+  queryBundle,
+  engineId,
+  initialZoom,
+  initialTreeState,
+}: QueryResourceTreeProps) {
   const { entities, resource_tree: resourceTree } = queryBundle;
-  const [selectedTypes, setSelectedTypes] = useState<Map<string, string>>(new Map());
-  const [selectedFsmTypes, setSelectedFsmTypes] = useState<Map<string, string | null>>(new Map());
 
   const startTime = queryBundle.start_time_unix_ns;
   const durationSeconds = queryBundle.duration_s;
   const startTimeMs = useMemo(() => nanosToMs(startTime), [startTime]);
 
-  const zoomInit = initialZoom ?? { start: 0, end: durationSeconds };
-  useHydrateAtoms([
-    [zoomRangeAtom, zoomInit],
-    [debouncedZoomRangeAtom, zoomInit],
-    [startTimeMsAtom, startTimeMs],
-  ]);
-
   const rootItem = useMemo(
     () => transformResourceTree(entities, resourceTree),
     [resourceTree, entities]
   );
+
+  const zoomInit = initialZoom ?? { start: 0, end: durationSeconds };
+
+  const initialExpandedIds = useMemo(
+    () =>
+      initialTreeState ? new Set(initialTreeState.expandedIds) : new Set<string>([rootItem.id]),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+  const initialSelectedTypes = useMemo(
+    () =>
+      initialTreeState
+        ? new Map(Object.entries(initialTreeState.selectedTypes))
+        : new Map<string, string>(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+  const initialSelectedFsmTypes = useMemo(
+    () =>
+      initialTreeState
+        ? new Map(Object.entries(initialTreeState.selectedFsmTypes))
+        : new Map<string, string | null>(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  useHydrateAtoms([
+    [zoomRangeAtom, zoomInit],
+    [debouncedZoomRangeAtom, zoomInit],
+    [startTimeMsAtom, startTimeMs],
+    [expandedIdsAtom, initialExpandedIds],
+    [selectedTypesAtom, initialSelectedTypes],
+    [selectedFsmTypesAtom, initialSelectedFsmTypes],
+  ]);
+
+  const [selectedTypes, setSelectedTypes] = useAtom(selectedTypesAtom);
+  const [selectedFsmTypes, setSelectedFsmTypes] = useAtom(selectedFsmTypesAtom);
+  const expandedIds = useAtomValue(expandedIdsAtom);
 
   const highlightedItemIds = useHighlightedItemIds(rootItem);
 
@@ -70,7 +110,8 @@ function QueryResourceTreeContent({ queryBundle, engineId, initialZoom }: QueryR
 
   const rootResourceGroupId = useMemo(() => getRootResourceGroupId(resourceTree), [resourceTree]);
 
-  const { expandedIds, handleExpandChange } = useExpandedIds(rootItem.id);
+  const { handleExpandChange } = useExpandedIds();
+  const expandedIdsArray = useMemo(() => [...expandedIds], [expandedIds]);
 
   const { handleZoomChange, handleExpand } = useBulkTimelines({
     engineId,
@@ -89,6 +130,19 @@ function QueryResourceTreeContent({ queryBundle, engineId, initialZoom }: QueryR
     },
     [handleExpandChange, handleExpand]
   );
+
+  const navigate = useNavigate({ from: '/profile/engine/$engineId/query/$queryId/' });
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const encoded = encodeTreeState({ expandedIds, selectedTypes, selectedFsmTypes });
+      void navigate({
+        search: prev => ({ ...prev, treeState: encoded }),
+        replace: true,
+      });
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [expandedIds, selectedTypes, selectedFsmTypes, navigate]);
 
   const { data: fetchedRootTimeline } = useQuery({
     queryKey: [
@@ -196,6 +250,8 @@ function QueryResourceTreeContent({ queryBundle, engineId, initialZoom }: QueryR
     engineId,
     queryBundle,
     handleZoomChange,
+    setSelectedTypes,
+    setSelectedFsmTypes,
   ]);
 
   return (
@@ -206,6 +262,7 @@ function QueryResourceTreeContent({ queryBundle, engineId, initialZoom }: QueryR
           data={treeData}
           columns={columns}
           initialSelectedItemId={rootItem.id}
+          expandedItemIds={expandedIdsArray}
           columnWidths={[275, 'auto']}
           onExpandChange={onExpandChange}
           highlightedItemIds={highlightedItemIds}

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -34,13 +34,14 @@ function getRootResourceGroupId(resourceTree: ResourceTree<EntityRef>): string |
 interface QueryResourceTreeProps {
   engineId: string;
   queryBundle: QueryBundle<EntityRef>;
+  initialZoom?: { start: number; end: number };
 }
 
 export function QueryResourceTree(props: QueryResourceTreeProps) {
   return <QueryResourceTreeContent {...props} />;
 }
 
-function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreeProps) {
+function QueryResourceTreeContent({ queryBundle, engineId, initialZoom }: QueryResourceTreeProps) {
   const { entities, resource_tree: resourceTree } = queryBundle;
   const [selectedTypes, setSelectedTypes] = useState<Map<string, string>>(new Map());
   const [selectedFsmTypes, setSelectedFsmTypes] = useState<Map<string, string | null>>(new Map());
@@ -49,9 +50,10 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
   const durationSeconds = queryBundle.duration_s;
   const startTimeMs = useMemo(() => nanosToMs(startTime), [startTime]);
 
+  const zoomInit = initialZoom ?? { start: 0, end: durationSeconds };
   useHydrateAtoms([
-    [zoomRangeAtom, { start: 0, end: durationSeconds }],
-    [debouncedZoomRangeAtom, { start: 0, end: durationSeconds }],
+    [zoomRangeAtom, zoomInit],
+    [debouncedZoomRangeAtom, zoomInit],
     [startTimeMsAtom, startTimeMs],
   ]);
 

--- a/ui/src/components/timeline/TimelineController.tsx
+++ b/ui/src/components/timeline/TimelineController.tsx
@@ -331,6 +331,12 @@ export function TimelineController({
 
   const zoomRange = useAtomValue(zoomRangeAtom);
 
+  // Refs for use inside handleChartReady (stable callback with no deps).
+  const zoomRangeRef = useRef(zoomRange);
+  zoomRangeRef.current = zoomRange;
+  const durationSecondsRef = useRef(durationSeconds);
+  durationSecondsRef.current = durationSeconds;
+
   useEffect(() => {
     if (selfTriggeredRef.current) {
       selfTriggeredRef.current = false;
@@ -354,6 +360,20 @@ export function TimelineController({
     instanceRef.current = instance;
     connectChart(instance);
     registerAxisPointerSync(instance, 0);
+
+    // Dispatch the initial zoom immediately so the chart group zoom state is correct
+    // before any Timeline row charts call connectChart and read it. The useEffect that
+    // normally handles zoom sync can't do this because instanceRef is null when it first runs.
+    const dur = durationSecondsRef.current;
+    if (dur > 0) {
+      const zoom = zoomRangeRef.current;
+      instance.dispatchAction({
+        type: 'dataZoom',
+        dataZoomIndex: 0,
+        start: (zoom.start / dur) * 100,
+        end: (zoom.end / dur) * 100,
+      });
+    }
   }, []);
 
   useEffect(() => {

--- a/ui/src/components/ui/tree-table.tsx
+++ b/ui/src/components/ui/tree-table.tsx
@@ -397,6 +397,8 @@ type TreeViewProps = React.HTMLAttributes<HTMLDivElement> & {
   defaultLeafIcon?: IconComponent;
   renderItem?: (params: TreeTableRenderItemParams) => React.ReactNode;
   highlightedItemIds?: Set<string>;
+  /** When provided, overrides the auto-computed expand path and directly controls which IDs start expanded. */
+  expandedItemIds?: string[];
 };
 
 const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
@@ -412,6 +414,7 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
       className,
       renderItem,
       highlightedItemIds,
+      expandedItemIds: expandedItemIdsProp,
       ...props
     },
     ref
@@ -428,7 +431,7 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
       [onSelectChange]
     );
 
-    const expandedItemIds = useMemo(() => {
+    const computedExpandedItemIds = useMemo(() => {
       if (!initialSelectedItemId) {
         return [] as string[];
       }
@@ -454,6 +457,8 @@ const TreeView = React.forwardRef<HTMLDivElement, TreeViewProps>(
       walkTreeItems(data, initialSelectedItemId);
       return ids;
     }, [data, expandAll, initialSelectedItemId]);
+
+    const expandedItemIds = expandedItemIdsProp ?? computedExpandedItemIds;
 
     return (
       <div className={cn('overflow-hidden relative bg-transparent w-full min-w-0', className)}>

--- a/ui/src/components/ui/tree-view.tsx
+++ b/ui/src/components/ui/tree-view.tsx
@@ -66,6 +66,12 @@ function TreeView<T extends TreeDataItem = TreeDataItem>({
     initialSelectedItemId
   );
 
+  // Keep internal selection in sync with prop changes (e.g. when URL state is restored
+  // after the component has already mounted with an empty initial value).
+  React.useEffect(() => {
+    setSelectedItemId(initialSelectedItemId);
+  }, [initialSelectedItemId]);
+
   const [draggedItem, setDraggedItem] = React.useState<T | null>(null);
 
   const handleSelectChange = React.useCallback(

--- a/ui/src/hooks/useExpandedIds.ts
+++ b/ui/src/hooks/useExpandedIds.ts
@@ -1,25 +1,31 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, useCallback } from 'react';
+import { useAtom } from 'jotai';
+import { useCallback } from 'react';
+import { expandedIdsAtom } from '@/atoms/resourceTree';
 
-/* getter/setter for tracking expanded IDs in the resource tree */
-export function useExpandedIds(initialId?: string) {
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
-    return initialId ? new Set([initialId]) : new Set();
-  });
+/**
+ * Getter/setter for tracking expanded IDs in the resource tree.
+ * Backed by expandedIdsAtom — initial state is set via useHydrateAtoms in QueryResourceTree.
+ */
+export function useExpandedIds() {
+  const [expandedIds, setExpandedIds] = useAtom(expandedIdsAtom);
 
-  const handleExpandChange = useCallback((itemId: string, isExpanded: boolean) => {
-    setExpandedIds(prev => {
-      const next = new Set(prev);
-      if (isExpanded) {
-        next.add(itemId);
-      } else {
-        next.delete(itemId);
-      }
-      return next;
-    });
-  }, []);
+  const handleExpandChange = useCallback(
+    (itemId: string, isExpanded: boolean) => {
+      setExpandedIds(prev => {
+        const next = new Set(prev);
+        if (isExpanded) {
+          next.add(itemId);
+        } else {
+          next.delete(itemId);
+        }
+        return next;
+      });
+    },
+    [setExpandedIds]
+  );
 
   return { expandedIds, handleExpandChange } as const;
 }

--- a/ui/src/hooks/useUrlStateSync.ts
+++ b/ui/src/hooks/useUrlStateSync.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+import { useAtomValue } from 'jotai';
+import { useHydrateAtoms } from 'jotai/utils';
+import { useNavigate } from '@tanstack/react-router';
+import { selectedPlanIdAtom, selectedNodeIdsAtom } from '@/atoms/dag';
+import { debouncedZoomRangeAtom, hideTasksAtom } from '@/atoms/timeline';
+
+export interface QueryIndexSearch {
+  planId?: string;
+  operatorId?: string;
+  zoomStart?: number;
+  zoomEnd?: number;
+  hideTasks?: boolean;
+}
+
+/**
+ * Syncs a fixed set of scalar UI atoms with the URL search params for the query index route.
+ *
+ * On mount: seeds atoms from URL values (via useHydrateAtoms) so deep links restore state.
+ * On change: writes updated atom values back to the URL using replace navigation so the
+ * browser history stack is not polluted on every zoom gesture or plan selection.
+ *
+ * Zoom range is NOT seeded here — it is passed as initialZoom to QueryResourceTree which
+ * owns the useHydrateAtoms call for timeline atoms. This avoids a timing conflict where
+ * QueryResourceTree would override whatever zoom this hook tried to hydrate.
+ */
+export function useUrlStateSync(search: QueryIndexSearch) {
+  useHydrateAtoms([
+    [selectedPlanIdAtom, search.planId ?? ''],
+    [selectedNodeIdsAtom, search.operatorId ? new Set([search.operatorId]) : new Set<string>()],
+    [hideTasksAtom, search.hideTasks ?? false],
+  ]);
+
+  const planId = useAtomValue(selectedPlanIdAtom);
+  const selectedNodeIds = useAtomValue(selectedNodeIdsAtom);
+  const zoomRange = useAtomValue(debouncedZoomRangeAtom);
+  const hideTasks = useAtomValue(hideTasksAtom);
+
+  const operatorId = selectedNodeIds.size > 0 ? [...selectedNodeIds][0] : undefined;
+
+  // Scoping navigate to this route gives TanStack Router the search type context it needs
+  // to type-check the search updater function correctly.
+  const navigate = useNavigate({ from: '/profile/engine/$engineId/query/$queryId/' });
+
+  useEffect(() => {
+    // zoomRange stays at { start: 0, end: 0 } until QueryResourceTree's useHydrateAtoms
+    // runs during its render. Skip URL writes until zoom is properly initialized.
+    if (zoomRange.end === 0) return;
+
+    void navigate({
+      search: prev => ({
+        ...prev,
+        planId: planId || undefined,
+        operatorId,
+        zoomStart: zoomRange.start,
+        zoomEnd: zoomRange.end,
+        hideTasks: hideTasks || undefined,
+      }),
+      replace: true,
+    });
+  }, [planId, operatorId, zoomRange.start, zoomRange.end, hideTasks, navigate]);
+}

--- a/ui/src/hooks/useUrlStateSync.ts
+++ b/ui/src/hooks/useUrlStateSync.ts
@@ -5,12 +5,13 @@ import { useEffect } from 'react';
 import { useAtomValue } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
 import { useNavigate } from '@tanstack/react-router';
-import { selectedPlanIdAtom, selectedNodeIdsAtom } from '@/atoms/dag';
+import { selectedPlanIdAtom, selectedNodeIdsAtom, selectedOperatorLabelAtom } from '@/atoms/dag';
 import { debouncedZoomRangeAtom, hideTasksAtom } from '@/atoms/timeline';
 
 export interface QueryIndexSearch {
   planId?: string;
   operatorId?: string;
+  operatorLabel?: string;
   zoomStart?: number;
   zoomEnd?: number;
   hideTasks?: boolean;
@@ -31,11 +32,13 @@ export function useUrlStateSync(search: QueryIndexSearch) {
   useHydrateAtoms([
     [selectedPlanIdAtom, search.planId ?? ''],
     [selectedNodeIdsAtom, search.operatorId ? new Set([search.operatorId]) : new Set<string>()],
+    [selectedOperatorLabelAtom, search.operatorLabel ?? null],
     [hideTasksAtom, search.hideTasks ?? false],
   ]);
 
   const planId = useAtomValue(selectedPlanIdAtom);
   const selectedNodeIds = useAtomValue(selectedNodeIdsAtom);
+  const operatorLabel = useAtomValue(selectedOperatorLabelAtom);
   const zoomRange = useAtomValue(debouncedZoomRangeAtom);
   const hideTasks = useAtomValue(hideTasksAtom);
 
@@ -55,11 +58,12 @@ export function useUrlStateSync(search: QueryIndexSearch) {
         ...prev,
         planId: planId || undefined,
         operatorId,
+        operatorLabel: operatorLabel ?? undefined,
         zoomStart: zoomRange.start,
         zoomEnd: zoomRange.end,
         hideTasks: hideTasks || undefined,
       }),
       replace: true,
     });
-  }, [planId, operatorId, zoomRange.start, zoomRange.end, hideTasks, navigate]);
+  }, [planId, operatorId, operatorLabel, zoomRange.start, zoomRange.end, hideTasks, navigate]);
 }

--- a/ui/src/lib/treeStateParam.ts
+++ b/ui/src/lib/treeStateParam.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+import { z } from 'zod';
+
+const treeStateSchema = z.object({
+  expandedIds: z.array(z.string()).catch([]),
+  selectedTypes: z.record(z.string(), z.string()).catch({}),
+  selectedFsmTypes: z.record(z.string(), z.string().nullable()).catch({}),
+});
+
+export type TreeState = z.infer<typeof treeStateSchema>;
+
+export interface TreeStateInput {
+  expandedIds: Set<string>;
+  selectedTypes: Map<string, string>;
+  selectedFsmTypes: Map<string, string | null>;
+}
+
+export function encodeTreeState(state: TreeStateInput): string {
+  const raw = {
+    expandedIds: [...state.expandedIds],
+    selectedTypes: Object.fromEntries(state.selectedTypes),
+    selectedFsmTypes: Object.fromEntries(state.selectedFsmTypes),
+  };
+  return compressToEncodedURIComponent(JSON.stringify(raw));
+}
+
+export function decodeTreeState(param: string): TreeState | null {
+  try {
+    const decompressed = decompressFromEncodedURIComponent(param);
+    if (!decompressed) return null;
+    const parsed: unknown = JSON.parse(decompressed);
+    const result = treeStateSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/ui/src/pages/EngineSelectionPage.tsx
+++ b/ui/src/pages/EngineSelectionPage.tsx
@@ -52,6 +52,13 @@ export function EngineSelectionPage() {
       navigate({
         to: '/profile/engine/$engineId/query/$queryId',
         params: { engineId, queryId },
+        search: {
+          planId: undefined,
+          operatorId: undefined,
+          zoomStart: undefined,
+          zoomEnd: undefined,
+          hideTasks: undefined,
+        },
       });
     }
   };

--- a/ui/src/pages/EngineSelectionPage.tsx
+++ b/ui/src/pages/EngineSelectionPage.tsx
@@ -55,9 +55,11 @@ export function EngineSelectionPage() {
         search: {
           planId: undefined,
           operatorId: undefined,
+          operatorLabel: undefined,
           zoomStart: undefined,
           zoomEnd: undefined,
           hideTasks: undefined,
+          treeState: undefined,
         },
       });
     }

--- a/ui/src/routes/profile.engine.$engineId.query.$queryId.index.tsx
+++ b/ui/src/routes/profile.engine.$engineId.query.$queryId.index.tsx
@@ -4,11 +4,20 @@
 import { QueryResourceTree } from '@/components/QueryResourceTree';
 import { queryBundleQueryOptions } from '@/hooks/useQueryBundle';
 import { queryClient } from '@/lib/queryClient';
+import { useUrlStateSync } from '@/hooks/useUrlStateSync';
 import { createFileRoute } from '@tanstack/react-router';
 import { QueryBundle } from '~quent/types/QueryBundle';
 import type { EntityRef } from '~quent/types/EntityRef';
 
 export const Route = createFileRoute('/profile/engine/$engineId/query/$queryId/')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    planId: typeof search.planId === 'string' ? search.planId : undefined,
+    operatorId: typeof search.operatorId === 'string' ? search.operatorId : undefined,
+    zoomStart: Number.isFinite(Number(search.zoomStart)) ? Number(search.zoomStart) : undefined,
+    zoomEnd: Number.isFinite(Number(search.zoomEnd)) ? Number(search.zoomEnd) : undefined,
+    hideTasks:
+      search.hideTasks === 'true' ? true : search.hideTasks === 'false' ? false : undefined,
+  }),
   component: QueryIndex,
   loader: async ({ params }): Promise<QueryBundle<EntityRef>> => {
     const { engineId, queryId } = params;
@@ -20,9 +29,18 @@ export const Route = createFileRoute('/profile/engine/$engineId/query/$queryId/'
 function QueryIndex() {
   const queryBundle = Route.useLoaderData();
   const { engineId } = Route.useParams();
+  const search = Route.useSearch();
+
+  useUrlStateSync(search);
+
+  const initialZoom =
+    search.zoomStart !== undefined && search.zoomEnd !== undefined
+      ? { start: search.zoomStart, end: search.zoomEnd }
+      : undefined;
+
   return (
     <div className="flex items-center justify-center w-full h-full min-h-[200px]">
-      <QueryResourceTree engineId={engineId} queryBundle={queryBundle} />
+      <QueryResourceTree engineId={engineId} queryBundle={queryBundle} initialZoom={initialZoom} />
     </div>
   );
 }

--- a/ui/src/routes/profile.engine.$engineId.query.$queryId.index.tsx
+++ b/ui/src/routes/profile.engine.$engineId.query.$queryId.index.tsx
@@ -5,6 +5,7 @@ import { QueryResourceTree } from '@/components/QueryResourceTree';
 import { queryBundleQueryOptions } from '@/hooks/useQueryBundle';
 import { queryClient } from '@/lib/queryClient';
 import { useUrlStateSync } from '@/hooks/useUrlStateSync';
+import { decodeTreeState } from '@/lib/treeStateParam';
 import { createFileRoute } from '@tanstack/react-router';
 import { QueryBundle } from '~quent/types/QueryBundle';
 import type { EntityRef } from '~quent/types/EntityRef';
@@ -13,10 +14,12 @@ export const Route = createFileRoute('/profile/engine/$engineId/query/$queryId/'
   validateSearch: (search: Record<string, unknown>) => ({
     planId: typeof search.planId === 'string' ? search.planId : undefined,
     operatorId: typeof search.operatorId === 'string' ? search.operatorId : undefined,
+    operatorLabel: typeof search.operatorLabel === 'string' ? search.operatorLabel : undefined,
     zoomStart: Number.isFinite(Number(search.zoomStart)) ? Number(search.zoomStart) : undefined,
     zoomEnd: Number.isFinite(Number(search.zoomEnd)) ? Number(search.zoomEnd) : undefined,
     hideTasks:
       search.hideTasks === 'true' ? true : search.hideTasks === 'false' ? false : undefined,
+    treeState: typeof search.treeState === 'string' ? search.treeState : undefined,
   }),
   component: QueryIndex,
   loader: async ({ params }): Promise<QueryBundle<EntityRef>> => {
@@ -38,9 +41,16 @@ function QueryIndex() {
       ? { start: search.zoomStart, end: search.zoomEnd }
       : undefined;
 
+  const initialTreeState = search.treeState ? decodeTreeState(search.treeState) : null;
+
   return (
     <div className="flex items-center justify-center w-full h-full min-h-[200px]">
-      <QueryResourceTree engineId={engineId} queryBundle={queryBundle} initialZoom={initialZoom} />
+      <QueryResourceTree
+        engineId={engineId}
+        queryBundle={queryBundle}
+        initialZoom={initialZoom}
+        initialTreeState={initialTreeState}
+      />
     </div>
   );
 }


### PR DESCRIPTION
* Encodes/compresses jotai state as a qs parameter to handle a list of expanded item ids, resource/fsm type selections per row, etc. 
* Persists: selected operator id, selected plan id, zoom range, expanded items, selected resource/fsm types


https://github.com/user-attachments/assets/752f2e8b-d4f5-485b-a26c-18d43b7a3ad8


