### PR TITLE
feat(ui): replace operator stats popup with fixed panel

### DIFF
--- a/ui/src/atoms/dag.ts
+++ b/ui/src/atoms/dag.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atom } from 'jotai';
-import type { NodeColoring, EdgeWidthConfig, EdgeColoring, StatValue } from '@/services/query-plan/types';
+import type {
+  NodeColoring,
+  EdgeWidthConfig,
+  EdgeColoring,
+  StatValue,
+} from '@/services/query-plan/types';
 import type { ContinuousPaletteName } from '@/services/colors';
 
 export interface InspectedNodeData {

--- a/ui/src/atoms/dag.ts
+++ b/ui/src/atoms/dag.ts
@@ -2,8 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atom } from 'jotai';
-import type { NodeColoring, EdgeWidthConfig, EdgeColoring } from '@/services/query-plan/types';
+import type { NodeColoring, EdgeWidthConfig, EdgeColoring, StatValue } from '@/services/query-plan/types';
 import type { ContinuousPaletteName } from '@/services/colors';
+
+export interface InspectedNodeData {
+  nodeId: string;
+  label: string;
+  operationType: string;
+  statistics: Array<{ key: string; value: StatValue }>;
+}
+
+/** Data for the node currently being hovered (drives the preview panel) */
+export const hoveredNodeDataAtom = atom<InspectedNodeData | null>(null);
+
+/** Data for the currently selected/pinned node (persists in the panel after click) */
+export const selectedNodeDataAtom = atom<InspectedNodeData | null>(null);
 
 /** The set of currently selected node IDs in the DAG chart */
 export const selectedNodeIdsAtom = atom(new Set<string>());

--- a/ui/src/components/dag/DAGChart.tsx
+++ b/ui/src/components/dag/DAGChart.tsx
@@ -27,15 +27,18 @@ import {
 } from '@/services/query-plan/operationTypes';
 import { QueryPlanNode, type QueryPlanNodeData } from '../query-plan/QueryPlanNode';
 import { DAGLegend } from './DAGLegend';
+import { DAGNodeInfoPanel } from './DAGNodeInfoPanel';
 import {
   selectedNodeIdsAtom,
   selectedOperatorLabelAtom,
+  selectedNodeDataAtom,
   edgeWidthConfigAtom,
   edgeColoringAtom,
   edgeColorPaletteAtom,
   selectedEdgeWidthFieldAtom,
   selectedEdgeColorFieldAtom,
 } from '@/atoms/dag';
+import { parseCustomStatistics } from '@/lib/queryBundle.utils';
 import { continuousColor } from '@/services/colors';
 import { useTheme, THEME_DARK } from '@/contexts/ThemeContext';
 import { inferFieldFormatter } from '@/services/query-plan/dagFieldProcessing';
