### PR TITLE
fix!: Export stdlib entities under their module paths

### DIFF
--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -917,7 +917,7 @@ fn emit_state_flat_args(
         let resource_id_field = format_ident!("{}_resource_id", usage.field_name);
         let alias = format_ident!("__{}Capacity", to_pascal_case(&usage.field_name));
         // Resource type paths may be bare names (e.g., "Queue") for types in the
-        // same crate, or qualified (e.g., "quent_stdlib::Processor"). Bare names
+        // same crate, or qualified (e.g., "quent_stdlib::processor::Processor"). Bare names
         // need to be resolved against the component's module path.
         let resource_ty: syn::Type = {
             let path = &usage.resource_type_path;

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -10,7 +10,7 @@
 //!         root: ResourceRoot,
 //!         quent_query_engine_model::Engine,
 //!         task::Task,
-//!         quent_stdlib::Memory,
+//!         quent_stdlib::memory::Memory,
 //!     }
 //! }
 //! ```

--- a/crates/model/src/model.rs
+++ b/crates/model/src/model.rs
@@ -129,7 +129,7 @@ pub enum TransitionEndpoint {
 pub struct UsageDef {
     pub field_name: String,
     pub resource_name: String,
-    /// Rust path to the resource marker type (e.g., "quent_stdlib::ProcessorResource").
+    /// Rust path to the resource marker type (e.g., "quent_stdlib::processor::ProcessorResource").
     /// The codegen uses `<T as Resource>::CapacityValue` to get the operating state type.
     pub resource_type_path: String,
 }

--- a/crates/model/tests/cross_crate_composition.rs
+++ b/crates/model/tests/cross_crate_composition.rs
@@ -27,9 +27,9 @@ quent_model::entity! {
 // Application-specific types using stdlib resources
 
 // Use the resource marker types for Usage<T>
-type WorkerMemory = quent_stdlib::MemoryResource;
-type Thread = quent_stdlib::ProcessorResource;
-type FsToMem = quent_stdlib::ChannelResource;
+type WorkerMemory = quent_stdlib::memory::MemoryResource;
+type Thread = quent_stdlib::processor::ProcessorResource;
+type FsToMem = quent_stdlib::channel::ChannelResource;
 
 // Application FSM using stdlib resource types
 
@@ -85,9 +85,9 @@ type DomainModel = Model<(Engine, Operator)>;
 type AppModel = Model<(
     DomainModel,
     Task,
-    quent_stdlib::Memory,
-    quent_stdlib::Processor,
-    quent_stdlib::Channel,
+    quent_stdlib::memory::Memory,
+    quent_stdlib::processor::Processor,
+    quent_stdlib::channel::Channel,
 )>;
 
 // Tests
@@ -110,7 +110,7 @@ fn ref_type_safety() {
 fn usage_with_stdlib_memory() {
     let usage: Usage<WorkerMemory> = Usage {
         resource_id: Ref::new(Uuid::nil()),
-        capacity: quent_stdlib::MemoryOperating {
+        capacity: quent_stdlib::memory::MemoryOperating {
             capacity_bytes: Capacity::new(Some(1024 * 1024)),
         },
     };
@@ -122,7 +122,7 @@ fn usage_with_stdlib_processor() {
     let _usage: Usage<Thread> = Usage {
         resource_id: Ref::new(Uuid::nil()),
         // ProcessorOperating is a unit struct (no capacity fields)
-        capacity: quent_stdlib::ProcessorOperating {},
+        capacity: quent_stdlib::processor::ProcessorOperating {},
     };
 }
 
@@ -130,7 +130,7 @@ fn usage_with_stdlib_processor() {
 fn usage_with_stdlib_channel() {
     let _usage: Usage<FsToMem> = Usage {
         resource_id: Ref::new(Uuid::nil()),
-        capacity: quent_stdlib::ChannelOperating {
+        capacity: quent_stdlib::channel::ChannelOperating {
             capacity_bytes: Capacity::new(Some(4096)),
         },
     };
@@ -230,7 +230,7 @@ fn fsm_event_serde_roundtrip() {
         state: TaskTransition::Sending(Sending {
             channel: Some(Usage {
                 resource_id: Ref::new(Uuid::nil()),
-                capacity: quent_stdlib::ChannelOperating {
+                capacity: quent_stdlib::channel::ChannelOperating {
                     capacity_bytes: Capacity::new(Some(1024)),
                 },
             }),

--- a/crates/model/tests/state_macro.rs
+++ b/crates/model/tests/state_macro.rs
@@ -20,8 +20,8 @@ quent_model::state! {
 quent_model::state! {
     Computing {
         usages: {
-            thread: quent_stdlib::Processor,
-            memory: quent_stdlib::Memory,
+            thread: quent_stdlib::processor::Processor,
+            memory: quent_stdlib::memory::Memory,
         },
     }
 }
@@ -59,11 +59,11 @@ fn state_macro_generates_usage_struct() {
     let c = Computing {
         thread: Some(quent_model::Usage {
             resource_id: Ref::new(Uuid::nil()),
-            capacity: quent_stdlib::ProcessorOperating {},
+            capacity: quent_stdlib::processor::ProcessorOperating {},
         }),
         memory: Some(quent_model::Usage {
             resource_id: Ref::new(Uuid::nil()),
-            capacity: quent_stdlib::MemoryOperating {
+            capacity: quent_stdlib::memory::MemoryOperating {
                 capacity_bytes: quent_model::Capacity::new(Some(1024)),
             },
         }),
@@ -128,11 +128,11 @@ fn flat_args_handle_transition() {
     let mut handle = observer.queued(id, "my_task", 5);
 
     handle.computing(
-        Some(quent_model::usage(Ref::<quent_stdlib::Processor>::new(
-            Uuid::nil(),
-        ))),
+        Some(quent_model::usage(
+            Ref::<quent_stdlib::processor::Processor>::new(Uuid::nil()),
+        )),
         Some(quent_model::usage((
-            Ref::<quent_stdlib::Memory>::new(Uuid::nil()),
+            Ref::<quent_stdlib::memory::Memory>::new(Uuid::nil()),
             2048,
         ))),
     );
@@ -155,11 +155,11 @@ fn extract_usages() {
     let c = Computing {
         thread: Some(quent_model::Usage {
             resource_id: Ref::new(Uuid::from_u128(1)),
-            capacity: quent_stdlib::ProcessorOperating {},
+            capacity: quent_stdlib::processor::ProcessorOperating {},
         }),
         memory: Some(quent_model::Usage {
             resource_id: Ref::new(Uuid::from_u128(2)),
-            capacity: quent_stdlib::MemoryOperating {
+            capacity: quent_stdlib::memory::MemoryOperating {
                 capacity_bytes: quent_model::Capacity::new(Some(4096)),
             },
         }),
@@ -177,7 +177,7 @@ fn extract_usages_skips_none() {
         thread: None,
         memory: Some(quent_model::Usage {
             resource_id: Ref::new(Uuid::from_u128(2)),
-            capacity: quent_stdlib::MemoryOperating {
+            capacity: quent_stdlib::memory::MemoryOperating {
                 capacity_bytes: quent_model::Capacity::new(Some(4096)),
             },
         }),

--- a/crates/stdlib/src/lib.rs
+++ b/crates/stdlib/src/lib.rs
@@ -8,10 +8,6 @@
 //! - [`Processor`]: unit resource for computation
 //! - [`Channel`]: unidirectional data transfer resource with `bytes` capacity
 
-mod channel;
-mod memory;
-mod processor;
-
-pub use channel::*;
-pub use memory::*;
-pub use processor::*;
+pub mod channel;
+pub mod memory;
+pub mod processor;

--- a/crates/stdlib/tests/stdlib_types.rs
+++ b/crates/stdlib/tests/stdlib_types.rs
@@ -8,47 +8,47 @@ use uuid::Uuid;
 
 #[test]
 fn memory_types_exist() {
-    let _init = quent_stdlib::MemoryInitializing {
+    let _init = quent_stdlib::memory::MemoryInitializing {
         instance_name: "test".into(),
         parent_group_id: Uuid::nil(),
         resource_type_name: "memory".into(),
     };
-    let _op = quent_stdlib::MemoryOperating {
+    let _op = quent_stdlib::memory::MemoryOperating {
         capacity_bytes: Capacity::new(Some(1024)),
     };
-    let _fin = quent_stdlib::MemoryFinalizing;
+    let _fin = quent_stdlib::memory::MemoryFinalizing;
 }
 
 #[test]
 fn processor_types_exist() {
-    let _init = quent_stdlib::ProcessorInitializing {
+    let _init = quent_stdlib::processor::ProcessorInitializing {
         instance_name: "cpu0".into(),
         parent_group_id: Uuid::nil(),
         resource_type_name: "processor".into(),
     };
-    let _op = quent_stdlib::ProcessorOperating;
-    let _fin = quent_stdlib::ProcessorFinalizing;
+    let _op = quent_stdlib::processor::ProcessorOperating;
+    let _fin = quent_stdlib::processor::ProcessorFinalizing;
 }
 
 #[test]
 fn channel_types_exist() {
-    let _init = quent_stdlib::ChannelInitializing {
+    let _init = quent_stdlib::channel::ChannelInitializing {
         instance_name: "ch0".into(),
         parent_group_id: Uuid::nil(),
         resource_type_name: "channel".into(),
         source_id: Uuid::nil(),
         target_id: Uuid::nil(),
     };
-    let _op = quent_stdlib::ChannelOperating {
+    let _op = quent_stdlib::channel::ChannelOperating {
         capacity_bytes: Capacity::new(Some(4096)),
     };
-    let _fin = quent_stdlib::ChannelFinalizing;
+    let _fin = quent_stdlib::channel::ChannelFinalizing;
 }
 
 #[test]
 fn memory_model_component() {
     let mut builder = ModelBuilder::new("test");
-    quent_stdlib::Memory::collect(&mut builder);
+    quent_stdlib::memory::Memory::collect(&mut builder);
     assert_eq!(builder.fsms.len(), 1);
     assert_eq!(builder.fsms[0].name, "memory");
 }
@@ -56,7 +56,7 @@ fn memory_model_component() {
 #[test]
 fn processor_model_component() {
     let mut builder = ModelBuilder::new("test");
-    quent_stdlib::Processor::collect(&mut builder);
+    quent_stdlib::processor::Processor::collect(&mut builder);
     assert_eq!(builder.fsms.len(), 1);
     assert_eq!(builder.fsms[0].name, "processor");
 }
@@ -64,7 +64,7 @@ fn processor_model_component() {
 #[test]
 fn channel_model_component() {
     let mut builder = ModelBuilder::new("test");
-    quent_stdlib::Channel::collect(&mut builder);
+    quent_stdlib::channel::Channel::collect(&mut builder);
     assert_eq!(builder.fsms.len(), 1);
     assert_eq!(builder.fsms[0].name, "channel");
 }
@@ -72,7 +72,7 @@ fn channel_model_component() {
 #[test]
 fn resizable_memory_model_component() {
     let mut builder = ModelBuilder::new("test");
-    quent_stdlib::ResizableMemory::collect(&mut builder);
+    quent_stdlib::memory::ResizableMemory::collect(&mut builder);
     assert_eq!(builder.fsms.len(), 1);
     let fsm = &builder.fsms[0];
     assert_eq!(fsm.name, "resizable_memory");
@@ -83,8 +83,8 @@ fn resizable_memory_model_component() {
 #[test]
 fn resource_markers_exist() {
     fn assert_resource<T: Resource>() {}
-    assert_resource::<quent_stdlib::MemoryResource>();
-    assert_resource::<quent_stdlib::ProcessorResource>();
-    assert_resource::<quent_stdlib::ChannelResource>();
-    assert_resource::<quent_stdlib::ResizableMemoryResource>();
+    assert_resource::<quent_stdlib::memory::MemoryResource>();
+    assert_resource::<quent_stdlib::processor::ProcessorResource>();
+    assert_resource::<quent_stdlib::channel::ChannelResource>();
+    assert_resource::<quent_stdlib::memory::ResizableMemoryResource>();
 }

--- a/examples/simulator/analyzer/src/model.rs
+++ b/examples/simulator/analyzer/src/model.rs
@@ -325,10 +325,10 @@ impl SimulatorModelBuilder {
         &mut self,
         id: Uuid,
         timestamp: quent_time::TimeUnixNanoSec,
-        event: quent_stdlib::MemoryEvent,
+        event: quent_stdlib::memory::MemoryEvent,
     ) -> AnalyzerResult<()> {
         let state = event.state;
-        use quent_stdlib::MemoryTransition;
+        use quent_stdlib::memory::MemoryTransition;
         match state {
             MemoryTransition::MemoryInitializing(init) => {
                 self.arbitrary_resources
@@ -365,10 +365,10 @@ impl SimulatorModelBuilder {
         &mut self,
         id: Uuid,
         timestamp: quent_time::TimeUnixNanoSec,
-        event: quent_stdlib::ProcessorEvent,
+        event: quent_stdlib::processor::ProcessorEvent,
     ) -> AnalyzerResult<()> {
         let state = event.state;
-        use quent_stdlib::ProcessorTransition;
+        use quent_stdlib::processor::ProcessorTransition;
         match state {
             ProcessorTransition::ProcessorInitializing(init) => {
                 self.arbitrary_resources
@@ -402,10 +402,10 @@ impl SimulatorModelBuilder {
         &mut self,
         id: Uuid,
         timestamp: quent_time::TimeUnixNanoSec,
-        event: quent_stdlib::ChannelEvent,
+        event: quent_stdlib::channel::ChannelEvent,
     ) -> AnalyzerResult<()> {
         let state = event.state;
-        use quent_stdlib::ChannelTransition;
+        use quent_stdlib::channel::ChannelTransition;
         match state {
             ChannelTransition::ChannelInitializing(init) => {
                 self.arbitrary_resources

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -504,9 +504,9 @@ struct Worker {
     thread_pool: Uuid,
     threads: Vec<Uuid>,
     // Resource handles — kept alive until shut_down().
-    memory_handles: Vec<quent_stdlib::MemoryHandle<SimulatorEvent>>,
-    channel_handles: Vec<quent_stdlib::ChannelHandle<SimulatorEvent>>,
-    processor_handles: Vec<quent_stdlib::ProcessorHandle<SimulatorEvent>>,
+    memory_handles: Vec<quent_stdlib::memory::MemoryHandle<SimulatorEvent>>,
+    channel_handles: Vec<quent_stdlib::channel::ChannelHandle<SimulatorEvent>>,
+    processor_handles: Vec<quent_stdlib::processor::ProcessorHandle<SimulatorEvent>>,
 }
 
 impl Worker {
@@ -1026,7 +1026,7 @@ struct Engine {
     workers: HashMap<Uuid, Worker>,
     network: Uuid,
     network_links: HashMap<(Uuid, Uuid), Uuid>,
-    network_link_handles: Vec<quent_stdlib::ChannelHandle<SimulatorEvent>>,
+    network_link_handles: Vec<quent_stdlib::channel::ChannelHandle<SimulatorEvent>>,
 }
 
 impl Engine {

--- a/examples/simulator/instrumentation/src/lib.rs
+++ b/examples/simulator/instrumentation/src/lib.rs
@@ -29,9 +29,9 @@ model! {
         task::Task,
         ThreadPool,
         Network,
-        quent_stdlib::Memory,
-        quent_stdlib::Processor,
-        quent_stdlib::Channel,
+        quent_stdlib::memory::Memory,
+        quent_stdlib::processor::Processor,
+        quent_stdlib::channel::Channel,
     }
 }
 

--- a/examples/simulator/instrumentation/src/task.rs
+++ b/examples/simulator/instrumentation/src/task.rs
@@ -23,8 +23,8 @@ state! {
 state! {
     Computing {
         usages: {
-            use_thread: quent_stdlib::Processor,
-            use_memory: quent_stdlib::Memory,
+            use_thread: quent_stdlib::processor::Processor,
+            use_memory: quent_stdlib::memory::Memory,
         },
     }
 }
@@ -32,7 +32,7 @@ state! {
 state! {
     Allocating {
         usages: {
-            use_thread: quent_stdlib::Processor,
+            use_thread: quent_stdlib::processor::Processor,
         },
     }
 }
@@ -40,9 +40,9 @@ state! {
 state! {
     Loading {
         usages: {
-            use_thread: quent_stdlib::Processor,
-            use_fs_to_mem: quent_stdlib::Channel,
-            use_memory: quent_stdlib::Memory,
+            use_thread: quent_stdlib::processor::Processor,
+            use_fs_to_mem: quent_stdlib::channel::Channel,
+            use_memory: quent_stdlib::memory::Memory,
         },
     }
 }
@@ -50,8 +50,8 @@ state! {
 state! {
     Spilling {
         usages: {
-            use_thread: quent_stdlib::Processor,
-            use_mem_to_fs: quent_stdlib::Channel,
+            use_thread: quent_stdlib::processor::Processor,
+            use_mem_to_fs: quent_stdlib::channel::Channel,
         },
     }
 }
@@ -59,8 +59,8 @@ state! {
 state! {
     Sending {
         usages: {
-            use_thread: quent_stdlib::Processor,
-            use_link: quent_stdlib::Channel,
+            use_thread: quent_stdlib::processor::Processor,
+            use_link: quent_stdlib::channel::Channel,
         },
     }
 }


### PR DESCRIPTION
Exports stdlib entities under their module paths, same as how it is done for the query engine domain entities:  https://github.com/rapidsai/quent/blob/c5508d77ff2a726315ff9d9b9211c4f317868253/domains/query_engine/model/src/lib.rs#L8-L14

This allows consistent re-exports: https://github.com/sirius-db/sirius/pull/648/changes#diff-8f6110d51df61b895aec59a39ab0eb4e79e2e98e7e99ede2a06e31b75d911ad9