### PR TITLE
fix(ui): stop timeline zoom once limit is reached

### DIFF
--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -253,6 +253,12 @@ export function Timeline({
     return Math.min(100, (MIN_ZOOM_WINDOW_S / durationSeconds) * 100);
   }, [durationSeconds]);
 
+  // Kept in sync via the ECharts datazoom event (no React render-cycle lag) so the
+  // capture listener can reliably block shift+wheel-in the moment the limit is reached.
+  const minZoomSpanPctRef = useRef(minZoomSpanPct);
+  minZoomSpanPctRef.current = minZoomSpanPct;
+  const atZoomLimitRef = useRef(false);
+
   const eChartOptions: EChartsOption = useMemo(() => {
     return {
       animation: false,
@@ -357,6 +363,18 @@ export function Timeline({
     instanceRef.current = instance;
     connectChart(instance, CHART_GROUP, false);
 
+    // Update atZoomLimitRef synchronously from the ECharts datazoom event, which fires
+    // within the same event-dispatch tick as the wheel handler — before any React render.
+    // This avoids the one-tick stale-state window that windowMsRef.current has.
+    instance.on('datazoom', () => {
+      const opt = instance.getOption() as { dataZoom?: Array<{ start?: number; end?: number }> };
+      const dz = opt.dataZoom?.[0];
+      if (dz != null) {
+        const spanPct = (dz.end ?? 100) - (dz.start ?? 0);
+        atZoomLimitRef.current = spanPct <= minZoomSpanPctRef.current * 1.01;
+      }
+    });
+
     const dom = instance.getDom();
     dom.addEventListener('pointerdown', () => {
       isDraggingRef.current = true;
@@ -370,14 +388,15 @@ export function Timeline({
     // Without this, echarts' inside dataZoom calls preventDefault on all wheel events.
     // Also block shift+wheel-in when at the zoom limit so ECharts can't convert the
     // blocked zoom into a pan (zoomLock:true converts excess zoom delta into pan).
+    // atZoomLimitRef is kept current by the datazoom event listener above, which fires
+    // in the same synchronous tick as the ECharts canvas handler — no render-cycle lag.
     dom.addEventListener(
       'wheel',
       e => {
         if (!e.shiftKey) {
           e.stopPropagation();
-        } else if (e.deltaY < 0) {
-          const minWindowMs = MIN_ZOOM_WINDOW_S * 1_000;
-          if (windowMsRef.current <= minWindowMs * 1.01) e.stopPropagation();
+        } else if (e.deltaY < 0 && atZoomLimitRef.current) {
+          e.stopPropagation();
         }
       },
       { capture: true, passive: true }

--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -253,8 +253,6 @@ export function Timeline({
     return Math.min(100, (MIN_ZOOM_WINDOW_S / durationSeconds) * 100);
   }, [durationSeconds]);
 
-  // Kept in sync via the ECharts datazoom event (no React render-cycle lag) so the
-  // capture listener can reliably block shift+wheel-in the moment the limit is reached.
   const minZoomSpanPctRef = useRef(minZoomSpanPct);
   minZoomSpanPctRef.current = minZoomSpanPct;
   const atZoomLimitRef = useRef(false);
@@ -363,18 +361,6 @@ export function Timeline({
     instanceRef.current = instance;
     connectChart(instance, CHART_GROUP, false);
 
-    // Update atZoomLimitRef synchronously from the ECharts datazoom event, which fires
-    // within the same event-dispatch tick as the wheel handler — before any React render.
-    // This avoids the one-tick stale-state window that windowMsRef.current has.
-    instance.on('datazoom', () => {
-      const opt = instance.getOption() as { dataZoom?: Array<{ start?: number; end?: number }> };
-      const dz = opt.dataZoom?.[0];
-      if (dz != null) {
-        const spanPct = (dz.end ?? 100) - (dz.start ?? 0);
-        atZoomLimitRef.current = spanPct <= minZoomSpanPctRef.current * 1.01;
-      }
-    });
-
     const dom = instance.getDom();
     dom.addEventListener('pointerdown', () => {
       isDraggingRef.current = true;
@@ -384,12 +370,21 @@ export function Timeline({
       isDraggingRef.current = false;
     });
 
-    // Let non-shift wheel events pass through to the page for normal scrolling.
-    // Without this, echarts' inside dataZoom calls preventDefault on all wheel events.
-    // Also block shift+wheel-in when at the zoom limit so ECharts can't convert the
-    // blocked zoom into a pan (zoomLock:true converts excess zoom delta into pan).
-    // atZoomLimitRef is kept current by the datazoom event listener above, which fires
-    // in the same synchronous tick as the ECharts canvas handler — no render-cycle lag.
+    // Update atZoomLimitRef from ECharts' datazoom event, which fires synchronously
+    // within the same dispatch tick as the wheel handler — no React render-cycle lag.
+    instance.on('datazoom', () => {
+      const opt = instance.getOption() as { dataZoom?: Array<{ start?: number; end?: number }> };
+      const dz = opt.dataZoom?.[0];
+      if (dz != null) {
+        const spanPct = (dz.end ?? 100) - (dz.start ?? 0);
+        atZoomLimitRef.current = spanPct <= minZoomSpanPctRef.current * 1.01;
+      }
+    });
+
+    // Pass non-shift wheel events through to the page for normal scrolling.
+    // Without this, ECharts' inside dataZoom calls preventDefault on all wheel events.
+    // When at the zoom limit, also block shift+wheel-in before ECharts sees it —
+    // ECharts converts a blocked zoom into a pan, so we must stop it at the source.
     dom.addEventListener(
       'wheel',
       e => {
@@ -402,8 +397,7 @@ export function Timeline({
       { capture: true, passive: true }
     );
 
-    // Bubble-phase (fires after ECharts' canvas listener). Prevents the browser from handling
-    // shift+wheel zoom-in when ECharts can't act (e.g. zoom limit reached, pan disabled).
+    // Prevent the browser from handling shift+wheel-in when ECharts can't zoom further
     dom.addEventListener(
       'wheel',
       e => {

--- a/ui/src/components/timeline/Timeline.tsx
+++ b/ui/src/components/timeline/Timeline.tsx
@@ -19,7 +19,7 @@ import {
   TIMELINE_SPACING,
   TIMELINE_X_AXIS_ANIMATION,
 } from './types';
-import { connectChart, nanosToMs } from '@/lib/timeline.utils';
+import { connectChart, MIN_ZOOM_WINDOW_S, nanosToMs } from '@/lib/timeline.utils';
 import { useTimelineChartColors, TIMELINE_MONO_FONT } from './useTimelineChartColors';
 import { zoomRangeAtom } from '@/atoms/timeline';
 
@@ -248,6 +248,11 @@ export function Timeline({
     [gridBorderColor, gridBackgroundColor]
   );
 
+  const minZoomSpanPct = useMemo(() => {
+    if (durationSeconds <= 0) return 0;
+    return Math.min(100, (MIN_ZOOM_WINDOW_S / durationSeconds) * 100);
+  }, [durationSeconds]);
+
   const eChartOptions: EChartsOption = useMemo(() => {
     return {
       animation: false,
@@ -307,11 +312,18 @@ export function Timeline({
       yAxis: yAxisOptions,
       series: seriesOptions,
       dataZoom: [
-        { type: 'slider', show: false, realtime: true, filterMode: 'none' },
+        {
+          type: 'slider',
+          show: false,
+          realtime: true,
+          filterMode: 'none',
+          minSpan: minZoomSpanPct,
+        },
         {
           type: 'inside',
           zoomLock: true,
           zoomOnMouseWheel: false,
+          moveOnMouseWheel: false,
           throttle: 30,
           filterMode: 'none',
         },
@@ -322,12 +334,14 @@ export function Timeline({
           moveOnMouseWheel: false,
           throttle: 30,
           filterMode: 'none',
+          minSpan: minZoomSpanPct,
         },
       ],
     } as EChartsOption;
   }, [
     showTooltip,
     gridOptions,
+    minZoomSpanPct,
     xAxisOptions,
     yAxisOptions,
     seriesOptions,
@@ -354,12 +368,29 @@ export function Timeline({
 
     // Let non-shift wheel events pass through to the page for normal scrolling.
     // Without this, echarts' inside dataZoom calls preventDefault on all wheel events.
+    // Also block shift+wheel-in when at the zoom limit so ECharts can't convert the
+    // blocked zoom into a pan (zoomLock:true converts excess zoom delta into pan).
     dom.addEventListener(
       'wheel',
       e => {
-        if (!e.shiftKey) e.stopPropagation();
+        if (!e.shiftKey) {
+          e.stopPropagation();
+        } else if (e.deltaY < 0) {
+          const minWindowMs = MIN_ZOOM_WINDOW_S * 1_000;
+          if (windowMsRef.current <= minWindowMs * 1.01) e.stopPropagation();
+        }
       },
       { capture: true, passive: true }
+    );
+
+    // Bubble-phase (fires after ECharts' canvas listener). Prevents the browser from handling
+    // shift+wheel zoom-in when ECharts can't act (e.g. zoom limit reached, pan disabled).
+    dom.addEventListener(
+      'wheel',
+      e => {
+        if (e.shiftKey && e.deltaY < 0) e.preventDefault();
+      },
+      { passive: false }
     );
   }, []);
 

--- a/ui/src/components/timeline/TimelineController.tsx
+++ b/ui/src/components/timeline/TimelineController.tsx
@@ -14,6 +14,7 @@ import {
   connectChart,
   getAdaptiveNumBins,
   getTimelineXAxisIntervalMs,
+  MIN_ZOOM_WINDOW_S,
   nanosToMs,
   registerAxisPointerSync,
   unregisterAxisPointerSync,
@@ -212,6 +213,11 @@ export function TimelineController({
     [colors.gridBorderColor, colors.controllerGridBackgroundColor]
   );
 
+  const minZoomSpanPct = useMemo(() => {
+    if (durationSeconds <= 0) return 0;
+    return Math.min(100, (MIN_ZOOM_WINDOW_S / durationSeconds) * 100);
+  }, [durationSeconds]);
+
   const eChartOptions: EChartsOption = useMemo(() => {
     return {
       tooltip: { show: true, showContent: false, trigger: 'axis' },
@@ -227,6 +233,7 @@ export function TimelineController({
           xAxisIndex: [1],
           realtime: true,
           filterMode: 'none',
+          minSpan: minZoomSpanPct,
           top: 0,
           height: height - 24,
           brushSelect: true,
@@ -285,6 +292,7 @@ export function TimelineController({
           zoomOnMouseWheel: true,
           moveOnMouseMove: false,
           moveOnMouseWheel: false,
+          minSpan: minZoomSpanPct,
         },
       ],
       xAxis: [staticXAxisOptions, zoomXAxisOptions],
@@ -295,6 +303,7 @@ export function TimelineController({
     colors,
     gridOptions,
     height,
+    minZoomSpanPct,
     staticXAxisOptions,
     zoomXAxisOptions,
     yAxisOptions,

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -48,6 +48,10 @@ export function nanosToMs(ns: bigint): number {
   return Number(ns / 1_000_000n) + Number(ns % 1_000_000n) / 1_000_000;
 }
 
+/**
+ * Currently static but may be used in the future to prevent sub
+ * nanosecond bin sizes
+ */
 export function getAdaptiveNumBins(): number {
   return MAX_TIMELINE_BINS;
 }

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -30,18 +30,25 @@ import type { TimelineRequest } from '~quent/types/TimelineRequest';
 import type { TaskFilter } from '~quent/types/TaskFilter';
 import type { TimelineConfig } from '~quent/types/TimelineConfig';
 
-const MAX_TIMELINE_BINS = 400;
+export const MAX_TIMELINE_BINS = 400;
 const LONG_ENTITIES_BIN_MULTIPLIER = 30;
+
+/** Minimum bin duration in nanoseconds — prevents ECharts from stacking bins when zoomed too far. */
+export const MIN_BIN_DURATION_NS = 10;
+
+/**
+ * Minimum visible zoom window in seconds.
+ * Below this, each bin would cover less than MIN_BIN_DURATION_NS nanoseconds.
+ * 10 ns/bin × 400 bins = 4 μs
+ * TODO: lower back to (MIN_BIN_DURATION_NS * MAX_TIMELINE_BINS) / 1_000_000_000 after verification
+ */
+export const MIN_ZOOM_WINDOW_S = 0.020; // 20ms — temporary high value for testing
 
 /** Convert a nanosecond-precision bigint epoch to milliseconds, preserving sub-ms precision. */
 export function nanosToMs(ns: bigint): number {
   return Number(ns / 1_000_000n) + Number(ns % 1_000_000n) / 1_000_000;
 }
 
-/**
- * Currently static but may be used in the future to prevent sub
- * nanosecond bin sizes
- */
 export function getAdaptiveNumBins(): number {
   return MAX_TIMELINE_BINS;
 }

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -34,7 +34,7 @@ export const MAX_TIMELINE_BINS = 400;
 const LONG_ENTITIES_BIN_MULTIPLIER = 30;
 
 /** Minimum bin duration in nanoseconds — prevents ECharts from stacking bins when zoomed too far. */
-export const MIN_BIN_DURATION_NS = 10;
+export const MIN_BIN_DURATION_NS = 250;
 
 /**
  * Minimum visible zoom window in seconds.

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -40,9 +40,8 @@ export const MIN_BIN_DURATION_NS = 10;
  * Minimum visible zoom window in seconds.
  * Below this, each bin would cover less than MIN_BIN_DURATION_NS nanoseconds.
  * 10 ns/bin × 400 bins = 4 μs
- * TODO: lower back to (MIN_BIN_DURATION_NS * MAX_TIMELINE_BINS) / 1_000_000_000 after verification
  */
-export const MIN_ZOOM_WINDOW_S = 0.020; // 20ms — temporary high value for testing
+export const MIN_ZOOM_WINDOW_S = (MIN_BIN_DURATION_NS * MAX_TIMELINE_BINS) / 1_000_000_000;
 
 /** Convert a nanosecond-precision bigint epoch to milliseconds, preserving sub-ms precision. */
 export function nanosToMs(ns: bigint): number {


### PR DESCRIPTION
Creates a minimum zoom window and stops timelines from scrolling at that point. Also needed to stop the shift+scroll from panning once you could not zoom any further - this seemed to be the default echarts functionality. Additionally, prevents the browser from catching this event once echarts cannot intercept and using it to zoom in on the webpage. See comments for additional information.

Fixes: #46 