@@ -288,6 +291,7 @@ const FlowLayout = ({
   const { fitView } = useReactFlow();
   const setSelectedNodeIds = useSetAtom(selectedNodeIdsAtom);
   const setSelectedOperatorLabel = useSetAtom(selectedOperatorLabelAtom);
+  const setSelectedNodeData = useSetAtom(selectedNodeDataAtom);
   const selectedNodeIds = useAtomValue(selectedNodeIdsAtom);
   const hasUserInteracted = useRef(false);
 
@@ -342,13 +346,26 @@ const FlowLayout = ({
       if (selectedNodeIds.has(node.id)) {
         setSelectedNodeIds(new Set());
         setSelectedOperatorLabel(null);
+        setSelectedNodeData(null);
       } else {
         setSelectedNodeIds(new Set([node.id]));
         setSelectedOperatorLabel(node.data.label);
+        setSelectedNodeData({
+          nodeId: node.id,
+          label: node.data.label,
+          operationType: node.data.operationType,
+          statistics: parseCustomStatistics(node.data.metadata?.rawNode),
+        });
       }
     },
-    [selectedNodeIds, setSelectedNodeIds, setSelectedOperatorLabel]
+    [selectedNodeIds, setSelectedNodeIds, setSelectedOperatorLabel, setSelectedNodeData]
   );
+
+  const handlePaneClick = useCallback(() => {
+    setSelectedNodeIds(new Set());
+    setSelectedOperatorLabel(null);
+    setSelectedNodeData(null);
+  }, [setSelectedNodeIds, setSelectedOperatorLabel, setSelectedNodeData]);
 
   // Re-fit view when the react-flow container is resized, but only if the user
   // hasn't interacted with the chart (to maintain any focus states applied)
@@ -389,6 +406,7 @@ const FlowLayout = ({
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       onNodeClick={handleNodeClick}
+      onPaneClick={handlePaneClick}
       onMoveStart={handleMoveStart}
       proOptions={{ hideAttribution: true }}
       nodeTypes={nodeTypes}
@@ -400,6 +418,7 @@ const FlowLayout = ({
     >
       <Background />
       <DAGLegend />
+      <DAGNodeInfoPanel />
       <MiniMap
         pannable
         zoomable

--- a/ui/src/components/dag/DAGNodeInfoPanel.tsx
+++ b/ui/src/components/dag/DAGNodeInfoPanel.tsx
@@ -1,45 +1,41 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
-import { StatValue } from '@/services/query-plan/types';
+import { Panel } from '@xyflow/react';
+import { useAtomValue } from 'jotai';
+import { Pin } from 'lucide-react';
+import { selectedNodeIdsAtom, hoveredNodeDataAtom, selectedNodeDataAtom } from '@/atoms/dag';
 import { DataText } from '@/components/ui/data-text';
 
-export interface OperatorStatisticsPopupProps {
-  children: React.ReactNode;
-  data: Array<{ key: string; value: StatValue }>;
-  nodeId: string;
-  operatorLabel: string;
-  operationType: string;
-}
+export const DAGNodeInfoPanel = () => {
+  const selectedNodeIds = useAtomValue(selectedNodeIdsAtom);
+  const hoveredNodeData = useAtomValue(hoveredNodeDataAtom);
+  const selectedNodeData = useAtomValue(selectedNodeDataAtom);
 
-export const OperatorStatisticsPopup = ({
-  children,
-  data,
-  nodeId,
-  operatorLabel,
-  operationType,
-}: OperatorStatisticsPopupProps) => {
+  const isPinned = selectedNodeIds.size > 0;
+  const displayData = isPinned ? selectedNodeData : hoveredNodeData;
+
+  if (!displayData) return null;
+
   return (
-    <HoverCard openDelay={300} closeDelay={100}>
-      {/* nodrag/nopan prevents ReactFlow from intercepting mouse events on the trigger */}
-      <HoverCardTrigger asChild className="nodrag nopan">
-        {children}
-      </HoverCardTrigger>
-      <HoverCardContent className="flex w-72 flex-col gap-1.5">
-        <div className="flex items-center justify-between">
-          <DataText className="font-semibold text-sm">{operatorLabel}</DataText>
-          <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded">
-            {operationType}
-          </DataText>
+    <Panel position="bottom-left" className="nodrag nopan mb-2 ml-2">
+      <div className="w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md">
+        <div className="flex items-center justify-between gap-2">
+          <DataText className="font-semibold text-sm truncate">{displayData.label}</DataText>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {isPinned && <Pin className="h-3 w-3 text-muted-foreground" />}
+            <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded">
+              {displayData.operationType}
+            </DataText>
+          </div>
         </div>
-        <DataText as="div" className="text-xs text-muted-foreground truncate">
-          {nodeId}
+        <DataText as="div" className="text-xs text-muted-foreground truncate mt-0.5">
+          {displayData.nodeId}
         </DataText>
-        {data.length > 0 && (
+        {displayData.statistics.length > 0 && (
           <div className="mt-1 border-t pt-1.5 max-h-56 overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
             <div className="flex flex-col gap-1 pr-3">
-              {data.map(({ key, value }) => (
+              {displayData.statistics.map(({ key, value }) => (
                 <div key={key} className="text-xs mt-1">
                   {Array.isArray(value) ? (
                     <div className="flex items-center justify-between gap-0.5">
@@ -63,7 +59,7 @@ export const OperatorStatisticsPopup = ({
             </div>
           </div>
         )}
-      </HoverCardContent>
-    </HoverCard>
+      </div>
+    </Panel>
   );
 };

--- a/ui/src/components/dag/DAGNodeInfoPanel.tsx
+++ b/ui/src/components/dag/DAGNodeInfoPanel.tsx
@@ -18,7 +18,11 @@ export const DAGNodeInfoPanel = () => {
   if (!displayData) return null;
 
   return (
-    <Panel position="bottom-left" className="nodrag nopan mb-2 ml-2">
+    <Panel
+      position="bottom-left"
+      className="nodrag nopan mb-2 ml-2"
+      style={isPinned ? undefined : { pointerEvents: 'none' }}
+    >
       <div className="w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md">
         <div className="flex items-center justify-between gap-2">
           <DataText className="font-semibold text-sm truncate">{displayData.label}</DataText>

--- a/ui/src/components/query-plan/QueryPlanNode.tsx
+++ b/ui/src/components/query-plan/QueryPlanNode.tsx
@@ -80,7 +80,12 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
       className={nodeVariants({ selected: isSelected, dimmed: isDimmed })}
       onMouseEnter={() => {
         setIsHovered(true);
-        setHoveredNodeData({ nodeId: data.nodeId, label: data.label, operationType: data.operationType, statistics });
+        setHoveredNodeData({
+          nodeId: data.nodeId,
+          label: data.label,
+          operationType: data.operationType,
+          statistics,
+        });
       }}
       onMouseLeave={() => {
         setIsHovered(false);

--- a/ui/src/components/query-plan/QueryPlanNode.tsx
+++ b/ui/src/components/query-plan/QueryPlanNode.tsx
@@ -5,10 +5,9 @@ import { memo, useState, useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Handle, Position } from '@xyflow/react';
 import { cva } from 'class-variance-authority';
-import { useAtomValue } from 'jotai';
-import { selectedNodeLabelFieldAtom, NODE_LABEL_FIELD } from '@/atoms/dag';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { selectedNodeLabelFieldAtom, NODE_LABEL_FIELD, hoveredNodeDataAtom } from '@/atoms/dag';
 import { Operator } from '~quent/types/Operator';
-import { OperatorStatisticsPopup } from './OperatorStatisticsPopup';
 import { parseCustomStatistics } from '@/lib/queryBundle.utils.ts';
 import { isLightColor, withOpacity, WHITE, BLACK } from '@/services/colors';
 import { useNodeColoring } from '@/hooks/useNodeColoring';
@@ -29,7 +28,7 @@ export interface QueryPlanNodeData extends Record<string, unknown> {
 }
 
 const nodeVariants = cva(
-  'px-4 py-2 rounded-md border-1 min-w-[180px] max-w-[250px] transition cursor-pointer text-foreground z-10',
+  'px-4 py-2 rounded-md border-1 min-w-[180px] max-w-[250px] transition cursor-pointer text-foreground z-10 nodrag nopan',
   {
     variants: {
       selected: {
@@ -54,6 +53,7 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
   const nodeLabelField = useAtomValue(selectedNodeLabelFieldAtom);
   const { fieldColor, isDimmed, isSelected, colorField } = useNodeColoring(operatorId);
   const [isHovered, setIsHovered] = useState(false);
+  const setHoveredNodeData = useSetAtom(hoveredNodeDataAtom);
 
   const resolvedLabel = useMemo(() => {
     if (nodeLabelField === NODE_LABEL_FIELD.ID) return data.metadata?.rawNode?.id ?? data.nodeId;
@@ -78,8 +78,14 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
   const nodeContent = (
     <div
       className={nodeVariants({ selected: isSelected, dimmed: isDimmed })}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseEnter={() => {
+        setIsHovered(true);
+        setHoveredNodeData({ nodeId: data.nodeId, label: data.label, operationType: data.operationType, statistics });
+      }}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        setHoveredNodeData(null);
+      }}
       style={
         {
           borderColor: activeColor,
@@ -122,16 +128,7 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
     </div>
   );
 
-  return (
-    <OperatorStatisticsPopup
-      data={statistics}
-      nodeId={data.nodeId}
-      operatorLabel={data.label}
-      operationType={data.operationType}
-    >
-      {nodeContent}
-    </OperatorStatisticsPopup>
-  );
+  return nodeContent;
 });
 
 QueryPlanNode.displayName = 'QueryPlanNode';


### PR DESCRIPTION
Through testing we found the existing operator statistics pop-up to be too intrusive when trying to explore/navigate the DAG. We looked through several potential designs and decided to re-write it as a panel, fixed to the bottom-left side of the DAG. Some notes:

- Hovering over a node will update the data that is displayed in the panel to show statistics for that specific node
- Hovering over blank space empties the panel
- Clicking on a node to select it will cause that node's statistics to stay in the panel, allowing the user to interact with it
- To dismiss a selected node, click anywhere in the DAG chart

Fixes: #103
