### PR TITLE
feat(ui): themed palettes

### DIFF
--- a/ui/src/components/timeline/ResourceTimeline.tsx
+++ b/ui/src/components/timeline/ResourceTimeline.tsx
@@ -194,7 +194,13 @@ export function ResourceTimeline({
     const filterSet =
       resourceType === EntityTypeKey.Resource ? new Set([resourceId]) : new Set<string>();
 
-    const timelineMarks = buildTimelineMarks(longFsms, startTime, paletteTheme, filterSet, fsmTypes);
+    const timelineMarks = buildTimelineMarks(
+      longFsms,
+      startTime,
+      paletteTheme,
+      filterSet,
+      fsmTypes
+    );
 
     if (operatorId && operatorLabel) {
       if (overlayPreloadedData) {

--- a/ui/src/components/timeline/ResourceTimeline.tsx
+++ b/ui/src/components/timeline/ResourceTimeline.tsx
@@ -28,6 +28,7 @@ import {
 import { TimelineSeries, TimelineMark } from './types';
 import { EntityTypeKey } from '@/types';
 import { WHITE, withOpacity } from '@/services/colors';
+import { THEME_DARK, useTheme } from '@/contexts/ThemeContext';
 import type { SingleTimelineResponse } from '~quent/types/SingleTimelineResponse';
 import type { SingleTimelineRequest } from '~quent/types/SingleTimelineRequest';
 import type { QueryFilter } from '~quent/types/QueryFilter';
@@ -78,6 +79,8 @@ export function ResourceTimeline({
   quantitySpecs,
   fsmTypes,
 }: ResourceTimelineProps) {
+  const { theme } = useTheme();
+  const paletteTheme = theme === THEME_DARK ? 'dark' : 'light';
   const deferredReady = useDeferredReady();
   const zoomRange = useAtomValue(debouncedZoomRangeAtom);
   const bulkInitialized = useAtomValue(bulkInitializedAtom);
@@ -182,6 +185,7 @@ export function ResourceTimeline({
       data.data,
       data.config,
       startTime,
+      paletteTheme,
       capacities,
       quantitySpecs,
       fsmTypes
@@ -190,7 +194,7 @@ export function ResourceTimeline({
     const filterSet =
       resourceType === EntityTypeKey.Resource ? new Set([resourceId]) : new Set<string>();
 
-    const timelineMarks = buildTimelineMarks(longFsms, startTime, filterSet, fsmTypes);
+    const timelineMarks = buildTimelineMarks(longFsms, startTime, paletteTheme, filterSet, fsmTypes);
 
     if (operatorId && operatorLabel) {
       if (overlayPreloadedData) {
@@ -202,6 +206,7 @@ export function ResourceTimeline({
             overlayPreloadedData.data,
             overlayPreloadedData.config,
             startTime,
+            paletteTheme,
             capacities,
             quantitySpecs,
             fsmTypes
@@ -213,6 +218,7 @@ export function ResourceTimeline({
             marks: buildTimelineMarks(
               longFsms,
               startTime,
+              paletteTheme,
               filterSet,
               fsmTypes,
               opLongFsmIds,
@@ -245,6 +251,7 @@ export function ResourceTimeline({
     resourceType,
     resourceId,
     operatorLabel,
+    paletteTheme,
   ]);
 
   if (!preloadedData && (!deferredReady || isLoading)) {

--- a/ui/src/components/timeline/TimelineController.tsx
+++ b/ui/src/components/timeline/TimelineController.tsx
@@ -22,6 +22,7 @@ import { TIMELINE_X_AXIS_ANIMATION, TIMELINE_SPACING } from './types';
 import type { SingleTimelineResponse } from '~quent/types/SingleTimelineResponse';
 import { useTimelineEchartsTheme } from './timelineEchartsTheme';
 import { zoomRangeAtom } from '@/atoms/timeline';
+import { THEME_DARK, useTheme } from '@/contexts/ThemeContext';
 
 const CONTROLLER_HEIGHT = 50;
 const CONTROLLER_TOP_HEADROOM_RATIO = 0.2;
@@ -52,6 +53,8 @@ export function TimelineController({
   onZoomChange,
 }: TimelineControllerProps) {
   const { themeName, controllerGridBackgroundColor } = useTimelineEchartsTheme();
+  const { theme } = useTheme();
+  const paletteTheme = theme === THEME_DARK ? 'dark' : 'light';
 
   const startTimeMillis = useMemo(() => nanosToMs(startTime), [startTime]);
 
@@ -60,7 +63,8 @@ export function TimelineController({
       const { timestamps: ts, series } = buildBinnedTimelineSeries(
         timelineData.data,
         timelineData.config,
-        startTime
+        startTime,
+        paletteTheme
       );
       const entries = Object.entries(series);
       const values = entries.length > 0 ? entries[0][1].values : null;
@@ -71,7 +75,7 @@ export function TimelineController({
       const ts = Array.from({ length: numBins }, (_, i) => startTimeMillis + i * binDurationMs);
       return { timestamps: ts, seriesData: null };
     }
-  }, [timelineData, startTime, startTimeMillis, durationSeconds]);
+  }, [timelineData, startTime, startTimeMillis, durationSeconds, paletteTheme]);
 
   const hasSeriesData = useMemo(() => Boolean(seriesData && seriesData.length > 0), [seriesData]);
 

--- a/ui/src/hooks/useDagControls.ts
+++ b/ui/src/hooks/useDagControls.ts
@@ -18,11 +18,17 @@ import {
   computeEdgeColoring,
 } from '@/services/query-plan/dagFieldProcessing';
 import { parseCustomStatistics } from '@/lib/queryBundle.utils';
+import { THEME_DARK, useTheme } from '@/contexts/ThemeContext';
 
 export function useDagNodeColoring(nodes: DAGNode[]) {
   const selectedField = useAtomValue(selectedColorField);
   const setNodeColoring = useSetAtom(nodeColoringAtom);
-  const coloring = useMemo(() => computeNodeColoring(nodes, selectedField), [nodes, selectedField]);
+  const { theme } = useTheme();
+  const paletteTheme = theme === THEME_DARK ? 'dark' : 'light';
+  const coloring = useMemo(
+    () => computeNodeColoring(nodes, selectedField, paletteTheme),
+    [nodes, selectedField, paletteTheme]
+  );
   useEffect(() => {
     setNodeColoring(coloring);
   }, [coloring, setNodeColoring]);
@@ -43,7 +49,12 @@ export function useDagEdgeWidthConfig(edges: DAGEdge[]) {
 export function useDagEdgeColoring(edges: DAGEdge[]) {
   const selectedField = useAtomValue(selectedEdgeColorFieldAtom);
   const setEdgeColoring = useSetAtom(edgeColoringAtom);
-  const coloring = useMemo(() => computeEdgeColoring(edges, selectedField), [edges, selectedField]);
+  const { theme } = useTheme();
+  const paletteTheme = theme === THEME_DARK ? 'dark' : 'light';
+  const coloring = useMemo(
+    () => computeEdgeColoring(edges, selectedField, paletteTheme),
+    [edges, selectedField, paletteTheme]
+  );
   useEffect(() => {
     setEdgeColoring(coloring);
   }, [coloring, setEdgeColoring]);

--- a/ui/src/lib/timeline.utils.ts
+++ b/ui/src/lib/timeline.utils.ts
@@ -19,6 +19,7 @@ import { CHART_GROUP } from '@/components/timeline/Timeline';
 import {
   createCapacitiesColorFn,
   createFsmTypeColorFn,
+  type PaletteTheme,
   WHITE,
   withOpacity,
 } from '@/services/colors';
@@ -66,6 +67,7 @@ export function buildBinnedTimelineSeries(
   data: ResourceTimeline,
   config: BinnedSpanSec,
   startTime: bigint,
+  theme: PaletteTheme,
   capacities?: CapacityDecl[],
   quantitySpecs?: { [key in string]?: QuantitySpec },
   fsmTypes?: { [key in string]?: FsmTypeDecl }
@@ -101,7 +103,7 @@ export function buildBinnedTimelineSeries(
     // ResourceTimelineBinned: capacities_values (flat: capacity → values)
     const { capacities_values } = data.Binned;
     const capacityKeys = Object.keys(capacities_values).sort();
-    const colorCapacity = createCapacitiesColorFn(capacityKeys);
+    const colorCapacity = createCapacitiesColorFn(capacityKeys, theme);
     for (const [capacity, values] of Object.entries(capacities_values)) {
       const formatter = getFormatter(capacity);
       series[capacity] = {
@@ -113,7 +115,7 @@ export function buildBinnedTimelineSeries(
     }
   } else if ('BinnedByState' in data) {
     const { capacities_states_values } = data.BinnedByState;
-    const colorFsm = createFsmTypeColorFn(fsmTypes ?? {});
+    const colorFsm = createFsmTypeColorFn(fsmTypes ?? {}, theme);
     for (const capacityType of Object.keys(capacities_states_values)) {
       const capacityStateValues = capacities_states_values[capacityType] ?? {};
       for (const [state, values] of Object.entries(capacityStateValues)) {
@@ -164,6 +166,7 @@ export function getLongFsms(data: ResourceTimeline): FiniteStateMachine[] {
 export function buildTimelineMarks(
   longFsms: FiniteStateMachine[],
   startTime: bigint,
+  theme: PaletteTheme,
   resourceIdsForFilter?: Set<string> | null,
   fsmTypes?: { [key in string]?: FsmTypeDecl },
   /** When provided, marks whose FSM is in this set are highlighted; others are dimmed. */
@@ -173,7 +176,7 @@ export function buildTimelineMarks(
   if (longFsms.length === 0) return undefined;
 
   const startTimeMs = nanosToMs(startTime);
-  const colorFsm = createFsmTypeColorFn(fsmTypes ?? {});
+  const colorFsm = createFsmTypeColorFn(fsmTypes ?? {}, theme);
 
   const marks = longFsms.flatMap(fsm => {
     const label = fsm.instance_name || fsm.id;

--- a/ui/src/services/colors.ts
+++ b/ui/src/services/colors.ts
@@ -34,30 +34,54 @@ export const PALETTES = {
     '#ea7ccc', // Pink
   ],
   /** Tol qualitative colorblind-friendly palette */
-  extended: [
-    '#44AA99', // Teal
-    '#CC6677', // Rose
-    '#332288', // Indigo
-    '#DDCC77', // Sand
-    '#AA4499', // Purple
-    '#88CCEE', // Cyan
-    '#882255', // Wine
-    '#88AA55', // Muted Lime
-    '#666666', // Grey
-  ],
+  extended: {
+    /** Qualitative palette — light mode */
+    light: [
+      '#44AA99', // Teal
+      '#CC6677', // Rose
+      '#332288', // Indigo
+      '#DDCC77', // Sand
+      '#AA4499', // Purple
+      '#88CCEE', // Cyan
+      '#882255', // Wine
+      '#88AA55', // Muted Lime
+      '#666666', // Grey
+    ],
+    /** Qualitative palette — dark mode (muted, lower contrast) */
+    dark: [
+      '#3D9485', // Teal
+      '#B85858', // Coral Red
+      '#4A68AA', // Steel Blue
+      '#B8A85E', // Sand
+      '#9466BB', // Violet
+      '#6BA8C8', // Cyan
+      '#B87A44', // Amber
+      '#6E8C44', // Muted Lime
+      '#808080', // Grey
+    ],
+  },
 } as const;
 
 export type PaletteName = keyof typeof PALETTES;
 export type ChartColor = string;
+export type PaletteTheme = 'light' | 'dark';
+type PaletteValue = (typeof PALETTES)[PaletteName];
 
 // Current active palette
 let activePalette: PaletteName = 'extended';
 
+function resolvePalette(palette: PaletteValue, theme: PaletteTheme = 'light'): readonly string[] {
+  if ('light' in palette && 'dark' in palette) {
+    return palette[theme];
+  }
+  return palette;
+}
+
 /**
  * Get the currently active palette.
  */
-export function getActivePalette(): readonly string[] {
-  return PALETTES[activePalette];
+export function getActivePalette(theme: PaletteTheme = 'light'): readonly string[] {
+  return resolvePalette(PALETTES[activePalette], theme);
 }
 
 /**
@@ -71,8 +95,8 @@ export function setActivePalette(name: PaletteName): void {
 /**
  * Get palette by name.
  */
-export function getPalette(name: PaletteName): readonly string[] {
-  return PALETTES[name];
+export function getPalette(name: PaletteName, theme: PaletteTheme = 'light'): readonly string[] {
+  return resolvePalette(PALETTES[name], theme);
 }
 
 /**
@@ -98,8 +122,8 @@ const usedIndices = new Set<number>();
  * collisions so different keys get different colors (until the palette
  * is exhausted, after which duplicates are allowed).
  */
-export function getColorForKey(key: string): ChartColor {
-  const palette = getActivePalette();
+export function getColorForKey(key: string, theme: PaletteTheme): ChartColor {
+  const palette = getActivePalette(theme);
 
   if (colorAssignments.has(key)) {
     return palette[colorAssignments.get(key)!];
@@ -128,8 +152,11 @@ export function getColorForKey(key: string): ChartColor {
  * Assign colors to an array of keys in order.
  * Useful for batch assignment to maintain consistent ordering.
  */
-export function assignColors<T extends string>(keys: T[]): Record<T, ChartColor> {
-  const palette = getActivePalette();
+export function assignColors<T extends string>(
+  keys: T[],
+  theme: PaletteTheme
+): Record<T, ChartColor> {
+  const palette = getActivePalette(theme);
   return Object.fromEntries(
     keys.map((key, index) => [key, palette[index % palette.length]])
   ) as Record<T, ChartColor>;
@@ -141,31 +168,39 @@ export function assignColors<T extends string>(keys: T[]): Record<T, ChartColor>
  * key-based deterministic coloring to stay stable across timelines.
  */
 export function createCapacitiesColorFn(
-  capacityKeys: string[]
+  capacityKeys: string[],
+  theme: PaletteTheme
 ): (capacityName: string) => ChartColor {
   const colorMap =
     capacityKeys.length > 1
-      ? assignColors(capacityKeys)
-      : Object.fromEntries(capacityKeys.map(capacity => [capacity, getColorForKey(capacity)]));
+      ? assignColors(capacityKeys, theme)
+      : Object.fromEntries(
+          capacityKeys.map(capacity => [capacity, getColorForKey(capacity, theme)])
+        );
 
-  return (capacityName: string) => colorMap[capacityName] ?? getColorForKey(capacityName);
+  return (capacityName: string) => colorMap[capacityName] ?? getColorForKey(capacityName, theme);
 }
 
 /**
  * Get a color by index from the active palette (wraps around).
  */
-export function getColorByIndex(index: number): ChartColor {
-  const palette = getActivePalette();
+export function getColorByIndex(index: number, theme: PaletteTheme): ChartColor {
+  const palette = getActivePalette(theme);
   return palette[index % palette.length];
 }
 
-export function createFsmTypeColorFn(fsmTypes: { [key in string]?: FsmTypeDecl }): (
+export function createFsmTypeColorFn(
+  fsmTypes: { [key in string]?: FsmTypeDecl },
+  theme: PaletteTheme
+): (
   stateName: string
 ) => ChartColor {
   const stateIndexMap = buildFsmStateIndexMap(fsmTypes);
   return (stateName: string) => {
     const stateIndex = stateIndexMap.get(stateName);
-    return stateIndex != null ? getColorByIndex(stateIndex) : getColorForKey(stateName);
+    return stateIndex != null
+      ? getColorByIndex(stateIndex, theme)
+      : getColorForKey(stateName, theme);
   };
 }
 

--- a/ui/src/services/colors.ts
+++ b/ui/src/services/colors.ts
@@ -192,9 +192,7 @@ export function getColorByIndex(index: number, theme: PaletteTheme): ChartColor 
 export function createFsmTypeColorFn(
   fsmTypes: { [key in string]?: FsmTypeDecl },
   theme: PaletteTheme
-): (
-  stateName: string
-) => ChartColor {
+): (stateName: string) => ChartColor {
   const stateIndexMap = buildFsmStateIndexMap(fsmTypes);
   return (stateName: string) => {
     const stateIndex = stateIndexMap.get(stateName);

--- a/ui/src/services/query-plan/dagFieldProcessing.ts
+++ b/ui/src/services/query-plan/dagFieldProcessing.ts
@@ -3,9 +3,13 @@
 
 import type { DAGNode, DAGEdge, NodeColoring, EdgeWidthConfig, EdgeColoring } from './types';
 import { parseCustomStatistics } from '@/lib/queryBundle.utils';
-import { getActivePalette } from '@/services/colors';
+import { getActivePalette, type PaletteTheme } from '@/services/colors';
 
-export function computeNodeColoring(nodes: DAGNode[], field: string | null): NodeColoring {
+export function computeNodeColoring(
+  nodes: DAGNode[],
+  field: string | null,
+  theme: PaletteTheme
+): NodeColoring {
   if (!field || !nodes.length) return null;
 
   const entries = nodes.flatMap(node => {
@@ -25,7 +29,7 @@ export function computeNodeColoring(nodes: DAGNode[], field: string | null): Nod
     };
   }
 
-  const palette = getActivePalette();
+  const palette = getActivePalette(theme);
   const uniqueValues = [...new Set(entries.map(e => String(e.value)))];
   const valueColor = new Map(uniqueValues.map((v, i) => [v, palette[i % palette.length]]));
   return {
@@ -35,7 +39,11 @@ export function computeNodeColoring(nodes: DAGNode[], field: string | null): Nod
   };
 }
 
-export function computeEdgeColoring(edges: DAGEdge[], field: string | null): EdgeColoring {
+export function computeEdgeColoring(
+  edges: DAGEdge[],
+  field: string | null,
+  theme: PaletteTheme
+): EdgeColoring {
   if (!field || !edges.length) return null;
 
   const entries = edges.flatMap(edge => {
@@ -55,7 +63,7 @@ export function computeEdgeColoring(edges: DAGEdge[], field: string | null): Edg
     };
   }
 
-  const palette = getActivePalette();
+  const palette = getActivePalette(theme);
   const uniqueValues = [...new Set(entries.map(e => String(e.value)))];
   const valueColor = new Map(uniqueValues.map((v, i) => [v, palette[i % palette.length]]));
   return {


### PR DESCRIPTION
Allow for light/dark themes for each palette (or not). Use this for our defualt tol palette. 

Fixes #125 

<img width="788" height="510" alt="Screenshot 2026-05-01 at 3 32 15 PM" src="https://github.com/user-attachments/assets/e9d851d5-b054-46d7-997b-9b17d540135f" />

<img width="820" height="519" alt="Screenshot 2026-05-01 at 3 32 07 PM" src="https://github.com/user-attachments/assets/01ae9ab1-efb0-4aa8-a1bc-f75a3c029096" />
