### PR TITLE
fix(simulator): fix quantity specs rename bytes -> capacity_bytes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,4 @@
 target/
 server/data/*.ndjson
 data/
-
-# Node / pnpm artifacts (root, packages, examples, and any nested workspace)
-**/node_modules/
-**/.pnpm-store/
-**/.pnpm/
-.pnpm-store/
+ui/node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 target/
 server/data/*.ndjson
 data/
-ui/node_modules
+
+# Node / pnpm artifacts (root, packages, examples, and any nested workspace)
+**/node_modules/
+**/.pnpm-store/
+**/.pnpm/
+.pnpm-store/

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -210,7 +210,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
             resource_tree,
             unique_operator_names,
             quantity_specs: [
-                ("bytes".into(), QuantitySpec::bytes()),
+                ("capacity_bytes".into(), QuantitySpec::bytes()),
                 ("unit".into(), QuantitySpec::unit()),
             ]
             .into(),


### PR DESCRIPTION
https://github.com/rapidsai/quent/pull/112/changes#diff-1490f88168e9d578d6e6f32419d485d4b461847223944bf101e333216344368bL152-R147

`bytes` changed to `capacity_bytes` in analyzer but not in simulator I believe, which broke UI formatting of bytes

Not sure if this is the correct fix @johanpel would appreciate a quick look

Fixes: #123 