### PR TITLE
feat(query-engine): bulk timeline caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,6 @@ dependencies = [
  "quent-ui",
  "rust-embed",
  "serde",
- "serde_json",
  "thiserror",
  "tokio",
  "tonic",

--- a/domains/query_engine/server/Cargo.toml
+++ b/domains/query_engine/server/Cargo.toml
@@ -20,7 +20,6 @@ quent-query-engine-ui = { path = "../../../domains/query_engine/ui" }
 quent-time = { path = "../../../crates/time" }
 quent-ui = { path = "../../../crates/ui" }
 serde.workspace = true
-serde_json.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"]}
 tonic.workspace = true

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -8,6 +8,8 @@ use axum::Router as AxumRouter;
 use quent_collector::server::{CollectorService, CollectorServiceOptions};
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_query_engine_analyzer::ui::UiAnalyzer;
+use std::hash::Hash;
+
 use serde::{Deserialize, Serialize};
 use tonic::transport::{Server as GrpcServer, server::Router};
 use tower_http::cors::CorsLayer;
@@ -59,8 +61,9 @@ pub fn analyzer_service_router<A>(
 where
     A: UiAnalyzer + Send + Sync + 'static,
     <A as UiAnalyzer>::EntityRef: serde::Serialize,
-    <A as UiAnalyzer>::TimelineGlobalParams: Send + Sync + Clone + serde::Serialize + 'static,
-    <A as UiAnalyzer>::TimelineParams: Send + Sync + Clone + serde::Serialize + 'static,
+    <A as UiAnalyzer>::TimelineGlobalParams:
+        Send + Sync + Clone + serde::Serialize + Hash + Eq + 'static,
+    <A as UiAnalyzer>::TimelineParams: Send + Sync + Clone + serde::Serialize + Hash + Eq + 'static,
     for<'de> <A as UiAnalyzer>::TimelineGlobalParams: serde::Deserialize<'de>,
     for<'de> <A as UiAnalyzer>::TimelineParams: serde::Deserialize<'de>,
 {

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -147,7 +147,7 @@ impl TimelineCache {
         let mut miss_count = 0u64;
 
         for chunk_idx in first_chunk..=last_chunk {
-            for (key, _entry) in &request.entries {
+            for key in request.entries.keys() {
                 let cache_key = ChunkCacheKey {
                     engine_id,
                     params_hash: entry_hashes[key],

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -156,7 +156,7 @@ impl TimelineCache {
         <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone,
     {
         let Some(geometry) = compute_chunk_geometry(analyzer, &request)? else {
-            return Ok(analyzer.bulk_resource_timeline(request)?);
+            return Ok(tokio::task::block_in_place(|| analyzer.bulk_resource_timeline(request))?);
         };
 
         let entry_hashes = compute_entry_hashes(&request.entries, &request.app_params);
@@ -263,7 +263,8 @@ impl TimelineCache {
             "bulk timeline cold cache: full fetch"
         );
 
-        let response = analyzer.bulk_resource_timeline(request)?;
+        let response =
+            tokio::task::block_in_place(|| analyzer.bulk_resource_timeline(request))?;
 
         for (key, entry_resp) in &response.entries {
             if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
@@ -346,9 +347,11 @@ impl TimelineCache {
                     })
                     .collect();
 
-            let response = analyzer.bulk_resource_timeline(BulkTimelineRequest {
-                entries: chunk_entries,
-                app_params: app_params.clone(),
+            let response = tokio::task::block_in_place(|| {
+                analyzer.bulk_resource_timeline(BulkTimelineRequest {
+                    entries: chunk_entries,
+                    app_params: app_params.clone(),
+                })
             })?;
 
             for (key, entry_resp) in response.entries {
@@ -467,7 +470,8 @@ impl TimelineCache {
                 app_params: request.app_params.clone(),
             };
 
-            let response = analyzer.single_resource_timeline(chunk_request)?;
+            let response =
+                tokio::task::block_in_place(|| analyzer.single_resource_timeline(chunk_request))?;
             self.chunks.insert(cache_key, response.clone()).await;
             chunk_responses.push(response);
         }

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -19,7 +19,7 @@ use quent_ui::timeline::{
         ResourceTimelineBinned, ResourceTimelineBinnedByState, SingleTimelineResponse,
     },
 };
-use tracing::debug;
+use tracing::{debug, trace};
 use uuid::Uuid;
 
 use crate::error::ServerResult;
@@ -468,12 +468,12 @@ impl TimelineCache {
             };
 
             if let Some(cached) = self.chunks.get(&cache_key).await {
-                debug!("timeline chunk cache hit: {cache_key:?}");
+                trace!("timeline chunk cache hit: {cache_key:?}");
                 chunk_responses.push(cached);
                 continue;
             }
 
-            debug!("timeline chunk cache miss: {cache_key:?}");
+            trace!("timeline chunk cache miss: {cache_key:?}");
 
             // Convert chunk span back to relative seconds for the request.
             let chunk_request = SingleTimelineRequest {

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -12,9 +12,9 @@ use quent_analyzer::Span;
 use quent_query_engine_analyzer::{QueryEngineModel, ui::UiAnalyzer};
 use quent_time::{SpanNanoSec, TimeNanoSec, bin::BinnedSpan, to_nanosecs, to_secs_relative};
 use quent_ui::timeline::{
-    request::{self, BulkTimelineRequest, SingleTimelineRequest, TimelineConfig, TimelineRequest},
+    request::{BulkTimelineRequest, SingleTimelineRequest, TimelineConfig, TimelineRequest},
     response::{
-        self, BulkTimelinesResponse, BulkTimelinesResponseEntry, ResourceTimeline,
+        BulkTimelinesResponse, BulkTimelinesResponseEntry, ResourceTimeline,
         ResourceTimelineBinned, ResourceTimelineBinnedByState, SingleTimelineResponse,
     },
 };
@@ -102,6 +102,10 @@ impl TimelineCache {
         // Determine chunk geometry for this zoom level.
         let zoom_level = determine_zoom_level(view_duration, engine_duration);
         let chunk_duration = engine_duration / zoom_level;
+        debug!(
+            engine_duration,
+            view_duration, zoom_level, "bulk timeline zoom level determined"
+        );
 
         // Find which chunk indices overlap the current viewport.
         let first_chunk =
@@ -115,7 +119,16 @@ impl TimelineCache {
 
         for (key, entry) in &request.entries {
             let params_hash = {
-                let serialized = serde_json::to_string(&(&entry, &request.app_params))
+                // Strip the viewport config (start/end/num_bins) before hashing: start/end vary
+                // with every pan or zoom, and num_bins is already a separate field in ChunkCacheKey.
+                // Only the query-identity fields (resource, filters, app params) should determine
+                // whether two requests map to the same cached chunks.
+                let canonical = entry.clone().with_config(TimelineConfig {
+                    num_bins: 0,
+                    start: 0.0,
+                    end: 0.0,
+                });
+                let serialized = serde_json::to_string(&(&canonical, &request.app_params))
                     .map_err(|e| crate::error::ServerError::Cache(e.to_string()))?;
                 let mut hasher = DefaultHasher::new();
                 serialized.hash(&mut hasher);
@@ -130,6 +143,8 @@ impl TimelineCache {
         let mut entry_chunks: HashMap<String, Vec<SingleTimelineResponse>> = HashMap::new();
         let mut chunk_misses: HashMap<u64, Vec<String>> = HashMap::new();
         let mut any_cache_hit = false;
+        let mut hit_count = 0u64;
+        let mut miss_count = 0u64;
 
         for chunk_idx in first_chunk..=last_chunk {
             for (key, _entry) in &request.entries {
@@ -143,15 +158,29 @@ impl TimelineCache {
 
                 if let Some(cached) = self.chunks.get(&cache_key).await {
                     any_cache_hit = true;
+                    hit_count += 1;
                     entry_chunks.entry(key.clone()).or_default().push(cached);
                 } else {
+                    miss_count += 1;
                     chunk_misses.entry(chunk_idx).or_default().push(key.clone());
                 }
             }
         }
 
-        // Fast path: cold cache. Make one bulk call, split response into chunks, cache them.
+        debug!(
+            hit_count,
+            miss_count,
+            zoom_level,
+            n_entries = request.entries.len(),
+            "bulk timeline cache check"
+        );
+
+        // Fast path: cold cache — no chunks were cached, so fetch everything in one bulk call.
         if !any_cache_hit {
+            debug!(
+                n_entries = request.entries.len(),
+                zoom_level, "bulk timeline cold cache: full fetch"
+            );
             let response = analyzer.bulk_resource_timeline(request)?;
             for (key, entry_resp) in &response.entries {
                 if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
@@ -189,6 +218,15 @@ impl TimelineCache {
             entries,
             app_params,
         } = request;
+
+        // Partial cache hit: fetch only the missing (entry, chunk) pairs.
+        if !chunk_misses.is_empty() {
+            let n_miss_entries: usize = chunk_misses.values().map(|v| v.len()).sum();
+            debug!(
+                n_miss_chunks = chunk_misses.len(),
+                n_miss_entries, zoom_level, "bulk timeline partial cache: fetching missing chunks"
+            );
+        }
 
         for (chunk_idx, miss_keys) in &chunk_misses {
             let chunk_start = epoch + chunk_idx * chunk_duration;
@@ -310,8 +348,14 @@ impl TimelineCache {
         let chunk_duration = engine_duration / zoom_level;
 
         // Hash the entry + app_params for cache key construction.
+        // Strip the viewport config before hashing — same reasoning as in cached_bulk_timeline.
         let params_hash = {
-            let serialized = serde_json::to_string(&(&request.entry, &request.app_params))
+            let canonical = request.entry.clone().with_config(TimelineConfig {
+                num_bins: 0,
+                start: 0.0,
+                end: 0.0,
+            });
+            let serialized = serde_json::to_string(&(&canonical, &request.app_params))
                 .map_err(|e| crate::error::ServerError::Cache(e.to_string()))?;
             let mut hasher = DefaultHasher::new();
             serialized.hash(&mut hasher);
@@ -391,10 +435,6 @@ fn determine_zoom_level(view_duration: TimeNanoSec, total_duration: TimeNanoSec)
 }
 
 /// Splits a full-viewport response into per-chunk responses for caching.
-///
-/// This is the reverse of `combine_chunks`: given a response spanning multiple
-/// chunks, it slices the bin arrays at chunk boundaries and returns one
-/// `SingleTimelineResponse` per chunk.
 fn split_response_into_chunks(
     response: &SingleTimelineResponse,
     first_chunk: u64,
@@ -406,74 +446,81 @@ fn split_response_into_chunks(
 ) -> ServerResult<Vec<(u64, SingleTimelineResponse)>> {
     let mut result = Vec::new();
 
-    // Loop over each chunk_idx from first_chunk..=last_chunk.
-    // For each chunk:
-    //
-    // ── S1: Compute chunk boundaries ──
-    //   chunk_start = epoch + chunk_idx * chunk_duration
-    //   chunk_end:
-    //     if chunk_idx == zoom_level - 1 → engine_end  (last chunk gets remainder)
-    //     else → epoch + (chunk_idx + 1) * chunk_duration
-    //   (Same pattern as cached_single_timeline lines ~287-292.)
-    //
-    // ── S2: Build chunk span ──
-    //   Use SpanNanoSec::try_new(chunk_start, chunk_end).
-    //   If it returns Err, skip this chunk with `continue`.
-    //
-    // ── S3: Find which bins belong to this chunk ──
-    //   Call overlap_indices(response, &chunk_span, epoch)
-    //   This returns (start_idx, end_idx) — the slice of bins for this chunk.
-    //   If start_idx >= end_idx, skip (no data overlaps this chunk).
-    //
-    // ── S4: Build config for this chunk ──
-    //   let chunk_num_bins = (end_idx - start_idx) as u64;
-    //   Build a BinnedSpan, then convert to BinnedSpanSec:
-    //     BinnedSpan::try_new(
-    //         chunk_span,
-    //         NonZero::try_from(chunk_num_bins).map_err(|e| ...)?
-    //     )?
-    //     .try_to_secs_relative(epoch)?
-    //   (Same pattern as combine_chunks lines ~318-324.)
-    //
-    //   Tip: NonZero is std::num::NonZero — you'll need to add it to the
-    //   imports at the top of the file.
-    //
-    // ── S5: Slice the data ──
-    //   Match on &response.data to handle both variants:
-    //
-    //     ResourceTimeline::Binned(data) →
-    //       Build a new HashMap<String, Vec<f64>> by iterating
-    //       data.capacities_values. For each (cap_name, values):
-    //         cap_name.clone() → values[start_idx..end_idx].to_vec()
-    //
-    //       For long_fsms: just clone the whole vec (data.long_fsms.clone()).
-    //       These aren't per-bin, so no slicing needed.
-    //
-    //       Build: ResourceTimeline::Binned(ResourceTimelineBinned {
-    //           config: chunk_config,
-    //           capacities_values: <your new map>,
-    //           long_fsms: <cloned>,
-    //       })
-    //
-    //     ResourceTimeline::BinnedByState(data) →
-    //       Same idea but one level deeper: data.capacities_states_values is
-    //       HashMap<String, HashMap<String, Vec<f64>>>.
-    //       For each (cap_name, states) → for each (state_name, values):
-    //         values[start_idx..end_idx].to_vec()
-    //
-    //       Build: ResourceTimeline::BinnedByState(ResourceTimelineBinnedByState {
-    //           config: chunk_config,
-    //           capacities_states_values: <your new nested map>,
-    //           long_fsms: <cloned>,
-    //       })
-    //
-    //   Tip: look at combine_chunks for the iteration patterns over these
-    //   nested HashMaps — it does the reverse operation (combining slices).
-    //
-    // ── S6: Push result ──
-    //   Build SingleTimelineResponse { config: chunk_config, data: <your data> }
-    //   Push (chunk_idx, response) into `result`.
-    todo!("implement split_response_into_chunks");
+    for chunk_idx in first_chunk..=last_chunk {
+        let chunk_start = epoch + chunk_idx * chunk_duration;
+        let chunk_end = if chunk_idx == zoom_level - 1 {
+            engine_end
+        } else {
+            epoch + (chunk_idx + 1) * chunk_duration
+        };
+
+        let chunk_span = match SpanNanoSec::try_new(chunk_start, chunk_end) {
+            Ok(span) => span,
+            Err(_) => continue,
+        };
+
+        // Find the bin range within the full response that falls inside this chunk.
+        let (start_idx, end_idx) = overlap_indices(response, &chunk_span, epoch);
+        if start_idx >= end_idx {
+            continue;
+        }
+
+        let chunk_num_bins = (end_idx - start_idx) as u64;
+        let chunk_config = BinnedSpan::try_new(
+            chunk_span,
+            std::num::NonZero::try_from(chunk_num_bins).map_err(|e| {
+                quent_time::TimeError::InvalidArgument(format!("chunk bins must be > 0: {e}"))
+            })?,
+        )?
+        .try_to_secs_relative(epoch)?;
+
+        // Slice the data arrays at the chunk's bin boundaries.
+        let chunk_data = match &response.data {
+            ResourceTimeline::Binned(data) => {
+                let capacities_values = data
+                    .capacities_values
+                    .iter()
+                    .map(|(cap_name, values)| {
+                        (cap_name.clone(), values[start_idx..end_idx].to_vec())
+                    })
+                    .collect();
+                ResourceTimeline::Binned(ResourceTimelineBinned {
+                    config: chunk_config,
+                    capacities_values,
+                    long_fsms: data.long_fsms.clone(),
+                })
+            }
+            ResourceTimeline::BinnedByState(data) => {
+                let capacities_states_values = data
+                    .capacities_states_values
+                    .iter()
+                    .map(|(cap_name, states)| {
+                        let sliced_states = states
+                            .iter()
+                            .map(|(state_name, values)| {
+                                (state_name.clone(), values[start_idx..end_idx].to_vec())
+                            })
+                            .collect();
+                        (cap_name.clone(), sliced_states)
+                    })
+                    .collect();
+                ResourceTimeline::BinnedByState(ResourceTimelineBinnedByState {
+                    config: chunk_config,
+                    capacities_states_values,
+                    long_fsms: data.long_fsms.clone(),
+                })
+            }
+        };
+
+        // Push this chunk into the result.
+        result.push((
+            chunk_idx,
+            SingleTimelineResponse {
+                config: chunk_config,
+                data: chunk_data,
+            },
+        ));
+    }
 
     Ok(result)
 }

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -87,6 +87,28 @@ struct CacheParamsKey<'a, AppParams, EntryParams> {
     app_params: &'a AppParams,
 }
 
+/// Chunk geometry computed from engine metadata and the current viewport.
+struct ChunkGeometry {
+    epoch: TimeNanoSec,
+    engine_end: TimeNanoSec,
+    zoom_level: u64,
+    chunk_duration: u64,
+    first_chunk: u64,
+    last_chunk: u64,
+    num_bins: u16,
+}
+
+/// Result of a bulk cache check: which chunks were hits and which were misses.
+struct CacheCheckResult {
+    /// Cached chunk responses accumulated per entry key.
+    entry_chunks: HashMap<String, Vec<SingleTimelineResponse>>,
+    /// Entry keys that missed, grouped by chunk index.
+    chunk_misses: HashMap<u64, Vec<String>>,
+    any_cache_hit: bool,
+    hit_count: u64,
+    miss_count: u64,
+}
+
 /// Key identifying a cached timeline chunk.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 struct ChunkCacheKey {
@@ -118,6 +140,7 @@ impl TimelineCache {
         }
     }
 
+    /// Fetch bulk timelines, serving as many chunks from cache as possible.
     pub(crate) async fn cached_bulk_timeline<A>(
         &self,
         analyzer: &A,
@@ -132,82 +155,71 @@ impl TimelineCache {
         <A as UiAnalyzer>::TimelineGlobalParams: Hash + Eq + Clone,
         <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone,
     {
-        // Fetch engine metadata needed for chunk math.
-        let engine_span = analyzer.query_engine_model().engine()?.span()?;
-        let engine_duration = engine_span.duration();
-        let epoch = engine_span.start();
-
-        // Bypass caching for degenerate cases.
-        if engine_duration == 0 || request.entries.is_empty() {
+        let Some(geometry) = compute_chunk_geometry(analyzer, &request)? else {
             return Ok(analyzer.bulk_resource_timeline(request)?);
-        }
-
-        // All entries share the same viewport config — grab it from the first.
-        // Safety: unwrap never panics as empty requests returns early above
-        let timeline_config = request.entries.values().next().unwrap().config();
-
-        let req_start = epoch + to_nanosecs(timeline_config.start);
-        let req_end = epoch + to_nanosecs(timeline_config.end);
-        let req_span = match SpanNanoSec::try_new(req_start, req_end) {
-            Ok(span) => span,
-            Err(_) => return Ok(analyzer.bulk_resource_timeline(request)?),
         };
 
-        let num_bins = timeline_config.num_bins;
-        let view_duration = req_span.duration();
+        let entry_hashes = compute_entry_hashes(&request.entries, &request.app_params);
+        let cache_result = self.check_cache(engine_id, &entry_hashes, &geometry).await;
 
-        if view_duration == 0 {
-            return Ok(analyzer.bulk_resource_timeline(request)?);
-        }
-
-        // Determine chunk geometry for this zoom level.
-        let zoom_level = determine_zoom_level(view_duration, engine_duration);
-        let chunk_duration = engine_duration / zoom_level;
         debug!(
-            engine_duration,
-            view_duration, zoom_level, "bulk timeline zoom level determined"
+            hit_count = cache_result.hit_count,
+            miss_count = cache_result.miss_count,
+            zoom_level = geometry.zoom_level,
+            n_entries = request.entries.len(),
+            "bulk timeline cache check"
         );
 
-        // Find which chunk indices overlap the current viewport.
-        let first_chunk =
-            ((req_span.start().saturating_sub(epoch)) / chunk_duration).min(zoom_level - 1);
-        let last_chunk = ((req_span.end().saturating_sub(1).saturating_sub(epoch))
-            / chunk_duration)
-            .min(zoom_level - 1);
-
-        // Hash each entry's params to build stable cache keys.
-        let mut entry_hashes: HashMap<String, u64> = HashMap::new();
-
-        for (key, entry) in &request.entries {
-            let params_hash = {
-                let cache_key = CacheParamsKey {
-                    entry: EntryParamsKey::from_request(entry),
-                    app_params: &request.app_params,
-                };
-                let mut hasher = DefaultHasher::new();
-                cache_key.hash(&mut hasher);
-                hasher.finish()
-            };
-
-            entry_hashes.insert(key.clone(), params_hash);
+        if !cache_result.any_cache_hit {
+            return self
+                .cold_fetch_and_cache(analyzer, engine_id, request, &entry_hashes, &geometry)
+                .await;
         }
 
-        // Check the cache for each (entry, chunk) pair.
-        // Hits go into entry_chunks; misses are recorded in chunk_misses.
+        let CacheCheckResult {
+            mut entry_chunks,
+            chunk_misses,
+            ..
+        } = cache_result;
+
+        if !chunk_misses.is_empty() {
+            self.partial_fetch_and_cache(
+                analyzer,
+                engine_id,
+                &request.entries,
+                &request.app_params,
+                &entry_hashes,
+                &chunk_misses,
+                &geometry,
+                &mut entry_chunks,
+            )
+            .await?;
+        }
+
+        assemble_bulk_response(entry_chunks, &request.entries, &geometry)
+    }
+
+    /// Check the cache for each (entry, chunk) pair in the current viewport.
+    async fn check_cache(
+        &self,
+        engine_id: Uuid,
+        entry_hashes: &HashMap<String, u64>,
+        geometry: &ChunkGeometry,
+    ) -> CacheCheckResult {
         let mut entry_chunks: HashMap<String, Vec<SingleTimelineResponse>> = HashMap::new();
         let mut chunk_misses: HashMap<u64, Vec<String>> = HashMap::new();
         let mut any_cache_hit = false;
         let mut hit_count = 0u64;
         let mut miss_count = 0u64;
 
-        for chunk_idx in first_chunk..=last_chunk {
-            for key in request.entries.keys() {
+        for chunk_idx in geometry.first_chunk..=geometry.last_chunk {
+            for (key, &params_hash) in entry_hashes {
                 let cache_key = ChunkCacheKey {
                     engine_id,
-                    params_hash: entry_hashes[key],
-                    zoom_level,
+                    params_hash,
+                    zoom_level: geometry.zoom_level,
                     chunk_idx,
-                    num_bins,
+                    num_bins: geometry.num_bins,
                 };
 
                 if let Some(cached) = self.chunks.get(&cache_key).await {
@@ -221,89 +233,118 @@ impl TimelineCache {
             }
         }
 
-        debug!(
+        CacheCheckResult {
+            entry_chunks,
+            chunk_misses,
+            any_cache_hit,
             hit_count,
             miss_count,
-            zoom_level,
+        }
+    }
+
+    /// Cold-cache path: fetch all entries in one bulk call, then split and cache each chunk.
+    async fn cold_fetch_and_cache<A>(
+        &self,
+        analyzer: &A,
+        engine_id: Uuid,
+        request: BulkTimelineRequest<
+            <A as UiAnalyzer>::TimelineGlobalParams,
+            <A as UiAnalyzer>::TimelineParams,
+        >,
+        entry_hashes: &HashMap<String, u64>,
+        geometry: &ChunkGeometry,
+    ) -> ServerResult<BulkTimelinesResponse>
+    where
+        A: UiAnalyzer + Send + Sync + 'static,
+    {
+        debug!(
             n_entries = request.entries.len(),
-            "bulk timeline cache check"
+            zoom_level = geometry.zoom_level,
+            "bulk timeline cold cache: full fetch"
         );
 
-        // Fast path: cold cache — no chunks were cached, so fetch everything in one bulk call.
-        if !any_cache_hit {
-            debug!(
-                n_entries = request.entries.len(),
-                zoom_level, "bulk timeline cold cache: full fetch"
-            );
-            let response = analyzer.bulk_resource_timeline(request)?;
-            for (key, entry_resp) in &response.entries {
-                if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
-                    let chunk_resp = SingleTimelineResponse {
-                        config: *config,
-                        data: data.clone(),
-                    };
-                    let chunks = split_response_into_chunks(
-                        &chunk_resp,
-                        first_chunk,
-                        last_chunk,
-                        chunk_duration,
-                        zoom_level,
-                        epoch,
-                        engine_span.end(),
-                    )?;
+        let response = analyzer.bulk_resource_timeline(request)?;
 
-                    // Cache each chunk individually.
-                    for (chunk_idx, chunk) in chunks {
-                        let cache_key = ChunkCacheKey {
-                            engine_id,
-                            params_hash: entry_hashes[key],
-                            zoom_level,
-                            chunk_idx,
-                            num_bins,
-                        };
-                        self.chunks.insert(cache_key, chunk).await;
-                    }
+        for (key, entry_resp) in &response.entries {
+            if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
+                let chunk_resp = SingleTimelineResponse {
+                    config: *config,
+                    data: data.clone(),
+                };
+                let chunks = split_response_into_chunks(
+                    &chunk_resp,
+                    geometry.first_chunk,
+                    geometry.last_chunk,
+                    geometry.chunk_duration,
+                    geometry.zoom_level,
+                    geometry.epoch,
+                    geometry.engine_end,
+                )?;
+
+                for (chunk_idx, chunk) in chunks {
+                    let cache_key = ChunkCacheKey {
+                        engine_id,
+                        params_hash: entry_hashes[key],
+                        zoom_level: geometry.zoom_level,
+                        chunk_idx,
+                        num_bins: geometry.num_bins,
+                    };
+                    self.chunks.insert(cache_key, chunk).await;
                 }
             }
-            return Ok(response);
         }
 
-        let BulkTimelineRequest {
-            entries,
-            app_params,
-        } = request;
+        Ok(response)
+    }
 
-        // Partial cache hit: fetch only the missing (entry, chunk) pairs.
-        if !chunk_misses.is_empty() {
-            let n_miss_entries: usize = chunk_misses.values().map(|v| v.len()).sum();
-            debug!(
-                n_miss_chunks = chunk_misses.len(),
-                n_miss_entries, zoom_level, "bulk timeline partial cache: fetching missing chunks"
-            );
-        }
+    /// Partial-hit path: fetch only the (entry, chunk) pairs that missed the cache.
+    async fn partial_fetch_and_cache<A>(
+        &self,
+        analyzer: &A,
+        engine_id: Uuid,
+        entries: &HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>>,
+        app_params: &<A as UiAnalyzer>::TimelineGlobalParams,
+        entry_hashes: &HashMap<String, u64>,
+        chunk_misses: &HashMap<u64, Vec<String>>,
+        geometry: &ChunkGeometry,
+        entry_chunks: &mut HashMap<String, Vec<SingleTimelineResponse>>,
+    ) -> ServerResult<()>
+    where
+        A: UiAnalyzer + Send + Sync + 'static,
+        <A as UiAnalyzer>::TimelineGlobalParams: Clone,
+        <A as UiAnalyzer>::TimelineParams: Clone,
+    {
+        let n_miss_entries: usize = chunk_misses.values().map(|v| v.len()).sum();
+        debug!(
+            n_miss_chunks = chunk_misses.len(),
+            n_miss_entries,
+            zoom_level = geometry.zoom_level,
+            "bulk timeline partial cache: fetching missing chunks"
+        );
 
-        for (chunk_idx, miss_keys) in &chunk_misses {
-            let chunk_start = epoch + chunk_idx * chunk_duration;
-            let chunk_end = if *chunk_idx == zoom_level - 1 {
-                engine_span.end()
+        for (chunk_idx, miss_keys) in chunk_misses {
+            let chunk_start = geometry.epoch + chunk_idx * geometry.chunk_duration;
+            let chunk_end = if *chunk_idx == geometry.zoom_level - 1 {
+                geometry.engine_end
             } else {
-                epoch + (chunk_idx + 1) * chunk_duration
+                geometry.epoch + (chunk_idx + 1) * geometry.chunk_duration
             };
             let timeline_config = TimelineConfig {
-                num_bins,
-                start: to_secs_relative(chunk_start, epoch),
-                end: to_secs_relative(chunk_end, epoch),
+                num_bins: geometry.num_bins,
+                start: to_secs_relative(chunk_start, geometry.epoch),
+                end: to_secs_relative(chunk_end, geometry.epoch),
             };
 
-            let mut chunk_entries: HashMap<
-                String,
-                TimelineRequest<<A as UiAnalyzer>::TimelineParams>,
-            > = HashMap::new();
-
-            for key in miss_keys {
-                let entry = entries[key].clone().with_config(timeline_config.clone());
-                chunk_entries.insert(key.clone(), entry);
-            }
+            let chunk_entries: HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>> =
+                miss_keys
+                    .iter()
+                    .map(|key| {
+                        (
+                            key.clone(),
+                            entries[key].clone().with_config(timeline_config.clone()),
+                        )
+                    })
+                    .collect();
 
             let response = analyzer.bulk_resource_timeline(BulkTimelineRequest {
                 entries: chunk_entries,
@@ -316,9 +357,9 @@ impl TimelineCache {
                     let cache_key = ChunkCacheKey {
                         engine_id,
                         params_hash: entry_hashes[&key],
-                        zoom_level,
+                        zoom_level: geometry.zoom_level,
                         chunk_idx: *chunk_idx,
-                        num_bins,
+                        num_bins: geometry.num_bins,
                     };
                     self.chunks.insert(cache_key, single.clone()).await;
                     entry_chunks.entry(key).or_default().push(single);
@@ -326,36 +367,7 @@ impl TimelineCache {
             }
         }
 
-        let mut result_entries: HashMap<String, BulkTimelinesResponseEntry> = HashMap::new();
-
-        // now we have collected all chunks (both cached and fetched) in entry_chunks
-        for (key, chunk) in &entry_chunks {
-            if chunk.is_empty() {
-                continue;
-            }
-
-            let config = entries[key].config();
-            let chunk_span = match SpanNanoSec::try_new(
-                epoch + to_nanosecs(config.start),
-                epoch + to_nanosecs(config.end),
-            ) {
-                Ok(span) => span,
-                Err(_) => continue,
-            };
-
-            let combined = combine_chunks(chunk, chunk_span, epoch)?;
-            let result_entry = BulkTimelinesResponseEntry::Ok {
-                message: String::new(),
-                config: combined.config,
-                data: combined.data,
-            };
-
-            result_entries.insert(key.clone(), result_entry);
-        }
-
-        Ok(BulkTimelinesResponse {
-            entries: result_entries,
-        })
+        Ok(())
     }
 
     pub(crate) async fn cached_single_timeline<A>(
@@ -483,6 +495,125 @@ fn determine_zoom_level(view_duration: TimeNanoSec, total_duration: TimeNanoSec)
         return 1;
     }
     ((total_duration * TARGET_CHUNKS_PER_VIEW) / view_duration).max(1)
+}
+
+/// Compute chunk geometry from engine metadata and the current viewport.
+///
+/// Returns `None` for degenerate requests (empty, zero-duration, invalid span)
+/// that should fall through to an uncached bulk fetch.
+fn compute_chunk_geometry<A>(
+    analyzer: &A,
+    request: &BulkTimelineRequest<
+        <A as UiAnalyzer>::TimelineGlobalParams,
+        <A as UiAnalyzer>::TimelineParams,
+    >,
+) -> ServerResult<Option<ChunkGeometry>>
+where
+    A: UiAnalyzer,
+{
+    let engine_span = analyzer.query_engine_model().engine()?.span()?;
+    let engine_duration = engine_span.duration();
+    let epoch = engine_span.start();
+
+    if engine_duration == 0 || request.entries.is_empty() {
+        return Ok(None);
+    }
+
+    // Safety: unwrap OK — empty entries returns None above.
+    let timeline_config = request.entries.values().next().unwrap().config();
+
+    let req_start = epoch + to_nanosecs(timeline_config.start);
+    let req_end = epoch + to_nanosecs(timeline_config.end);
+    let req_span = match SpanNanoSec::try_new(req_start, req_end) {
+        Ok(span) => span,
+        Err(_) => return Ok(None),
+    };
+
+    let view_duration = req_span.duration();
+    if view_duration == 0 {
+        return Ok(None);
+    }
+
+    let zoom_level = determine_zoom_level(view_duration, engine_duration);
+    let chunk_duration = engine_duration / zoom_level;
+
+    debug!(engine_duration, view_duration, zoom_level, "bulk timeline zoom level determined");
+
+    let first_chunk =
+        ((req_span.start().saturating_sub(epoch)) / chunk_duration).min(zoom_level - 1);
+    let last_chunk = ((req_span.end().saturating_sub(1).saturating_sub(epoch)) / chunk_duration)
+        .min(zoom_level - 1);
+
+    Ok(Some(ChunkGeometry {
+        epoch,
+        engine_end: engine_span.end(),
+        zoom_level,
+        chunk_duration,
+        first_chunk,
+        last_chunk,
+        num_bins: timeline_config.num_bins,
+    }))
+}
+
+/// Hash each entry's identity fields (excluding viewport config) into a stable `u64`.
+fn compute_entry_hashes<GP, EP>(
+    entries: &HashMap<String, TimelineRequest<EP>>,
+    app_params: &GP,
+) -> HashMap<String, u64>
+where
+    GP: Hash,
+    EP: Hash,
+{
+    entries
+        .iter()
+        .map(|(key, entry)| {
+            let cache_key = CacheParamsKey {
+                entry: EntryParamsKey::from_request(entry),
+                app_params,
+            };
+            let mut hasher = DefaultHasher::new();
+            cache_key.hash(&mut hasher);
+            (key.clone(), hasher.finish())
+        })
+        .collect()
+}
+
+/// Assemble the final bulk response from the accumulated per-entry chunk slices.
+fn assemble_bulk_response<EP>(
+    entry_chunks: HashMap<String, Vec<SingleTimelineResponse>>,
+    entries: &HashMap<String, TimelineRequest<EP>>,
+    geometry: &ChunkGeometry,
+) -> ServerResult<BulkTimelinesResponse> {
+    let mut result_entries: HashMap<String, BulkTimelinesResponseEntry> = HashMap::new();
+
+    for (key, chunks) in &entry_chunks {
+        if chunks.is_empty() {
+            continue;
+        }
+
+        let config = entries[key].config();
+        let chunk_span = match SpanNanoSec::try_new(
+            geometry.epoch + to_nanosecs(config.start),
+            geometry.epoch + to_nanosecs(config.end),
+        ) {
+            Ok(span) => span,
+            Err(_) => continue,
+        };
+
+        let combined = combine_chunks(chunks, chunk_span, geometry.epoch)?;
+        result_entries.insert(
+            key.clone(),
+            BulkTimelinesResponseEntry::Ok {
+                message: String::new(),
+                config: combined.config,
+                data: combined.data,
+            },
+        );
+    }
+
+    Ok(BulkTimelinesResponse {
+        entries: result_entries,
+    })
 }
 
 /// Splits a full-viewport response into per-chunk responses for caching.

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -7,7 +7,6 @@ use std::{
     time::Duration,
 };
 
-use axum::http::response;
 use moka::future::Cache;
 use quent_analyzer::Span;
 use quent_query_engine_analyzer::{QueryEngineModel, ui::UiAnalyzer};
@@ -243,7 +242,7 @@ impl TimelineCache {
                 continue;
             }
 
-            let config = entries[&key].config();
+            let config = entries[key].config();
             let chunk_span = match SpanNanoSec::try_new(
                 epoch + to_nanosecs(config.start),
                 epoch + to_nanosecs(config.end),

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -2,20 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::hash_map::DefaultHasher,
+    collections::{HashMap, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
     time::Duration,
 };
 
+use axum::http::response;
 use moka::future::Cache;
 use quent_analyzer::Span;
 use quent_query_engine_analyzer::{QueryEngineModel, ui::UiAnalyzer};
 use quent_time::{SpanNanoSec, TimeNanoSec, bin::BinnedSpan, to_nanosecs, to_secs_relative};
 use quent_ui::timeline::{
-    request::{SingleTimelineRequest, TimelineConfig},
+    request::{self, BulkTimelineRequest, SingleTimelineRequest, TimelineConfig, TimelineRequest},
     response::{
-        ResourceTimeline, ResourceTimelineBinned, ResourceTimelineBinnedByState,
-        SingleTimelineResponse,
+        self, BulkTimelinesResponse, BulkTimelinesResponseEntry, ResourceTimeline,
+        ResourceTimelineBinned, ResourceTimelineBinnedByState, SingleTimelineResponse,
     },
 };
 use serde::Serialize;
@@ -38,6 +39,11 @@ struct ChunkCacheKey {
 }
 
 /// Cache for timeline chunk responses.
+///
+/// Used by both single and bulk timeline endpoints. The same `ChunkCacheKey`
+/// structure works for both: the `params_hash` is computed per-entry, so
+/// an entry fetched via bulk produces the same cache key as if it were
+/// fetched via single (allowing cross-endpoint cache sharing).
 #[derive(Clone)]
 pub struct TimelineCache {
     chunks: Cache<ChunkCacheKey, SingleTimelineResponse>,
@@ -51,6 +57,214 @@ impl TimelineCache {
                 .time_to_live(Duration::from_hours(1))
                 .build(),
         }
+    }
+
+    pub(crate) async fn cached_bulk_timeline<A>(
+        &self,
+        analyzer: &A,
+        engine_id: Uuid,
+        request: BulkTimelineRequest<
+            <A as UiAnalyzer>::TimelineGlobalParams,
+            <A as UiAnalyzer>::TimelineParams,
+        >,
+    ) -> ServerResult<BulkTimelinesResponse>
+    where
+        A: UiAnalyzer + Send + Sync + 'static,
+        <A as UiAnalyzer>::TimelineGlobalParams: Serialize + Clone,
+        <A as UiAnalyzer>::TimelineParams: Serialize + Clone,
+    {
+        // Fetch engine metadata needed for chunk math.
+        let engine_span = analyzer.query_engine_model().engine()?.span()?;
+        let engine_duration = engine_span.duration();
+        let epoch = engine_span.start();
+
+        // Bypass caching for degenerate cases.
+        if engine_duration == 0 || request.entries.is_empty() {
+            return Ok(analyzer.bulk_resource_timeline(request)?);
+        }
+
+        // All entries share the same viewport config — grab it from the first.
+        let timeline_config = request.entries.values().next().unwrap().config();
+
+        let req_start = epoch + to_nanosecs(timeline_config.start);
+        let req_end = epoch + to_nanosecs(timeline_config.end);
+        let req_span = match SpanNanoSec::try_new(req_start, req_end) {
+            Ok(span) => span,
+            Err(_) => return Ok(analyzer.bulk_resource_timeline(request)?),
+        };
+
+        let num_bins = timeline_config.num_bins;
+        let view_duration = req_span.duration();
+
+        if view_duration == 0 {
+            return Ok(analyzer.bulk_resource_timeline(request)?);
+        }
+
+        // Determine chunk geometry for this zoom level.
+        let zoom_level = determine_zoom_level(view_duration, engine_duration);
+        let chunk_duration = engine_duration / zoom_level;
+
+        // Find which chunk indices overlap the current viewport.
+        let first_chunk =
+            ((req_span.start().saturating_sub(epoch)) / chunk_duration).min(zoom_level - 1);
+        let last_chunk = ((req_span.end().saturating_sub(1).saturating_sub(epoch))
+            / chunk_duration)
+            .min(zoom_level - 1);
+
+        // Hash each entry's params to build stable cache keys.
+        let mut entry_hashes: HashMap<String, u64> = HashMap::new();
+
+        for (key, entry) in &request.entries {
+            let params_hash = {
+                let serialized = serde_json::to_string(&(&entry, &request.app_params))
+                    .map_err(|e| crate::error::ServerError::Cache(e.to_string()))?;
+                let mut hasher = DefaultHasher::new();
+                serialized.hash(&mut hasher);
+                hasher.finish()
+            };
+
+            entry_hashes.insert(key.clone(), params_hash);
+        }
+
+        // Check the cache for each (entry, chunk) pair.
+        // Hits go into entry_chunks; misses are recorded in chunk_misses.
+        let mut entry_chunks: HashMap<String, Vec<SingleTimelineResponse>> = HashMap::new();
+        let mut chunk_misses: HashMap<u64, Vec<String>> = HashMap::new();
+        let mut any_cache_hit = false;
+
+        for chunk_idx in first_chunk..=last_chunk {
+            for (key, _entry) in &request.entries {
+                let cache_key = ChunkCacheKey {
+                    engine_id,
+                    params_hash: entry_hashes[key],
+                    zoom_level,
+                    chunk_idx,
+                    num_bins,
+                };
+
+                if let Some(cached) = self.chunks.get(&cache_key).await {
+                    any_cache_hit = true;
+                    entry_chunks.entry(key.clone()).or_default().push(cached);
+                } else {
+                    chunk_misses.entry(chunk_idx).or_default().push(key.clone());
+                }
+            }
+        }
+
+        // Fast path: cold cache. Make one bulk call, split response into chunks, cache them.
+        if !any_cache_hit {
+            let response = analyzer.bulk_resource_timeline(request)?;
+            for (key, entry_resp) in &response.entries {
+                if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
+                    let chunk_resp = SingleTimelineResponse {
+                        config: *config,
+                        data: data.clone(),
+                    };
+                    let chunks = split_response_into_chunks(
+                        &chunk_resp,
+                        first_chunk,
+                        last_chunk,
+                        chunk_duration,
+                        zoom_level,
+                        epoch,
+                        engine_span.end(),
+                    )?;
+
+                    // Cache each chunk individually.
+                    for (chunk_idx, chunk) in chunks {
+                        let cache_key = ChunkCacheKey {
+                            engine_id,
+                            params_hash: entry_hashes[key],
+                            zoom_level,
+                            chunk_idx,
+                            num_bins,
+                        };
+                        self.chunks.insert(cache_key, chunk).await;
+                    }
+                }
+            }
+            return Ok(response);
+        }
+
+        let BulkTimelineRequest {
+            entries,
+            app_params,
+        } = request;
+
+        for (chunk_idx, miss_keys) in &chunk_misses {
+            let chunk_start = epoch + chunk_idx * chunk_duration;
+            let chunk_end = if *chunk_idx == zoom_level - 1 {
+                engine_span.end()
+            } else {
+                epoch + (chunk_idx + 1) * chunk_duration
+            };
+            let timeline_config = TimelineConfig {
+                num_bins,
+                start: to_secs_relative(chunk_start, epoch),
+                end: to_secs_relative(chunk_end, epoch),
+            };
+
+            let mut chunk_entries: HashMap<
+                String,
+                TimelineRequest<<A as UiAnalyzer>::TimelineParams>,
+            > = HashMap::new();
+
+            for key in miss_keys {
+                let entry = entries[key].clone().with_config(timeline_config.clone());
+                chunk_entries.insert(key.clone(), entry);
+            }
+
+            let response = analyzer.bulk_resource_timeline(BulkTimelineRequest {
+                entries: chunk_entries,
+                app_params: app_params.clone(),
+            })?;
+
+            for (key, entry_resp) in response.entries {
+                if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
+                    let single = SingleTimelineResponse { config, data };
+                    let cache_key = ChunkCacheKey {
+                        engine_id,
+                        params_hash: entry_hashes[&key],
+                        zoom_level,
+                        chunk_idx: *chunk_idx,
+                        num_bins,
+                    };
+                    self.chunks.insert(cache_key, single.clone()).await;
+                    entry_chunks.entry(key).or_default().push(single);
+                }
+            }
+        }
+
+        let mut result_entries: HashMap<String, BulkTimelinesResponseEntry> = HashMap::new();
+
+        // now we have collected all chunks (both cached and fetched) in entry_chunks
+        for (key, chunk) in &entry_chunks {
+            if chunk.is_empty() {
+                continue;
+            }
+
+            let config = entries[&key].config();
+            let chunk_span = match SpanNanoSec::try_new(
+                epoch + to_nanosecs(config.start),
+                epoch + to_nanosecs(config.end),
+            ) {
+                Ok(span) => span,
+                Err(_) => continue,
+            };
+
+            let combined = combine_chunks(chunk, chunk_span, epoch)?;
+            let result_entry = BulkTimelinesResponseEntry::Ok {
+                message: String::new(),
+                config: combined.config,
+                data: combined.data,
+            };
+
+            result_entries.insert(key.clone(), result_entry);
+        }
+
+        Ok(BulkTimelinesResponse {
+            entries: result_entries,
+        })
     }
 
     pub(crate) async fn cached_single_timeline<A>(
@@ -175,6 +389,94 @@ fn determine_zoom_level(view_duration: TimeNanoSec, total_duration: TimeNanoSec)
         return 1;
     }
     ((total_duration * TARGET_CHUNKS_PER_VIEW) / view_duration).max(1)
+}
+
+/// Splits a full-viewport response into per-chunk responses for caching.
+///
+/// This is the reverse of `combine_chunks`: given a response spanning multiple
+/// chunks, it slices the bin arrays at chunk boundaries and returns one
+/// `SingleTimelineResponse` per chunk.
+fn split_response_into_chunks(
+    response: &SingleTimelineResponse,
+    first_chunk: u64,
+    last_chunk: u64,
+    chunk_duration: u64,
+    zoom_level: u64,
+    epoch: TimeNanoSec,
+    engine_end: TimeNanoSec,
+) -> ServerResult<Vec<(u64, SingleTimelineResponse)>> {
+    let mut result = Vec::new();
+
+    // Loop over each chunk_idx from first_chunk..=last_chunk.
+    // For each chunk:
+    //
+    // ── S1: Compute chunk boundaries ──
+    //   chunk_start = epoch + chunk_idx * chunk_duration
+    //   chunk_end:
+    //     if chunk_idx == zoom_level - 1 → engine_end  (last chunk gets remainder)
+    //     else → epoch + (chunk_idx + 1) * chunk_duration
+    //   (Same pattern as cached_single_timeline lines ~287-292.)
+    //
+    // ── S2: Build chunk span ──
+    //   Use SpanNanoSec::try_new(chunk_start, chunk_end).
+    //   If it returns Err, skip this chunk with `continue`.
+    //
+    // ── S3: Find which bins belong to this chunk ──
+    //   Call overlap_indices(response, &chunk_span, epoch)
+    //   This returns (start_idx, end_idx) — the slice of bins for this chunk.
+    //   If start_idx >= end_idx, skip (no data overlaps this chunk).
+    //
+    // ── S4: Build config for this chunk ──
+    //   let chunk_num_bins = (end_idx - start_idx) as u64;
+    //   Build a BinnedSpan, then convert to BinnedSpanSec:
+    //     BinnedSpan::try_new(
+    //         chunk_span,
+    //         NonZero::try_from(chunk_num_bins).map_err(|e| ...)?
+    //     )?
+    //     .try_to_secs_relative(epoch)?
+    //   (Same pattern as combine_chunks lines ~318-324.)
+    //
+    //   Tip: NonZero is std::num::NonZero — you'll need to add it to the
+    //   imports at the top of the file.
+    //
+    // ── S5: Slice the data ──
+    //   Match on &response.data to handle both variants:
+    //
+    //     ResourceTimeline::Binned(data) →
+    //       Build a new HashMap<String, Vec<f64>> by iterating
+    //       data.capacities_values. For each (cap_name, values):
+    //         cap_name.clone() → values[start_idx..end_idx].to_vec()
+    //
+    //       For long_fsms: just clone the whole vec (data.long_fsms.clone()).
+    //       These aren't per-bin, so no slicing needed.
+    //
+    //       Build: ResourceTimeline::Binned(ResourceTimelineBinned {
+    //           config: chunk_config,
+    //           capacities_values: <your new map>,
+    //           long_fsms: <cloned>,
+    //       })
+    //
+    //     ResourceTimeline::BinnedByState(data) →
+    //       Same idea but one level deeper: data.capacities_states_values is
+    //       HashMap<String, HashMap<String, Vec<f64>>>.
+    //       For each (cap_name, states) → for each (state_name, values):
+    //         values[start_idx..end_idx].to_vec()
+    //
+    //       Build: ResourceTimeline::BinnedByState(ResourceTimelineBinnedByState {
+    //           config: chunk_config,
+    //           capacities_states_values: <your new nested map>,
+    //           long_fsms: <cloned>,
+    //       })
+    //
+    //   Tip: look at combine_chunks for the iteration patterns over these
+    //   nested HashMaps — it does the reverse operation (combining slices).
+    //
+    // ── S6: Push result ──
+    //   Build SingleTimelineResponse { config: chunk_config, data: <your data> }
+    //   Push (chunk_idx, response) into `result`.
+    todo!("implement split_response_into_chunks");
+
+    Ok(result)
 }
 
 fn combine_chunks(

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -18,7 +18,6 @@ use quent_ui::timeline::{
         ResourceTimelineBinned, ResourceTimelineBinnedByState, SingleTimelineResponse,
     },
 };
-use serde::Serialize;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -26,6 +25,67 @@ use crate::error::ServerResult;
 
 /// Target number of chunks visible in the current view range.
 const TARGET_CHUNKS_PER_VIEW: u64 = 2;
+
+/// Newtype wrapper for `f64` that provides `Hash` and `Eq` via bit representation.
+/// Two floats are considered equal when their bits are identical (NaN == NaN).
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct HashableF64(u64);
+
+impl From<f64> for HashableF64 {
+    fn from(v: f64) -> Self {
+        Self(v.to_bits())
+    }
+}
+
+/// View of a timeline entry's identity fields, excluding viewport config.
+///
+/// The viewport config (`start`, `end`, `num_bins`) is intentionally omitted:
+/// `start`/`end` vary with every pan or zoom, and `num_bins` is already a
+/// separate field in `ChunkCacheKey`. Only the query-identity fields determine
+/// whether two requests map to the same cached chunks.
+#[derive(Hash, PartialEq, Eq)]
+enum EntryParamsKey<'a, EntryParams> {
+    Resource {
+        resource_id: Uuid,
+        long_entities_threshold_s: Option<HashableF64>,
+        entity_type_name: Option<&'a str>,
+        application: &'a EntryParams,
+    },
+    ResourceGroup {
+        resource_group_id: Uuid,
+        resource_type_name: &'a str,
+        long_entities_threshold_s: Option<HashableF64>,
+        entity_type_name: Option<&'a str>,
+        app_params: &'a EntryParams,
+    },
+}
+
+impl<'a, EntryParams> EntryParamsKey<'a, EntryParams> {
+    fn from_request(entry: &'a TimelineRequest<EntryParams>) -> Self {
+        match entry {
+            TimelineRequest::Resource(r) => Self::Resource {
+                resource_id: r.resource_id,
+                long_entities_threshold_s: r.long_entities_threshold_s.map(HashableF64::from),
+                entity_type_name: r.entity_filter.entity_type_name.as_deref(),
+                application: &r.application,
+            },
+            TimelineRequest::ResourceGroup(rg) => Self::ResourceGroup {
+                resource_group_id: rg.resource_group_id,
+                resource_type_name: &rg.resource_type_name,
+                long_entities_threshold_s: rg.long_entities_threshold_s.map(HashableF64::from),
+                entity_type_name: rg.entity_filter.entity_type_name.as_deref(),
+                app_params: &rg.app_params,
+            },
+        }
+    }
+}
+
+/// Pairs an entry key with global app params for stable cache key hashing.
+#[derive(Hash, PartialEq, Eq)]
+struct CacheParamsKey<'a, AppParams, EntryParams> {
+    entry: EntryParamsKey<'a, EntryParams>,
+    app_params: &'a AppParams,
+}
 
 /// Key identifying a cached timeline chunk.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
@@ -69,8 +129,8 @@ impl TimelineCache {
     ) -> ServerResult<BulkTimelinesResponse>
     where
         A: UiAnalyzer + Send + Sync + 'static,
-        <A as UiAnalyzer>::TimelineGlobalParams: Serialize + Clone,
-        <A as UiAnalyzer>::TimelineParams: Serialize + Clone,
+        <A as UiAnalyzer>::TimelineGlobalParams: Hash + Eq + Clone,
+        <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone,
     {
         // Fetch engine metadata needed for chunk math.
         let engine_span = analyzer.query_engine_model().engine()?.span()?;
@@ -83,6 +143,7 @@ impl TimelineCache {
         }
 
         // All entries share the same viewport config — grab it from the first.
+        // Safety: unwrap never panics as empty requests returns early above
         let timeline_config = request.entries.values().next().unwrap().config();
 
         let req_start = epoch + to_nanosecs(timeline_config.start);
@@ -119,19 +180,12 @@ impl TimelineCache {
 
         for (key, entry) in &request.entries {
             let params_hash = {
-                // Strip the viewport config (start/end/num_bins) before hashing: start/end vary
-                // with every pan or zoom, and num_bins is already a separate field in ChunkCacheKey.
-                // Only the query-identity fields (resource, filters, app params) should determine
-                // whether two requests map to the same cached chunks.
-                let canonical = entry.clone().with_config(TimelineConfig {
-                    num_bins: 0,
-                    start: 0.0,
-                    end: 0.0,
-                });
-                let serialized = serde_json::to_string(&(&canonical, &request.app_params))
-                    .map_err(|e| crate::error::ServerError::Cache(e.to_string()))?;
+                let cache_key = CacheParamsKey {
+                    entry: EntryParamsKey::from_request(entry),
+                    app_params: &request.app_params,
+                };
                 let mut hasher = DefaultHasher::new();
-                serialized.hash(&mut hasher);
+                cache_key.hash(&mut hasher);
                 hasher.finish()
             };
 
@@ -315,8 +369,8 @@ impl TimelineCache {
     ) -> ServerResult<SingleTimelineResponse>
     where
         A: UiAnalyzer + Send + Sync + 'static,
-        <A as UiAnalyzer>::TimelineGlobalParams: Serialize + Clone,
-        <A as UiAnalyzer>::TimelineParams: Serialize + Clone,
+        <A as UiAnalyzer>::TimelineGlobalParams: Hash + Eq + Clone,
+        <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone,
     {
         let engine_span = analyzer.query_engine_model().engine()?.span()?;
         let engine_duration = engine_span.duration();
@@ -350,15 +404,12 @@ impl TimelineCache {
         // Hash the entry + app_params for cache key construction.
         // Strip the viewport config before hashing — same reasoning as in cached_bulk_timeline.
         let params_hash = {
-            let canonical = request.entry.clone().with_config(TimelineConfig {
-                num_bins: 0,
-                start: 0.0,
-                end: 0.0,
-            });
-            let serialized = serde_json::to_string(&(&canonical, &request.app_params))
-                .map_err(|e| crate::error::ServerError::Cache(e.to_string()))?;
+            let cache_key = CacheParamsKey {
+                entry: EntryParamsKey::from_request(&request.entry),
+                app_params: &request.app_params,
+            };
             let mut hasher = DefaultHasher::new();
-            serialized.hash(&mut hasher);
+            cache_key.hash(&mut hasher);
             hasher.finish()
         };
 

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{HashMap, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
+    sync::Arc,
     time::Duration,
 };
 
@@ -143,7 +144,7 @@ impl TimelineCache {
     /// Fetch bulk timelines, serving as many chunks from cache as possible.
     pub(crate) async fn cached_bulk_timeline<A>(
         &self,
-        analyzer: &A,
+        analyzer: Arc<A>,
         engine_id: Uuid,
         request: BulkTimelineRequest<
             <A as UiAnalyzer>::TimelineGlobalParams,
@@ -152,11 +153,14 @@ impl TimelineCache {
     ) -> ServerResult<BulkTimelinesResponse>
     where
         A: UiAnalyzer + Send + Sync + 'static,
-        <A as UiAnalyzer>::TimelineGlobalParams: Hash + Eq + Clone,
-        <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone,
+        <A as UiAnalyzer>::TimelineGlobalParams: Hash + Eq + Clone + Send + 'static,
+        <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone + Send + 'static,
     {
-        let Some(geometry) = compute_chunk_geometry(analyzer, &request)? else {
-            return Ok(tokio::task::block_in_place(|| analyzer.bulk_resource_timeline(request))?);
+        let Some(geometry) = compute_chunk_geometry(&*analyzer, &request)? else {
+            return Ok(
+                tokio::task::spawn_blocking(move || analyzer.bulk_resource_timeline(request))
+                    .await??,
+            );
         };
 
         let entry_hashes = compute_entry_hashes(&request.entries, &request.app_params);
@@ -172,7 +176,13 @@ impl TimelineCache {
 
         if !cache_result.any_cache_hit {
             return self
-                .cold_fetch_and_cache(analyzer, engine_id, request, &entry_hashes, &geometry)
+                .cold_fetch_and_cache(
+                    Arc::clone(&analyzer),
+                    engine_id,
+                    request,
+                    &entry_hashes,
+                    &geometry,
+                )
                 .await;
         }
 
@@ -184,7 +194,7 @@ impl TimelineCache {
 
         if !chunk_misses.is_empty() {
             self.partial_fetch_and_cache(
-                analyzer,
+                Arc::clone(&analyzer),
                 engine_id,
                 &request.entries,
                 &request.app_params,
@@ -245,7 +255,7 @@ impl TimelineCache {
     /// Cold-cache path: fetch all entries in one bulk call, then split and cache each chunk.
     async fn cold_fetch_and_cache<A>(
         &self,
-        analyzer: &A,
+        analyzer: Arc<A>,
         engine_id: Uuid,
         request: BulkTimelineRequest<
             <A as UiAnalyzer>::TimelineGlobalParams,
@@ -256,6 +266,8 @@ impl TimelineCache {
     ) -> ServerResult<BulkTimelinesResponse>
     where
         A: UiAnalyzer + Send + Sync + 'static,
+        <A as UiAnalyzer>::TimelineGlobalParams: Send + 'static,
+        <A as UiAnalyzer>::TimelineParams: Send + 'static,
     {
         debug!(
             n_entries = request.entries.len(),
@@ -264,7 +276,8 @@ impl TimelineCache {
         );
 
         let response =
-            tokio::task::block_in_place(|| analyzer.bulk_resource_timeline(request))?;
+            tokio::task::spawn_blocking(move || analyzer.bulk_resource_timeline(request))
+                .await??;
 
         for (key, entry_resp) in &response.entries {
             if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
@@ -301,7 +314,7 @@ impl TimelineCache {
     /// Partial-hit path: fetch only the (entry, chunk) pairs that missed the cache.
     async fn partial_fetch_and_cache<A>(
         &self,
-        analyzer: &A,
+        analyzer: Arc<A>,
         engine_id: Uuid,
         entries: &HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>>,
         app_params: &<A as UiAnalyzer>::TimelineGlobalParams,
@@ -312,8 +325,8 @@ impl TimelineCache {
     ) -> ServerResult<()>
     where
         A: UiAnalyzer + Send + Sync + 'static,
-        <A as UiAnalyzer>::TimelineGlobalParams: Clone,
-        <A as UiAnalyzer>::TimelineParams: Clone,
+        <A as UiAnalyzer>::TimelineGlobalParams: Clone + Send + 'static,
+        <A as UiAnalyzer>::TimelineParams: Clone + Send + 'static,
     {
         let n_miss_entries: usize = chunk_misses.values().map(|v| v.len()).sum();
         debug!(
@@ -347,12 +360,15 @@ impl TimelineCache {
                     })
                     .collect();
 
-            let response = tokio::task::block_in_place(|| {
-                analyzer.bulk_resource_timeline(BulkTimelineRequest {
+            let a = Arc::clone(&analyzer);
+            let app_params_clone = app_params.clone();
+            let response = tokio::task::spawn_blocking(move || {
+                a.bulk_resource_timeline(BulkTimelineRequest {
                     entries: chunk_entries,
-                    app_params: app_params.clone(),
+                    app_params: app_params_clone,
                 })
-            })?;
+            })
+            .await??;
 
             for (key, entry_resp) in response.entries {
                 if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
@@ -375,7 +391,7 @@ impl TimelineCache {
 
     pub(crate) async fn cached_single_timeline<A>(
         &self,
-        analyzer: &A,
+        analyzer: Arc<A>,
         engine_id: Uuid,
         request: SingleTimelineRequest<
             <A as UiAnalyzer>::TimelineGlobalParams,
@@ -384,8 +400,8 @@ impl TimelineCache {
     ) -> ServerResult<SingleTimelineResponse>
     where
         A: UiAnalyzer + Send + Sync + 'static,
-        <A as UiAnalyzer>::TimelineGlobalParams: Hash + Eq + Clone,
-        <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone,
+        <A as UiAnalyzer>::TimelineGlobalParams: Hash + Eq + Clone + Send + 'static,
+        <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone + Send + 'static,
     {
         let engine_span = analyzer.query_engine_model().engine()?.span()?;
         let engine_duration = engine_span.duration();
@@ -470,8 +486,10 @@ impl TimelineCache {
                 app_params: request.app_params.clone(),
             };
 
+            let a = Arc::clone(&analyzer);
             let response =
-                tokio::task::block_in_place(|| analyzer.single_resource_timeline(chunk_request))?;
+                tokio::task::spawn_blocking(move || a.single_resource_timeline(chunk_request))
+                    .await??;
             self.chunks.insert(cache_key, response.clone()).await;
             chunk_responses.push(response);
         }

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -110,6 +110,14 @@ struct CacheCheckResult {
     miss_count: u64,
 }
 
+/// Identity of a cache lookup: engine, per-entry param hashes, and chunk geometry.
+/// Together these uniquely determine the `ChunkCacheKey` for every (entry, chunk) pair.
+struct CacheRequestContext<'a> {
+    engine_id: Uuid,
+    entry_hashes: &'a HashMap<String, u64>,
+    geometry: &'a ChunkGeometry,
+}
+
 /// Key identifying a cached timeline chunk.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 struct ChunkCacheKey {
@@ -164,7 +172,12 @@ impl TimelineCache {
         };
 
         let entry_hashes = compute_entry_hashes(&request.entries, &request.app_params);
-        let cache_result = self.check_cache(engine_id, &entry_hashes, &geometry).await;
+        let ctx = CacheRequestContext {
+            engine_id,
+            entry_hashes: &entry_hashes,
+            geometry: &geometry,
+        };
+        let cache_result = self.check_cache(&ctx).await;
 
         debug!(
             hit_count = cache_result.hit_count,
@@ -176,13 +189,7 @@ impl TimelineCache {
 
         if !cache_result.any_cache_hit {
             return self
-                .cold_fetch_and_cache(
-                    Arc::clone(&analyzer),
-                    engine_id,
-                    request,
-                    &entry_hashes,
-                    &geometry,
-                )
+                .cold_fetch_and_cache(Arc::clone(&analyzer), request, &ctx)
                 .await;
         }
 
@@ -195,12 +202,10 @@ impl TimelineCache {
         if !chunk_misses.is_empty() {
             self.partial_fetch_and_cache(
                 Arc::clone(&analyzer),
-                engine_id,
                 &request.entries,
                 &request.app_params,
-                &entry_hashes,
                 &chunk_misses,
-                &geometry,
+                &ctx,
                 &mut entry_chunks,
             )
             .await?;
@@ -210,26 +215,21 @@ impl TimelineCache {
     }
 
     /// Check the cache for each (entry, chunk) pair in the current viewport.
-    async fn check_cache(
-        &self,
-        engine_id: Uuid,
-        entry_hashes: &HashMap<String, u64>,
-        geometry: &ChunkGeometry,
-    ) -> CacheCheckResult {
+    async fn check_cache(&self, ctx: &CacheRequestContext<'_>) -> CacheCheckResult {
         let mut entry_chunks: HashMap<String, Vec<SingleTimelineResponse>> = HashMap::new();
         let mut chunk_misses: HashMap<u64, Vec<String>> = HashMap::new();
         let mut any_cache_hit = false;
         let mut hit_count = 0u64;
         let mut miss_count = 0u64;
 
-        for chunk_idx in geometry.first_chunk..=geometry.last_chunk {
-            for (key, &params_hash) in entry_hashes {
+        for chunk_idx in ctx.geometry.first_chunk..=ctx.geometry.last_chunk {
+            for (key, &params_hash) in ctx.entry_hashes {
                 let cache_key = ChunkCacheKey {
-                    engine_id,
+                    engine_id: ctx.engine_id,
                     params_hash,
-                    zoom_level: geometry.zoom_level,
+                    zoom_level: ctx.geometry.zoom_level,
                     chunk_idx,
-                    num_bins: geometry.num_bins,
+                    num_bins: ctx.geometry.num_bins,
                 };
 
                 if let Some(cached) = self.chunks.get(&cache_key).await {
@@ -256,13 +256,11 @@ impl TimelineCache {
     async fn cold_fetch_and_cache<A>(
         &self,
         analyzer: Arc<A>,
-        engine_id: Uuid,
         request: BulkTimelineRequest<
             <A as UiAnalyzer>::TimelineGlobalParams,
             <A as UiAnalyzer>::TimelineParams,
         >,
-        entry_hashes: &HashMap<String, u64>,
-        geometry: &ChunkGeometry,
+        ctx: &CacheRequestContext<'_>,
     ) -> ServerResult<BulkTimelinesResponse>
     where
         A: UiAnalyzer + Send + Sync + 'static,
@@ -271,7 +269,7 @@ impl TimelineCache {
     {
         debug!(
             n_entries = request.entries.len(),
-            zoom_level = geometry.zoom_level,
+            zoom_level = ctx.geometry.zoom_level,
             "bulk timeline cold cache: full fetch"
         );
 
@@ -286,21 +284,21 @@ impl TimelineCache {
                 };
                 let chunks = split_response_into_chunks(
                     &chunk_resp,
-                    geometry.first_chunk,
-                    geometry.last_chunk,
-                    geometry.chunk_duration,
-                    geometry.zoom_level,
-                    geometry.epoch,
-                    geometry.engine_end,
+                    ctx.geometry.first_chunk,
+                    ctx.geometry.last_chunk,
+                    ctx.geometry.chunk_duration,
+                    ctx.geometry.zoom_level,
+                    ctx.geometry.epoch,
+                    ctx.geometry.engine_end,
                 )?;
 
                 for (chunk_idx, chunk) in chunks {
                     let cache_key = ChunkCacheKey {
-                        engine_id,
-                        params_hash: entry_hashes[key],
-                        zoom_level: geometry.zoom_level,
+                        engine_id: ctx.engine_id,
+                        params_hash: ctx.entry_hashes[key],
+                        zoom_level: ctx.geometry.zoom_level,
                         chunk_idx,
-                        num_bins: geometry.num_bins,
+                        num_bins: ctx.geometry.num_bins,
                     };
                     self.chunks.insert(cache_key, chunk).await;
                 }
@@ -314,12 +312,10 @@ impl TimelineCache {
     async fn partial_fetch_and_cache<A>(
         &self,
         analyzer: Arc<A>,
-        engine_id: Uuid,
         entries: &HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>>,
         app_params: &<A as UiAnalyzer>::TimelineGlobalParams,
-        entry_hashes: &HashMap<String, u64>,
         chunk_misses: &HashMap<u64, Vec<String>>,
-        geometry: &ChunkGeometry,
+        ctx: &CacheRequestContext<'_>,
         entry_chunks: &mut HashMap<String, Vec<SingleTimelineResponse>>,
     ) -> ServerResult<()>
     where
@@ -331,21 +327,21 @@ impl TimelineCache {
         debug!(
             n_miss_chunks = chunk_misses.len(),
             n_miss_entries,
-            zoom_level = geometry.zoom_level,
+            zoom_level = ctx.geometry.zoom_level,
             "bulk timeline partial cache: fetching missing chunks"
         );
 
         for (chunk_idx, miss_keys) in chunk_misses {
-            let chunk_start = geometry.epoch + chunk_idx * geometry.chunk_duration;
-            let chunk_end = if *chunk_idx == geometry.zoom_level - 1 {
-                geometry.engine_end
+            let chunk_start = ctx.geometry.epoch + chunk_idx * ctx.geometry.chunk_duration;
+            let chunk_end = if *chunk_idx == ctx.geometry.zoom_level - 1 {
+                ctx.geometry.engine_end
             } else {
-                geometry.epoch + (chunk_idx + 1) * geometry.chunk_duration
+                ctx.geometry.epoch + (chunk_idx + 1) * ctx.geometry.chunk_duration
             };
             let timeline_config = TimelineConfig {
-                num_bins: geometry.num_bins,
-                start: to_secs_relative(chunk_start, geometry.epoch),
-                end: to_secs_relative(chunk_end, geometry.epoch),
+                num_bins: ctx.geometry.num_bins,
+                start: to_secs_relative(chunk_start, ctx.geometry.epoch),
+                end: to_secs_relative(chunk_end, ctx.geometry.epoch),
             };
 
             let chunk_entries: HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>> =
@@ -373,11 +369,11 @@ impl TimelineCache {
                 if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
                     let single = SingleTimelineResponse { config, data };
                     let cache_key = ChunkCacheKey {
-                        engine_id,
-                        params_hash: entry_hashes[&key],
-                        zoom_level: geometry.zoom_level,
+                        engine_id: ctx.engine_id,
+                        params_hash: ctx.entry_hashes[&key],
+                        zoom_level: ctx.geometry.zoom_level,
                         chunk_idx: *chunk_idx,
-                        num_bins: geometry.num_bins,
+                        num_bins: ctx.geometry.num_bins,
                     };
                     self.chunks.insert(cache_key, single.clone()).await;
                     entry_chunks.entry(key).or_default().push(single);

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -157,10 +157,10 @@ impl TimelineCache {
         <A as UiAnalyzer>::TimelineParams: Hash + Eq + Clone + Send + 'static,
     {
         let Some(geometry) = compute_chunk_geometry(&*analyzer, &request)? else {
-            return Ok(
-                tokio::task::spawn_blocking(move || analyzer.bulk_resource_timeline(request))
-                    .await??,
-            );
+            return Ok(tokio::task::spawn_blocking(move || {
+                analyzer.bulk_resource_timeline(request)
+            })
+            .await??);
         };
 
         let entry_hashes = compute_entry_hashes(&request.entries, &request.app_params);
@@ -276,8 +276,7 @@ impl TimelineCache {
         );
 
         let response =
-            tokio::task::spawn_blocking(move || analyzer.bulk_resource_timeline(request))
-                .await??;
+            tokio::task::spawn_blocking(move || analyzer.bulk_resource_timeline(request)).await??;
 
         for (key, entry_resp) in &response.entries {
             if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
@@ -559,7 +558,10 @@ where
     let zoom_level = determine_zoom_level(view_duration, engine_duration);
     let chunk_duration = engine_duration / zoom_level;
 
-    debug!(engine_duration, view_duration, zoom_level, "bulk timeline zoom level determined");
+    debug!(
+        engine_duration,
+        view_duration, zoom_level, "bulk timeline zoom level determined"
+    );
 
     let first_chunk =
         ((req_span.start().saturating_sub(epoch)) / chunk_duration).min(zoom_level - 1);

--- a/domains/query_engine/server/src/ui.rs
+++ b/domains/query_engine/server/src/ui.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::hash::Hash;
+
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -225,8 +227,8 @@ async fn single_timeline<A>(
 ) -> ServerResult<Json<SingleTimelineResponse>>
 where
     A: UiAnalyzer + Send + Sync + 'static,
-    <A as UiAnalyzer>::TimelineGlobalParams: serde::Serialize + Clone,
-    <A as UiAnalyzer>::TimelineParams: serde::Serialize + Clone,
+    <A as UiAnalyzer>::TimelineGlobalParams: serde::Serialize + Hash + Eq + Clone,
+    <A as UiAnalyzer>::TimelineParams: serde::Serialize + Hash + Eq + Clone,
 {
     let analyzer = state.analyzers.get(engine_id).await?;
     Ok(Json(
@@ -263,8 +265,9 @@ async fn bulk_timelines<A>(
 ) -> ServerResult<Json<BulkTimelinesResponse>>
 where
     A: UiAnalyzer + Send + Sync + 'static,
-    <A as UiAnalyzer>::TimelineGlobalParams: Send + Sync + Clone + serde::Serialize + 'static,
-    <A as UiAnalyzer>::TimelineParams: Send + Sync + Clone + serde::Serialize + 'static,
+    <A as UiAnalyzer>::TimelineGlobalParams:
+        Send + Sync + Clone + serde::Serialize + Hash + Eq + 'static,
+    <A as UiAnalyzer>::TimelineParams: Send + Sync + Clone + serde::Serialize + Hash + Eq + 'static,
 {
     let analyzer = state.analyzers.get(engine_id).await?;
     Ok(Json(
@@ -298,8 +301,9 @@ pub fn routes<A>(state: ServiceState<A>) -> Router<()>
 where
     A: UiAnalyzer + Send + Sync + 'static,
     <A as UiAnalyzer>::EntityRef: serde::Serialize,
-    <A as UiAnalyzer>::TimelineGlobalParams: Send + Sync + Clone + serde::Serialize + 'static,
-    <A as UiAnalyzer>::TimelineParams: Send + Sync + Clone + serde::Serialize + 'static,
+    <A as UiAnalyzer>::TimelineGlobalParams:
+        Send + Sync + Clone + serde::Serialize + Hash + Eq + 'static,
+    <A as UiAnalyzer>::TimelineParams: Send + Sync + Clone + serde::Serialize + Hash + Eq + 'static,
     for<'de> <A as UiAnalyzer>::TimelineGlobalParams: serde::Deserialize<'de>,
     for<'de> <A as UiAnalyzer>::TimelineParams: serde::Deserialize<'de>,
 {

--- a/domains/query_engine/server/src/ui.rs
+++ b/domains/query_engine/server/src/ui.rs
@@ -263,13 +263,16 @@ async fn bulk_timelines<A>(
 ) -> ServerResult<Json<BulkTimelinesResponse>>
 where
     A: UiAnalyzer + Send + Sync + 'static,
-    <A as UiAnalyzer>::TimelineGlobalParams: Send + 'static,
-    <A as UiAnalyzer>::TimelineParams: Send + 'static,
+    <A as UiAnalyzer>::TimelineGlobalParams: Send + Sync + Clone + serde::Serialize + 'static,
+    <A as UiAnalyzer>::TimelineParams: Send + Sync + Clone + serde::Serialize + 'static,
 {
     let analyzer = state.analyzers.get(engine_id).await?;
-    let response =
-        tokio::task::spawn_blocking(move || analyzer.bulk_resource_timeline(request)).await??;
-    Ok(Json(response))
+    Ok(Json(
+        state
+            .timelines
+            .cached_bulk_timeline(&*analyzer, engine_id, request)
+            .await?,
+    ))
 }
 
 #[cfg(feature = "swagger")]

--- a/domains/query_engine/server/src/ui.rs
+++ b/domains/query_engine/server/src/ui.rs
@@ -227,14 +227,14 @@ async fn single_timeline<A>(
 ) -> ServerResult<Json<SingleTimelineResponse>>
 where
     A: UiAnalyzer + Send + Sync + 'static,
-    <A as UiAnalyzer>::TimelineGlobalParams: serde::Serialize + Hash + Eq + Clone,
-    <A as UiAnalyzer>::TimelineParams: serde::Serialize + Hash + Eq + Clone,
+    <A as UiAnalyzer>::TimelineGlobalParams: serde::Serialize + Hash + Eq + Clone + Send + 'static,
+    <A as UiAnalyzer>::TimelineParams: serde::Serialize + Hash + Eq + Clone + Send + 'static,
 {
     let analyzer = state.analyzers.get(engine_id).await?;
     Ok(Json(
         state
             .timelines
-            .cached_single_timeline(&*analyzer, engine_id, request)
+            .cached_single_timeline(analyzer, engine_id, request)
             .await?,
     ))
 }
@@ -273,7 +273,7 @@ where
     Ok(Json(
         state
             .timelines
-            .cached_bulk_timeline(&*analyzer, engine_id, request)
+            .cached_bulk_timeline(analyzer, engine_id, request)
             .await?,
     ))
 }

--- a/examples/simulator/ui/src/lib.rs
+++ b/examples/simulator/ui/src/lib.rs
@@ -32,12 +32,12 @@ impl EntityId for EntityRef {
     }
 }
 
-#[derive(TS, Debug, Clone, Serialize, Deserialize)]
+#[derive(TS, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TaskFilter {
     pub operator_id: Option<Uuid>,
 }
 
-#[derive(TS, Debug, Clone, Serialize, Deserialize)]
+#[derive(TS, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QueryFilter {
     pub query_id: Uuid,
 }


### PR DESCRIPTION
- Adds `cached_bulk_timeline` to `TimelineCache`, extending the existing single-timeline chunk cache to handle bulk requests
- Bulk responses are split into per-chunk `SingleTimelineResponse` entries and stored under the same `ChunkCacheKey` scheme used by single-timeline, so chunks fetched via either endpoint are shared
- On a cache hit (full or partial), cached chunks are recombined and returned without hitting the analyzer; on a full miss, falls back to a single bulk analyzer call and caches the result
- Fixes a bug in both bulk and single-timeline caching where `TimelineConfig` (containing start/end) was included in the `params_hash`, causing a cache miss on every pan or zoom since the viewport coordinates changed with each request

**How the caching works**

The engine's full time span is divided into zoom_level equal chunks, where `zoom_level = (engine_duration × 2) / view_duration`. Each chunk is cached independently. On subsequent requests at the same zoom level, only the chunks not already in cache are fetched from the analyzer; the rest are served directly.

**Test plan**

- Cold load: verify logs show hit_count=0 and full fetch on first request
- Pan left/right: verify subsequent requests show hit_count > 0 for previously loaded chunks
- Zoom in/out slightly within the same zoom level: verify cache hits are preserved
- Multiple entries: verify partial cache hits correctly merge cached and freshly-fetched chunks

Fixes: #8 
