### PR TITLE
feat!: Remove global sender in favor of explicit threading of context

### DIFF
--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -435,29 +435,34 @@ fn emit_uuid_bridge(model: &ModelBuilder, model_name: &str, options: &CxxOptions
 
 /// Generate the context bridge module.
 ///
-/// The context is created once and stores the event sender in a global static.
-/// This avoids the need to share opaque Rust types across CXX bridge modules.
+/// The `Context` owns the inner quent context and exposes a sender accessor.
+/// C++ callers retain the returned `Box<Context>` and pass a reference to
+/// each observer/FSM factory, which extracts the sender from it.
 fn emit_context_bridge(model_name: &str, options: &CxxOptions) -> GeneratedFile {
     let ns = &options.namespace;
     let q = quent_path(model_name, options);
     let event_type: syn::Type = syn::parse_str(&options.event_type(model_name)).unwrap();
     let uuid_include = format!("{}/{}/uuid.rs.h", options.crate_name, options.bridge_path);
+    let context_type_id = format!("{ns}::Context");
 
     // Rust impl part — formatted via prettyplease.
     let impl_tokens = quote! {
-        /// Global event sender, initialized by `create_context`.
-        /// Returns a noop sender if context has not been created yet.
-        static SENDER: OnceLock<#q::EventSender<#event_type>> = OnceLock::new();
-
         pub struct Context {
-            _inner: #q::Context<#event_type>,
+            inner: #q::Context<#event_type>,
         }
 
-        pub fn global_sender() -> #q::EventSender<#event_type> {
-            SENDER
-                .get()
-                .cloned()
-                .unwrap_or_default()
+        impl Context {
+            pub fn events_sender(&self) -> #q::EventSender<#event_type> {
+                self.inner.events_sender()
+            }
+        }
+
+        // Shared across bridges: other bridge modules declare `type Context;`
+        // and CXX uses this `ExternType` impl to point at the C++ class
+        // generated here instead of emitting a duplicate.
+        unsafe impl ::cxx::ExternType for Context {
+            type Id = ::cxx::type_id!(#context_type_id);
+            type Kind = ::cxx::kind::Opaque;
         }
 
         pub fn create_context(id: ffi::UUID, exporter: String, output_dir: String) -> Result<Box<Context>, String> {
@@ -471,10 +476,7 @@ fn emit_context_bridge(model_name: &str, options: &CxxOptions) -> GeneratedFile 
             };
             let inner = #q::Context::try_new(#q::uuid::Uuid::from(id), opts)
                 .map_err(|e| e.to_string())?;
-            SENDER.set(inner.events_sender()).map_err(|_| {
-                "context already created — only one context per process is supported".to_string()
-            })?;
-            Ok(Box::new(Context { _inner: inner }))
+            Ok(Box::new(Context { inner }))
         }
     };
 
@@ -500,12 +502,7 @@ pub mod ffi {{
 "#
     );
 
-    // Combine: the ffi block is raw string, impl part is pretty-printed.
-    let content = format!(
-        "use std::sync::OnceLock;\n{}\n{}",
-        ffi_block,
-        pretty_print(impl_tokens)
-    );
+    let content = format!("{}\n{}", ffi_block, pretty_print(impl_tokens));
 
     GeneratedFile {
         name: "context.rs".to_string(),
@@ -520,12 +517,14 @@ pub mod ffi {{
 /// format these, so the ffi module is built as a string.
 fn build_ffi_module_string(
     ns: &str,
+    context_ns: &str,
     include_path: &str,
     shared_structs: &str,
     extern_rust_body: &str,
     uses_custom_attrs: bool,
 ) -> String {
     let ca_include = include_path.replace("uuid.rs.h", "custom_attributes.rs.h");
+    let context_include = include_path.replace("uuid.rs.h", "context.rs.h");
     let custom_attrs_types = if uses_custom_attrs {
         format!(
             r#"
@@ -543,6 +542,20 @@ fn build_ffi_module_string(
         String::new()
     };
 
+    // Context is an opaque Rust type owned by the context bridge. Other
+    // bridges reference it via extern "C++" + an ExternType impl in
+    // context.rs; declaring it here as extern "Rust" would duplicate the
+    // `RustType` impl and fail to compile.
+    let context_alias = format!(
+        r#"
+    #[namespace = "{context_ns}"]
+    unsafe extern "C++" {{
+        include!("{context_include}");
+        type Context = crate::bridge::context::Context;
+    }}
+"#
+    );
+
     format!(
         r#"#[cxx::bridge(namespace = "{ns}")]
 pub mod ffi {{
@@ -555,7 +568,7 @@ pub mod ffi {{
         include!("{include_path}");
         type UUID = crate::bridge::uuid::ffi::UUID;
     }}
-{custom_attrs_types}
+{custom_attrs_types}{context_alias}
 {shared_structs}    extern "Rust" {{
 {extern_rust_body}    }}
 }}
@@ -750,7 +763,7 @@ fn emit_entity_bridge(
     let mut extern_rust_body = String::new();
     extern_rust_body.push_str(&format!("        type {observer_name_str};\n\n"));
     extern_rust_body.push_str(&format!(
-        "        fn create_observer() -> Box<{observer_name_str}>;\n"
+        "        fn create_observer(ctx: &Context) -> Box<{observer_name_str}>;\n"
     ));
 
     // Token streams for impl code (standard Rust)
@@ -813,6 +826,7 @@ fn emit_entity_bridge(
         .any(|ev| attrs_use_custom_attributes(&ev.attributes));
     let ffi_module = build_ffi_module_string(
         &ns,
+        &options.namespace,
         &include_path,
         &shared_structs_str,
         &extern_rust_body,
@@ -829,9 +843,9 @@ fn emit_entity_bridge(
             #(#observer_impl_methods)*
         }
 
-        pub fn create_observer() -> Box<#observer_name> {
+        pub fn create_observer(ctx: &super::context::Context) -> Box<#observer_name> {
             Box::new(#observer_name {
-                tx: super::context::global_sender(),
+                tx: ctx.events_sender(),
             })
         }
     };
@@ -1018,10 +1032,12 @@ fn emit_fsm_bridge(fsm: &FsmDef, model_name: &str, options: &CxxOptions) -> Gene
     // Factory method
     if has_entry_data {
         extern_rust_body.push_str(&format!(
-            "        fn create(data: {entry_pascal_str}) -> Box<{handle_name_str}>;\n"
+            "        fn create(ctx: &Context, data: {entry_pascal_str}) -> Box<{handle_name_str}>;\n"
         ));
     } else {
-        extern_rust_body.push_str(&format!("        fn create() -> Box<{handle_name_str}>;\n"));
+        extern_rust_body.push_str(&format!(
+            "        fn create(ctx: &Context) -> Box<{handle_name_str}>;\n"
+        ));
     }
 
     // Transition methods (skip entry state — handled by factory)
@@ -1048,6 +1064,7 @@ fn emit_fsm_bridge(fsm: &FsmDef, model_name: &str, options: &CxxOptions) -> Gene
         .any(|s| attrs_use_custom_attributes(&s.attributes));
     let ffi_module = build_ffi_module_string(
         &ns,
+        &options.namespace,
         &include_path,
         &shared_structs_str,
         &extern_rust_body,
@@ -1087,9 +1104,9 @@ fn emit_fsm_bridge(fsm: &FsmDef, model_name: &str, options: &CxxOptions) -> Gene
     let factory_fn = if has_entry_data {
         let (stmts, args) = emit_state_flat_args(entry_state, &q, &remapped);
         quote! {
-            pub fn create(data: ffi::#entry_pascal) -> Box<#handle_name> {
+            pub fn create(ctx: &super::context::Context, data: ffi::#entry_pascal) -> Box<#handle_name> {
                 #stmts
-                let obs = #component_mod::#observer_name::new(&super::context::global_sender());
+                let obs = #component_mod::#observer_name::new(&ctx.events_sender());
                 let id = #q::uuid::Uuid::now_v7();
                 Box::new(#handle_name {
                     inner: obs.#entry_name(id, #(#args),*),
@@ -1098,8 +1115,8 @@ fn emit_fsm_bridge(fsm: &FsmDef, model_name: &str, options: &CxxOptions) -> Gene
         }
     } else {
         quote! {
-            pub fn create() -> Box<#handle_name> {
-                let obs = #component_mod::#observer_name::new(&super::context::global_sender());
+            pub fn create(ctx: &super::context::Context) -> Box<#handle_name> {
+                let obs = #component_mod::#observer_name::new(&ctx.events_sender());
                 let id = #q::uuid::Uuid::now_v7();
                 Box::new(#handle_name {
                     inner: obs.#entry_name(id),

--- a/domains/query_engine/tests/cpp/cpp/src/main.cpp
+++ b/domains/query_engine/tests/cpp/cpp/src/main.cpp
@@ -22,7 +22,7 @@ int main() {
   auto ctx = quent::create_context(engine_id, "ndjson", "./events");
 
   // Engine: init with implementation attributes and custom attributes.
-  auto engine_obs = quent::engine::create_observer();
+  auto engine_obs = quent::engine::create_observer(*ctx);
 
   quent::CustomAttributes engine_custom;
   engine_custom.string_attrs.push_back({"deployment", "test"});
@@ -40,7 +40,7 @@ int main() {
                    });
 
   // Worker: init with parent engine reference.
-  auto worker_obs = quent::worker::create_observer();
+  auto worker_obs = quent::worker::create_observer(*ctx);
   auto worker_id = uuid::now_v7();
   worker_obs->init(worker_id, quent::worker::Init{
                                   .parent_engine_id = engine_id,
@@ -48,7 +48,7 @@ int main() {
                               });
 
   // QueryGroup: declaration with instance name and engine id.
-  auto qg_obs = quent::query_group::create_observer();
+  auto qg_obs = quent::query_group::create_observer(*ctx);
   auto qg_id = uuid::now_v7();
   qg_obs->declaration(qg_id, quent::query_group::Declaration{
                                  .instance_name = "qg-0",
@@ -56,16 +56,16 @@ int main() {
                              });
 
   // Query FSM: create in Init state, transition through planning and executing.
-  auto query = quent::query::create(quent::query::Init{
-      .instance_name = "select-1",
-      .query_group_id = qg_id,
-  });
+  auto query = quent::query::create(*ctx, quent::query::Init{
+                                              .instance_name = "select-1",
+                                              .query_group_id = qg_id,
+                                          });
   query->planning();
   query->executing();
   query->exit();
 
   // Plan: declaration with parent, edges, and optional worker.
-  auto plan_obs = quent::plan::create_observer();
+  auto plan_obs = quent::plan::create_observer(*ctx);
   auto plan_id = uuid::now_v7();
   auto port_src = uuid::now_v7();
   auto port_tgt = uuid::now_v7();
@@ -88,7 +88,7 @@ int main() {
 
   // Operator: declaration with plan reference, parent operators, and custom
   // attrs.
-  auto op_obs = quent::operator_::create_observer();
+  auto op_obs = quent::operator_::create_observer(*ctx);
   auto op_id = uuid::now_v7();
 
   quent::CustomAttributes op_custom;
@@ -113,7 +113,7 @@ int main() {
                             });
 
   // Port: declaration with operator reference.
-  auto port_obs = quent::port::create_observer();
+  auto port_obs = quent::port::create_observer(*ctx);
   auto port_id = uuid::now_v7();
   port_obs->declaration(port_id, quent::port::Declaration{
                                      .operator_id = op_id,

--- a/examples/cpp-integration/cpp/src/main.cpp
+++ b/examples/cpp-integration/cpp/src/main.cpp
@@ -28,14 +28,14 @@ int main() {
     // Create instrumentation context — events exported to ndjson.
     auto ctx = quent::create_context(cluster_id, "ndjson", "./events");
 
-    auto cluster_obs = quent::cluster::create_observer();
+    auto cluster_obs = quent::cluster::create_observer(*ctx);
     cluster_obs->cluster_declaration(cluster_id,
                                      quent::cluster::ClusterDeclaration{
                                          .instance_name = "example_cluster",
                                      });
 
     // Spawn a worker.
-    auto worker_obs = quent::worker::create_observer();
+    auto worker_obs = quent::worker::create_observer(*ctx);
     auto worker_id = uuid::now_v7();
     quent::CustomAttributes custom;
     custom.string_attrs.push_back({"version", "42.1.2"});
@@ -52,10 +52,10 @@ int main() {
                                    });
 
     // Construct a queue.
-    auto queue = quent::queue::create(quent::queue::Initializing{
-        .instance_name = "my_queue",
-        .parent_group_id = worker_id,
-    });
+    auto queue = quent::queue::create(*ctx, quent::queue::Initializing{
+                                                .instance_name = "my_queue",
+                                                .parent_group_id = worker_id,
+                                            });
     // Operating with unbounded capacity (Option<u64> = None in Rust).
     // In C++, the bridge wraps the value in Some(), so 0 here means Some(0).
     // True unbounded (None) is not representable in CXX without sentinel
@@ -63,30 +63,31 @@ int main() {
     queue->operating(quent::queue::Operating{.capacity_entries = 0});
 
     // Construct a memory pool (resizable).
-    auto mem_pool = quent::memory_pool::create(quent::memory_pool::Initializing{
-        .instance_name = "my_memory_pool",
-        .parent_group_id = worker_id,
-    });
+    auto mem_pool = quent::memory_pool::create(
+        *ctx, quent::memory_pool::Initializing{
+                  .instance_name = "my_memory_pool",
+                  .parent_group_id = worker_id,
+              });
     mem_pool->operating(quent::memory_pool::Operating{.capacity_bytes = 1337});
     mem_pool->resizing();
     mem_pool->operating(quent::memory_pool::Operating{.capacity_bytes = 2048});
 
     // Spawn a thread.
-    auto thread = quent::thread::create(quent::thread::Initializing{
-        .instance_name = "my_thread",
-        .parent_group_id = worker_id,
-    });
+    auto thread = quent::thread::create(*ctx, quent::thread::Initializing{
+                                                  .instance_name = "my_thread",
+                                                  .parent_group_id = worker_id,
+                                              });
     thread->operating();
 
     // Single event entity.
-    auto info_obs = quent::info::create_observer();
+    auto info_obs = quent::info::create_observer(*ctx);
     info_obs->info(uuid::now_v7(), quent::info::Info{
                                        .message = "ready to operate",
                                        .source = "main.cpp",
                                    });
 
     // Multi-event entity.
-    auto file_stats_obs = quent::file_stats::create_observer();
+    auto file_stats_obs = quent::file_stats::create_observer(*ctx);
     auto fs_id = uuid::now_v7();
     file_stats_obs->checksum(fs_id, quent::file_stats::Checksum{
                                         .algorithm = "sha256",
@@ -98,12 +99,12 @@ int main() {
                                         });
 
     // Queue a task. The entry transition returns an FSM handle.
-    auto task = quent::task::create(quent::task::Queued{
-        .instance_name = "my_task_31415",
-        .index = 1,
-        .worker = worker_id,
-        .queue_resource_id = queue->uuid(),
-    });
+    auto task = quent::task::create(*ctx, quent::task::Queued{
+                                              .instance_name = "my_task_31415",
+                                              .index = 1,
+                                              .worker = worker_id,
+                                              .queue_resource_id = queue->uuid(),
+                                          });
 
     // First computing transition — thread usage only, no memory pool.
     task->computing(quent::task::Computing{


### PR DESCRIPTION
Removes global sender in favor of explicit threading of context.

Singleton access vs explicit propagation of telemetry emitting handles, have their pros and cons:

Singleton / Global Access
- Pros:
	- Minimal func/data-structure signature changes more analogous to logging, gets less in the way of business logic -- fire and forget.

- Cons:
	- Hidden dependency -- harder to reason about what a function does from its signature
	- Harder to test, requires global state setup/teardown
	- Lifecycle management is tricky -- init order, shutdown order, use-after-destroy, improper clean-up
	- Thread safety overhead on every access (atomic/mutex for the global pointer)


Explicit Context Propagation
- Pros:
	- Dependencies are visible -- every function declares what it needs
	- Easily testable -- pass no-op telemetry handles
	- No hidden init-order or lifetime issues -- ownership is clear.
	- Adds the use of telemetry as a design consideration (a pro IMO)

- Cons:
	- Signature pollution — telemetry context threads through many layers that don't use it themselves. Small additions might need changes that pierce many layers.
		- A middle ground usually is using larger structures to store these telemetry handles, which can then be accessed by other entities. Like query storing the telemetry bits, and pipelines using them.

Considering these tradeoffs + prior experiences, it favourable to be explicit.