### PR TITLE
fix(ui): Timeline controller labels based on axis interval

### DIFF
--- a/ui/src/components/timeline/TimelineController.tsx
+++ b/ui/src/components/timeline/TimelineController.tsx
@@ -8,7 +8,7 @@ import type { EChartsOption } from '@/lib/echarts';
 import type { EChartsInstance } from 'echarts-for-react';
 import { useAtomValue } from 'jotai';
 import { withOpacity } from '@/services/colors';
-import { formatDuration } from '@/services/formatters';
+import { formatDurationForAxisInterval } from '@/services/formatters';
 import {
   buildBinnedTimelineSeries,
   connectChart,
@@ -139,7 +139,7 @@ export function TimelineController({
         color: colors.timelineMarkupColor,
         fontFamily: TIMELINE_MONO_FONT,
         formatter: (value: number) => {
-          return formatDuration(Number(value) - startTimeMillis, 0);
+          return formatDurationForAxisInterval(Number(value) - startTimeMillis, interval);
         },
       },
       splitLine: {
@@ -255,7 +255,12 @@ export function TimelineController({
             fontFamily: TIMELINE_MONO_FONT,
           },
           labelFormatter: (tsMilliseconds: number) => {
-            return formatDuration(Number(tsMilliseconds) - startTimeMillis, 0);
+            const spanMs = endTimeMillis - startTimeMillis;
+            const zoomInterval = getTimelineXAxisIntervalMs(spanMs, CONTROLLER_X_MIN_LABELS);
+            return formatDurationForAxisInterval(
+              Number(tsMilliseconds) - startTimeMillis,
+              zoomInterval
+            );
           },
           emphasis: {
             handleStyle: {

--- a/ui/src/services/formatters.ts
+++ b/ui/src/services/formatters.ts
@@ -63,6 +63,31 @@ export function formatDurationForWindow(ms: number, windowMs: number): string {
   return formatDuration(ms, decimals);
 }
 
+/**
+ * Format a duration with precision derived from the axis tick interval.
+ * Ensures no two adjacent axis labels produce the same string by choosing
+ * enough decimals so that one interval step is distinguishable in the
+ * label's display unit.
+ */
+export function formatDurationForAxisInterval(ms: number, intervalMs: number): string {
+  const absMs = Math.abs(ms);
+
+  let unitMs: number;
+  if (absMs < 0.001) unitMs = 1e-6;
+  else if (absMs < 1) unitMs = 0.001;
+  else if (absMs < MS_PER_SECOND) unitMs = 1;
+  else if (absMs < MS_PER_MINUTE) unitMs = MS_PER_SECOND;
+  else if (absMs < MS_PER_HOUR) unitMs = MS_PER_MINUTE;
+  else if (absMs < MS_PER_DAY) unitMs = MS_PER_HOUR;
+  else unitMs = MS_PER_DAY;
+
+  const intervalInUnit = intervalMs / unitMs;
+  const decimals =
+    intervalInUnit > 0 ? Math.min(6, Math.max(0, Math.ceil(-Math.log10(intervalInUnit)))) : 2;
+
+  return formatDuration(ms, decimals);
+}
+
 // Precomputed threshold/divisor tables to avoid Math.log/Math.pow per call.
 const SI_UP: readonly [number, string][] = [
   [1e15, 'P'],


### PR DESCRIPTION
I reduced the precision of these, and they looked bad. Adds a function to base it on axis interval to it _should_ always look good, not repeat numbers

Before:
<img width="585" height="163" alt="Screenshot 2026-04-06 at 10 44 26 AM" src="https://github.com/user-attachments/assets/65373f12-656c-4883-b3cf-eeb7614c5db7" />

After:
<img width="1179" height="328" alt="Screenshot 2026-04-06 at 10 44 03 AM" src="https://github.com/user-attachments/assets/cbac638b-146d-4c00-850a-443a5cc789ad" />