### PR TITLE
chore(ci): bump rumdl to 0.1.67 and split markdown workflow

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: rustup toolchain install stable --profile minimal
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: rumdl-cache
         with:
           path: ~/.cargo/bin/rumdl

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -27,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-rumdl-0.1.67
       - if: steps.rumdl-cache.outputs.cache-hit != 'true'
         run: cargo install rumdl --locked --version 0.1.67
-      - run: rumdl check --diff --exclude .cargo
+      - run: rumdl check --diff

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -19,12 +19,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: rustup toolchain install stable --profile minimal
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        id: rumdl-cache
-        with:
-          path: ~/.cargo/bin/rumdl
-          key: ${{ runner.os }}-${{ runner.arch }}-rumdl-0.1.67
-      - if: steps.rumdl-cache.outputs.cache-hit != 'true'
-        run: cargo install rumdl --locked --version 0.1.67
-      - run: rumdl check --diff
+      - run: pipx run rumdl==0.1.67 check --diff

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,30 @@
+name: Markdown
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - ".rumdl.toml"
+      - ".github/workflows/markdown.yml"
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".rumdl.toml"
+      - ".github/workflows/markdown.yml"
+
+jobs:
+  markdown:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal
+      - uses: actions/cache@v4
+        id: rumdl-cache
+        with:
+          path: ~/.cargo/bin/rumdl
+          key: ${{ runner.os }}-${{ runner.arch }}-rumdl-0.1.67
+      - if: steps.rumdl-cache.outputs.cache-hit != 'true'
+        run: cargo install rumdl --locked --version 0.1.67
+      - run: rumdl check --diff --exclude .cargo

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: rustup toolchain install stable --profile minimal
       - uses: actions/cache@v4
         id: rumdl-cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,18 +66,3 @@ jobs:
       - if: steps.cargo-deny-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-deny --locked --version 0.19.0
       - run: cargo deny check
-
-  markdown:
-    name: Markdown
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: rustup toolchain install stable --profile minimal
-      - uses: actions/cache@v4
-        id: rumdl-cache
-        with:
-          path: ~/.cargo/bin/rumdl
-          key: ${{ runner.os }}-${{ runner.arch }}-rumdl-0.1.21
-      - if: steps.rumdl-cache.outputs.cache-hit != 'true'
-        run: cargo install rumdl --locked --version 0.1.21
-      - run: rumdl check --diff --exclude .cargo

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,8 +1,6 @@
-[global]
-exclude = ["SECURITY.md"]
+exclude = ["CONTRIBUTING.md", "SECURITY.md"]
 
 [MD013]
 code-blocks = false
 tables = false
 reflow = true
-

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,4 +1,4 @@
-exclude = ["CONTRIBUTING.md", "SECURITY.md"]
+exclude = [".cargo", "CONTRIBUTING.md", "SECURITY.md"]
 
 [MD013]
 code-blocks = false

--- a/docs/modeling/time.md
+++ b/docs/modeling/time.md
@@ -6,8 +6,9 @@ Timestamps are 64-bit unsigned integers (`u64`) representing the amount of
 nanoseconds passed since the Unix Epoch as defined in the
 [POSIX](https://posix.opengroup.org/) standard (IEEE Std 1003.1-2024).
 
-> Rationale: The choice of nanoseconds represented as `u64` values allows timestamps
-> to extend approximately $`584.6`$ average Gregorian years past the Unix Epoch.
+> Rationale: The choice of nanoseconds represented as `u64` values allows
+> timestamps to extend approximately $`584.6`$ average Gregorian years past the
+> Unix Epoch.
 
 ## Span
 


### PR DESCRIPTION
Move markdown linting into its own workflow triggered by *.md, .rumdl.toml, and the workflow file. Exclude CONTRIBUTING.md and SECURITY.md from linting. Fix line-length violation in time.md.