### PR TITLE
fix(analyzer): bulk timeline cache correctness and cold-cache performance parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "quent-events",
  "quent-exporter-types",
  "quent-query-engine-analyzer",
+ "quent-query-engine-model",
  "quent-query-engine-ui",
  "quent-time",
  "quent-ui",

--- a/crates/ui/src/timeline/request.rs
+++ b/crates/ui/src/timeline/request.rs
@@ -11,7 +11,7 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 /// Configuration of the window and number of bins of a timeline.
-#[derive(TS, Debug, Clone, Serialize, Deserialize)]
+#[derive(TS, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct TimelineConfig {
     /// The number of bins for binned timelines.
     pub num_bins: u16,

--- a/crates/ui/src/timeline/request.rs
+++ b/crates/ui/src/timeline/request.rs
@@ -126,3 +126,24 @@ pub struct BulkTimelineRequest<GlobalParams, TimelineParams> {
     /// Global application-specific parameters, e.g. filters.
     pub app_params: GlobalParams,
 }
+
+/// Bulk request that asks for multiple time windows per entry in a single
+/// analyzer call.
+///
+/// The embedded `config` on each `TimelineRequest` is ignored here — the
+/// actual time windows come from the top-level `configs` vector and apply to
+/// every entry. This shape exists to amortize expensive per-call setup
+/// (e.g. iterating every task in the model) across multiple windows; see
+/// `UiAnalyzer::bulk_chunked_resource_timeline`.
+///
+/// Server-internal type — never crosses the HTTP boundary, so no `TS` or
+/// `Deserialize`.
+#[derive(Debug, Clone)]
+pub struct BulkChunkedTimelineRequest<GlobalParams, TimelineParams> {
+    /// Identity of each timeline entry. The embedded `config` is ignored.
+    pub entries: HashMap<String, TimelineRequest<TimelineParams>>,
+    /// Time windows to evaluate for every entry, in order.
+    pub configs: Vec<TimelineConfig>,
+    /// Global application-specific parameters, e.g. filters.
+    pub app_params: GlobalParams,
+}

--- a/crates/ui/src/timeline/request.rs
+++ b/crates/ui/src/timeline/request.rs
@@ -130,19 +130,12 @@ pub struct BulkTimelineRequest<GlobalParams, TimelineParams> {
 /// Bulk request that asks for multiple time windows per entry in a single
 /// analyzer call.
 ///
-/// The embedded `config` on each `TimelineRequest` is ignored here — the
-/// actual time windows come from the top-level `configs` vector and apply to
-/// every entry. This shape exists to amortize expensive per-call setup
-/// (e.g. iterating every task in the model) across multiple windows; see
-/// `UiAnalyzer::bulk_chunked_resource_timeline`.
-///
-/// Server-internal type — never crosses the HTTP boundary, so no `TS` or
-/// `Deserialize`.
+/// The embedded `config` on each `TimelineRequest` is ignored — the actual
+/// time windows come from the top-level `configs` vector and apply to every
+/// entry. See `UiAnalyzer::bulk_chunked_resource_timeline`.
 #[derive(Debug, Clone)]
 pub struct BulkChunkedTimelineRequest<GlobalParams, TimelineParams> {
-    /// Identity of each timeline entry. The embedded `config` is ignored.
     pub entries: HashMap<String, TimelineRequest<TimelineParams>>,
-    /// Time windows to evaluate for every entry, in order.
     pub configs: Vec<TimelineConfig>,
     /// Global application-specific parameters, e.g. filters.
     pub app_params: GlobalParams,

--- a/crates/ui/src/timeline/response.rs
+++ b/crates/ui/src/timeline/response.rs
@@ -74,3 +74,17 @@ pub struct BulkTimelinesResponse {
     /// The timeline responses, keyed by the same keys as the request entries.
     pub entries: HashMap<String, BulkTimelinesResponseEntry>,
 }
+
+/// Response for a chunked bulk timeline request.
+///
+/// Each entry's `Vec` has one slot per `config` in the request, in the same
+/// order. Slots are independent — a chunk failing produces an `Error` slot
+/// without affecting its peers.
+///
+/// Server-internal type — never crosses the HTTP boundary, so no `TS` or
+/// `Serialize`.
+#[derive(Debug)]
+pub struct BulkChunkedTimelinesResponse {
+    /// Per-entry responses, one slot per request config (in `configs` order).
+    pub entries: HashMap<String, Vec<BulkTimelinesResponseEntry>>,
+}

--- a/crates/ui/src/timeline/response.rs
+++ b/crates/ui/src/timeline/response.rs
@@ -80,11 +80,7 @@ pub struct BulkTimelinesResponse {
 /// Each entry's `Vec` has one slot per `config` in the request, in the same
 /// order. Slots are independent — a chunk failing produces an `Error` slot
 /// without affecting its peers.
-///
-/// Server-internal type — never crosses the HTTP boundary, so no `TS` or
-/// `Serialize`.
 #[derive(Debug)]
 pub struct BulkChunkedTimelinesResponse {
-    /// Per-entry responses, one slot per request config (in `configs` order).
     pub entries: HashMap<String, Vec<BulkTimelinesResponseEntry>>,
 }

--- a/domains/query_engine/analyzer/src/ui.rs
+++ b/domains/query_engine/analyzer/src/ui.rs
@@ -1,12 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use quent_analyzer::AnalyzerResult;
 use quent_events::Event;
 use quent_query_engine_ui as ui;
 use quent_ui::timeline::{
-    request::{BulkTimelineRequest, SingleTimelineRequest},
-    response::{BulkTimelinesResponse, SingleTimelineResponse},
+    request::{BulkChunkedTimelineRequest, BulkTimelineRequest, SingleTimelineRequest},
+    response::{
+        BulkChunkedTimelinesResponse, BulkTimelinesResponse, BulkTimelinesResponseEntry,
+        SingleTimelineResponse,
+    },
 };
 use uuid::Uuid;
 
@@ -65,4 +70,48 @@ pub trait UiAnalyzer {
         &self,
         request: BulkTimelineRequest<Self::TimelineGlobalParams, Self::TimelineParams>,
     ) -> AnalyzerResult<BulkTimelinesResponse>;
+
+    /// Return chunked bulk timelines: multiple time windows per entry.
+    ///
+    /// The default implementation falls back to one `bulk_resource_timeline`
+    /// call per config — correct, but pays the per-call setup cost N times.
+    /// Implementors should override this to amortize expensive per-call work
+    /// (e.g. iterating every task in the model) across all configs in a
+    /// single pass.
+    fn bulk_chunked_resource_timeline(
+        &self,
+        request: BulkChunkedTimelineRequest<Self::TimelineGlobalParams, Self::TimelineParams>,
+    ) -> AnalyzerResult<BulkChunkedTimelinesResponse>
+    where
+        Self::TimelineGlobalParams: Clone,
+        Self::TimelineParams: Clone,
+    {
+        let mut entries: HashMap<String, Vec<BulkTimelinesResponseEntry>> = request
+            .entries
+            .keys()
+            .map(|k| (k.clone(), Vec::with_capacity(request.configs.len())))
+            .collect();
+
+        for config in &request.configs {
+            let inner_entries = request
+                .entries
+                .iter()
+                .map(|(k, e)| (k.clone(), e.clone().with_config(config.clone())))
+                .collect();
+            let mut response = self.bulk_resource_timeline(BulkTimelineRequest {
+                entries: inner_entries,
+                app_params: request.app_params.clone(),
+            })?;
+            for (k, slot) in entries.iter_mut() {
+                let entry = response.entries.remove(k.as_str()).unwrap_or_else(|| {
+                    BulkTimelinesResponseEntry::Error {
+                        message: format!("missing entry '{k}' in chunked fallback"),
+                    }
+                });
+                slot.push(entry);
+            }
+        }
+
+        Ok(BulkChunkedTimelinesResponse { entries })
+    }
 }

--- a/domains/query_engine/analyzer/src/ui.rs
+++ b/domains/query_engine/analyzer/src/ui.rs
@@ -96,7 +96,7 @@ pub trait UiAnalyzer {
             let inner_entries = request
                 .entries
                 .iter()
-                .map(|(k, e)| (k.clone(), e.clone().with_config(config.clone())))
+                .map(|(k, e)| (k.clone(), e.clone().with_config(*config)))
                 .collect();
             let mut response = self.bulk_resource_timeline(BulkTimelineRequest {
                 entries: inner_entries,

--- a/domains/query_engine/server/Cargo.toml
+++ b/domains/query_engine/server/Cargo.toml
@@ -31,3 +31,6 @@ utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 uuid.workspace = true
 mime_guess = { version = "2", optional = true }
 rust-embed = { version = "8", optional = true }
+
+[dev-dependencies]
+quent-query-engine-model = { path = "../model" }

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -285,8 +285,7 @@ impl TimelineCache {
             .flat_map(|(chunk_idx, keys)| keys.iter().map(move |k| (k.clone(), *chunk_idx)))
             .collect();
 
-        let mut miss_entry_keys: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut miss_entry_keys: HashSet<String> = HashSet::new();
         for keys in chunk_misses.values() {
             for k in keys {
                 miss_entry_keys.insert(k.clone());

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -25,7 +25,7 @@ use quent_ui::timeline::{
 use tracing::{debug, trace};
 use uuid::Uuid;
 
-use crate::error::ServerResult;
+use crate::error::{ServerError, ServerResult};
 
 /// Target number of chunks visible in the current view range.
 const TARGET_CHUNKS_PER_VIEW: u64 = 2;
@@ -338,6 +338,14 @@ impl TimelineCache {
         .await??;
 
         for (key, per_chunk) in response.entries {
+            if per_chunk.len() != miss_chunk_indices.len() {
+                return Err(ServerError::Cache(format!(
+                    "chunked analyzer returned {} slots for entry '{}', expected {}",
+                    per_chunk.len(),
+                    key,
+                    miss_chunk_indices.len()
+                )));
+            }
             for (slot_idx, entry_resp) in per_chunk.into_iter().enumerate() {
                 let chunk_idx = miss_chunk_indices[slot_idx];
                 // Skip slots that weren't actually a miss for this entry —

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -356,10 +356,8 @@ impl TimelineCache {
                         entry_chunks.entry(key.clone()).or_default().push(single);
                     }
                     BulkTimelinesResponseEntry::Error { message } => {
-                        error_entries.insert(
-                            key.clone(),
-                            BulkTimelinesResponseEntry::Error { message },
-                        );
+                        error_entries
+                            .insert(key.clone(), BulkTimelinesResponseEntry::Error { message });
                     }
                 }
             }

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -277,13 +277,19 @@ impl TimelineCache {
             return Ok(());
         }
 
-        // Set of (entry_key, chunk_idx) pairs that actually missed. Used to
-        // discard responses for pairs the analyzer recomputed redundantly when
-        // entries have non-uniform miss patterns (rare).
-        let miss_pairs: std::collections::HashSet<(String, u64)> = chunk_misses
-            .iter()
-            .flat_map(|(chunk_idx, keys)| keys.iter().map(move |k| (k.clone(), *chunk_idx)))
-            .collect();
+        // For each entry that missed at least one chunk, the set of chunk indices
+        // it missed. Used to discard responses for pairs the analyzer recomputed
+        // redundantly when entries have non-uniform miss patterns (rare).
+        let mut entry_miss_chunks: HashMap<String, std::collections::HashSet<u64>> =
+            HashMap::new();
+        for (chunk_idx, keys) in chunk_misses {
+            for k in keys {
+                entry_miss_chunks
+                    .entry(k.clone())
+                    .or_default()
+                    .insert(*chunk_idx);
+            }
+        }
 
         let mut miss_entry_keys: std::collections::HashSet<String> =
             std::collections::HashSet::new();
@@ -346,12 +352,15 @@ impl TimelineCache {
                     miss_chunk_indices.len()
                 )));
             }
+            // Skip entries the analyzer recomputed redundantly (mixed miss
+            // patterns, rare). We only cache and collect slots that we actually
+            // asked for.
+            let Some(missed_chunks) = entry_miss_chunks.get(&key) else {
+                continue;
+            };
             for (slot_idx, entry_resp) in per_chunk.into_iter().enumerate() {
                 let chunk_idx = miss_chunk_indices[slot_idx];
-                // Skip slots that weren't actually a miss for this entry —
-                // mixed miss patterns can lead the analyzer to recompute pairs
-                // we already have cached. Don't double-push or overwrite.
-                if !miss_pairs.contains(&(key.clone(), chunk_idx)) {
+                if !missed_chunks.contains(&chunk_idx) {
                     continue;
                 }
                 match entry_resp {

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -318,8 +318,11 @@ impl TimelineCache {
 
         let chunked_entries: HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>> =
             miss_entry_keys
-                .iter()
-                .map(|k| (k.clone(), request.entries[k].clone()))
+                .into_iter()
+                .map(|k| {
+                    let request = request.entries[&k].clone();
+                    (k, request)
+                })
                 .collect();
 
         let a = Arc::clone(&analyzer);

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -284,7 +284,6 @@ impl TimelineCache {
             .flat_map(|(chunk_idx, keys)| keys.iter().map(move |k| (k.clone(), *chunk_idx)))
             .collect();
 
-        // Union of entries that missed any chunk.
         let mut miss_entry_keys: std::collections::HashSet<String> =
             std::collections::HashSet::new();
         for keys in chunk_misses.values() {
@@ -300,7 +299,6 @@ impl TimelineCache {
             "bulk timeline: fetching missing chunks"
         );
 
-        // Build canonical chunk configs aligned with `miss_chunk_indices`.
         let configs: Vec<TimelineConfig> = miss_chunk_indices
             .iter()
             .map(|&chunk_idx| {

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -200,6 +200,7 @@ impl TimelineCache {
         } = cache_result;
 
         if !chunk_misses.is_empty() {
+            let mut error_entries = HashMap::new();
             self.partial_fetch_and_cache(
                 Arc::clone(&analyzer),
                 &request.entries,
@@ -207,8 +208,13 @@ impl TimelineCache {
                 &chunk_misses,
                 &ctx,
                 &mut entry_chunks,
+                &mut error_entries,
             )
             .await?;
+
+            let mut response = assemble_bulk_response(entry_chunks, &request.entries, &geometry)?;
+            response.entries.extend(error_entries);
+            return Ok(response);
         }
 
         assemble_bulk_response(entry_chunks, &request.entries, &geometry)
@@ -252,7 +258,7 @@ impl TimelineCache {
         }
     }
 
-    /// Cold-cache path: fetch all entries in one bulk call, then split and cache each chunk.
+    /// Cold-cache path: fetch canonical chunks for all entries, then assemble the requested view.
     async fn cold_fetch_and_cache<A>(
         &self,
         analyzer: Arc<A>,
@@ -264,47 +270,35 @@ impl TimelineCache {
     ) -> ServerResult<BulkTimelinesResponse>
     where
         A: UiAnalyzer + Send + Sync + 'static,
-        <A as UiAnalyzer>::TimelineGlobalParams: Send + 'static,
-        <A as UiAnalyzer>::TimelineParams: Send + 'static,
+        <A as UiAnalyzer>::TimelineGlobalParams: Clone + Send + 'static,
+        <A as UiAnalyzer>::TimelineParams: Clone + Send + 'static,
     {
         debug!(
             n_entries = request.entries.len(),
             zoom_level = ctx.geometry.zoom_level,
-            "bulk timeline cold cache: full fetch"
+            "bulk timeline cold cache: fetching canonical chunks"
         );
 
-        let response =
-            tokio::task::spawn_blocking(move || analyzer.bulk_resource_timeline(request)).await??;
+        let chunk_misses: HashMap<u64, Vec<String>> = (ctx.geometry.first_chunk
+            ..=ctx.geometry.last_chunk)
+            .map(|chunk_idx| (chunk_idx, request.entries.keys().cloned().collect()))
+            .collect();
+        let mut entry_chunks = HashMap::new();
+        let mut error_entries = HashMap::new();
 
-        for (key, entry_resp) in &response.entries {
-            if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
-                let chunk_resp = SingleTimelineResponse {
-                    config: *config,
-                    data: data.clone(),
-                };
-                let chunks = split_response_into_chunks(
-                    &chunk_resp,
-                    ctx.geometry.first_chunk,
-                    ctx.geometry.last_chunk,
-                    ctx.geometry.chunk_duration,
-                    ctx.geometry.zoom_level,
-                    ctx.geometry.epoch,
-                    ctx.geometry.engine_end,
-                )?;
+        self.partial_fetch_and_cache(
+            analyzer,
+            &request.entries,
+            &request.app_params,
+            &chunk_misses,
+            ctx,
+            &mut entry_chunks,
+            &mut error_entries,
+        )
+        .await?;
 
-                for (chunk_idx, chunk) in chunks {
-                    let cache_key = ChunkCacheKey {
-                        engine_id: ctx.engine_id,
-                        params_hash: ctx.entry_hashes[key],
-                        zoom_level: ctx.geometry.zoom_level,
-                        chunk_idx,
-                        num_bins: ctx.geometry.num_bins,
-                    };
-                    self.chunks.insert(cache_key, chunk).await;
-                }
-            }
-        }
-
+        let mut response = assemble_bulk_response(entry_chunks, &request.entries, ctx.geometry)?;
+        response.entries.extend(error_entries);
         Ok(response)
     }
 
@@ -317,6 +311,7 @@ impl TimelineCache {
         chunk_misses: &HashMap<u64, Vec<String>>,
         ctx: &CacheRequestContext<'_>,
         entry_chunks: &mut HashMap<String, Vec<SingleTimelineResponse>>,
+        error_entries: &mut HashMap<String, BulkTimelinesResponseEntry>,
     ) -> ServerResult<()>
     where
         A: UiAnalyzer + Send + Sync + 'static,
@@ -366,17 +361,22 @@ impl TimelineCache {
             .await??;
 
             for (key, entry_resp) in response.entries {
-                if let BulkTimelinesResponseEntry::Ok { config, data, .. } = entry_resp {
-                    let single = SingleTimelineResponse { config, data };
-                    let cache_key = ChunkCacheKey {
-                        engine_id: ctx.engine_id,
-                        params_hash: ctx.entry_hashes[&key],
-                        zoom_level: ctx.geometry.zoom_level,
-                        chunk_idx: *chunk_idx,
-                        num_bins: ctx.geometry.num_bins,
-                    };
-                    self.chunks.insert(cache_key, single.clone()).await;
-                    entry_chunks.entry(key).or_default().push(single);
+                match entry_resp {
+                    BulkTimelinesResponseEntry::Ok { config, data, .. } => {
+                        let single = SingleTimelineResponse { config, data };
+                        let cache_key = ChunkCacheKey {
+                            engine_id: ctx.engine_id,
+                            params_hash: ctx.entry_hashes[&key],
+                            zoom_level: ctx.geometry.zoom_level,
+                            chunk_idx: *chunk_idx,
+                            num_bins: ctx.geometry.num_bins,
+                        };
+                        self.chunks.insert(cache_key, single.clone()).await;
+                        entry_chunks.entry(key).or_default().push(single);
+                    }
+                    BulkTimelinesResponseEntry::Error { message } => {
+                        error_entries.insert(key, BulkTimelinesResponseEntry::Error { message });
+                    }
                 }
             }
         }
@@ -636,97 +636,6 @@ fn assemble_bulk_response<EP>(
     })
 }
 
-/// Splits a full-viewport response into per-chunk responses for caching.
-fn split_response_into_chunks(
-    response: &SingleTimelineResponse,
-    first_chunk: u64,
-    last_chunk: u64,
-    chunk_duration: u64,
-    zoom_level: u64,
-    epoch: TimeNanoSec,
-    engine_end: TimeNanoSec,
-) -> ServerResult<Vec<(u64, SingleTimelineResponse)>> {
-    let mut result = Vec::new();
-
-    for chunk_idx in first_chunk..=last_chunk {
-        let chunk_start = epoch + chunk_idx * chunk_duration;
-        let chunk_end = if chunk_idx == zoom_level - 1 {
-            engine_end
-        } else {
-            epoch + (chunk_idx + 1) * chunk_duration
-        };
-
-        let chunk_span = match SpanNanoSec::try_new(chunk_start, chunk_end) {
-            Ok(span) => span,
-            Err(_) => continue,
-        };
-
-        // Find the bin range within the full response that falls inside this chunk.
-        let (start_idx, end_idx) = overlap_indices(response, &chunk_span, epoch);
-        if start_idx >= end_idx {
-            continue;
-        }
-
-        let chunk_num_bins = (end_idx - start_idx) as u64;
-        let chunk_config = BinnedSpan::try_new(
-            chunk_span,
-            std::num::NonZero::try_from(chunk_num_bins).map_err(|e| {
-                quent_time::TimeError::InvalidArgument(format!("chunk bins must be > 0: {e}"))
-            })?,
-        )?
-        .try_to_secs_relative(epoch)?;
-
-        // Slice the data arrays at the chunk's bin boundaries.
-        let chunk_data = match &response.data {
-            ResourceTimeline::Binned(data) => {
-                let capacities_values = data
-                    .capacities_values
-                    .iter()
-                    .map(|(cap_name, values)| {
-                        (cap_name.clone(), values[start_idx..end_idx].to_vec())
-                    })
-                    .collect();
-                ResourceTimeline::Binned(ResourceTimelineBinned {
-                    config: chunk_config,
-                    capacities_values,
-                    long_fsms: data.long_fsms.clone(),
-                })
-            }
-            ResourceTimeline::BinnedByState(data) => {
-                let capacities_states_values = data
-                    .capacities_states_values
-                    .iter()
-                    .map(|(cap_name, states)| {
-                        let sliced_states = states
-                            .iter()
-                            .map(|(state_name, values)| {
-                                (state_name.clone(), values[start_idx..end_idx].to_vec())
-                            })
-                            .collect();
-                        (cap_name.clone(), sliced_states)
-                    })
-                    .collect();
-                ResourceTimeline::BinnedByState(ResourceTimelineBinnedByState {
-                    config: chunk_config,
-                    capacities_states_values,
-                    long_fsms: data.long_fsms.clone(),
-                })
-            }
-        };
-
-        // Push this chunk into the result.
-        result.push((
-            chunk_idx,
-            SingleTimelineResponse {
-                config: chunk_config,
-                data: chunk_data,
-            },
-        ));
-    }
-
-    Ok(result)
-}
-
 fn combine_chunks(
     chunks: &[SingleTimelineResponse],
     req_span: SpanNanoSec,
@@ -764,6 +673,8 @@ fn combine_chunks(
             std::collections::HashMap<String, Vec<f64>>,
         > = std::collections::HashMap::new();
         let mut total_bins: u64 = 0;
+        let mut combined_start: Option<TimeNanoSec> = None;
+        let mut combined_end: Option<TimeNanoSec> = None;
 
         for chunk in &sorted {
             let (start_idx, end_idx) = overlap_indices(chunk, &req_span, epoch);
@@ -771,6 +682,9 @@ fn combine_chunks(
                 continue;
             }
             total_bins += (end_idx - start_idx) as u64;
+            let (bin_start, bin_end) = selected_bin_span(chunk, start_idx, end_idx, epoch);
+            combined_start = Some(combined_start.map_or(bin_start, |start| start.min(bin_start)));
+            combined_end = Some(combined_end.map_or(bin_end, |end| end.max(bin_end)));
 
             if let ResourceTimeline::BinnedByState(ref data) = chunk.data {
                 for (cap_name, states) in &data.capacities_states_values {
@@ -785,8 +699,12 @@ fn combine_chunks(
             }
         }
 
+        let combined_span = SpanNanoSec::try_new(
+            combined_start.unwrap_or(req_span.start()),
+            combined_end.unwrap_or(req_span.end()),
+        )?;
         let config = BinnedSpan::try_new(
-            req_span,
+            combined_span,
             std::num::NonZero::try_from(total_bins).map_err(|e| {
                 quent_time::TimeError::InvalidArgument(format!("combined bins must be > 0: {e}"))
             })?,
@@ -805,6 +723,8 @@ fn combine_chunks(
         let mut combined: std::collections::HashMap<String, Vec<f64>> =
             std::collections::HashMap::new();
         let mut total_bins: u64 = 0;
+        let mut combined_start: Option<TimeNanoSec> = None;
+        let mut combined_end: Option<TimeNanoSec> = None;
 
         for chunk in &sorted {
             let (start_idx, end_idx) = overlap_indices(chunk, &req_span, epoch);
@@ -812,6 +732,9 @@ fn combine_chunks(
                 continue;
             }
             total_bins += (end_idx - start_idx) as u64;
+            let (bin_start, bin_end) = selected_bin_span(chunk, start_idx, end_idx, epoch);
+            combined_start = Some(combined_start.map_or(bin_start, |start| start.min(bin_start)));
+            combined_end = Some(combined_end.map_or(bin_end, |end| end.max(bin_end)));
 
             if let ResourceTimeline::Binned(ref data) = chunk.data {
                 for (cap_name, values) in &data.capacities_values {
@@ -823,8 +746,12 @@ fn combine_chunks(
             }
         }
 
+        let combined_span = SpanNanoSec::try_new(
+            combined_start.unwrap_or(req_span.start()),
+            combined_end.unwrap_or(req_span.end()),
+        )?;
         let config = BinnedSpan::try_new(
-            req_span,
+            combined_span,
             std::num::NonZero::try_from(total_bins).map_err(|e| {
                 quent_time::TimeError::InvalidArgument(format!("combined bins must be > 0: {e}"))
             })?,
@@ -840,6 +767,20 @@ fn combine_chunks(
             }),
         })
     }
+}
+
+fn selected_bin_span(
+    chunk: &SingleTimelineResponse,
+    start_idx: usize,
+    end_idx: usize,
+    epoch: TimeNanoSec,
+) -> (TimeNanoSec, TimeNanoSec) {
+    let chunk_start = epoch + to_nanosecs(chunk.config.span.start());
+    let bin_duration_ns = to_nanosecs(chunk.config.bin_duration);
+    (
+        chunk_start + start_idx as u64 * bin_duration_ns,
+        chunk_start + end_idx as u64 * bin_duration_ns,
+    )
 }
 
 fn overlap_indices(
@@ -868,4 +809,563 @@ fn overlap_indices(
     let end_idx = (overlap_end - chunk_start).div_ceil(bin_duration_ns) as usize;
 
     (start_idx.min(num_bins), end_idx.min(num_bins))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use quent_analyzer::AnalyzerResult;
+    use quent_events::Event;
+    use quent_query_engine_analyzer::{
+        QueryEngineModel, engine::Engine, model::InMemoryQueryEngineModel, ui::UiAnalyzer,
+    };
+    use quent_query_engine_model::engine::{EngineEvent, Exit, Init};
+    use quent_ui::{
+        FiniteStateMachine, FsmTransition,
+        timeline::{
+            request::{
+                BulkTimelineRequest, EntityFilter, ResourceTimelineRequest, TimelineConfig,
+                TimelineRequest,
+            },
+            response::{
+                BulkTimelinesResponse, BulkTimelinesResponseEntry, ResourceTimeline,
+                ResourceTimelineBinned, SingleTimelineResponse,
+            },
+        },
+    };
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct TestGlobalParams {
+        query_id: Uuid,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct TestTimelineParams {
+        operator_id: Option<Uuid>,
+        series_offset: u32,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct BulkCallEntry {
+        key: String,
+        start: f64,
+        end: f64,
+        operator_id: Option<Uuid>,
+    }
+
+    struct TestAnalyzer {
+        engine_id: Uuid,
+        model: InMemoryQueryEngineModel,
+        calls: Mutex<Vec<Vec<BulkCallEntry>>>,
+    }
+
+    impl TestAnalyzer {
+        fn new() -> Self {
+            let engine_id = Uuid::from_u128(1);
+            let mut engine = Engine::new(engine_id).unwrap();
+            engine.push(Event::new(engine_id, 0, EngineEvent::Init(Init::default())));
+            engine.push(Event::new(
+                engine_id,
+                100_000_000_000,
+                EngineEvent::Exit(Exit),
+            ));
+
+            Self {
+                engine_id,
+                model: InMemoryQueryEngineModel {
+                    engine,
+                    workers: Default::default(),
+                    query_groups: Default::default(),
+                    queries: Default::default(),
+                    plans: Default::default(),
+                    operators: Default::default(),
+                    ports: Default::default(),
+                },
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn call_entries(&self) -> Vec<BulkCallEntry> {
+            let mut entries = self
+                .calls
+                .lock()
+                .unwrap()
+                .iter()
+                .flat_map(|call| call.iter().cloned())
+                .collect::<Vec<_>>();
+            entries.sort_by(|a, b| {
+                a.start
+                    .partial_cmp(&b.start)
+                    .unwrap()
+                    .then_with(|| a.key.cmp(&b.key))
+            });
+            entries
+        }
+
+        fn call_keys_by_call(&self) -> Vec<Vec<String>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|call| {
+                    let mut keys = call
+                        .iter()
+                        .map(|entry| entry.key.clone())
+                        .collect::<Vec<_>>();
+                    keys.sort();
+                    keys
+                })
+                .collect()
+        }
+    }
+
+    impl UiAnalyzer for TestAnalyzer {
+        type Event = ();
+        type EntityRef = ();
+        type TimelineGlobalParams = TestGlobalParams;
+        type TimelineParams = TestTimelineParams;
+
+        fn try_new(
+            _engine_id: Uuid,
+            _events: impl Iterator<Item = Event<Self::Event>>,
+        ) -> AnalyzerResult<Self>
+        where
+            Self: Sized,
+        {
+            unimplemented!("not needed by timeline cache tests")
+        }
+
+        fn extract_engine(
+            _engine_id: Uuid,
+            _events: impl Iterator<Item = Event<Self::Event>>,
+        ) -> AnalyzerResult<quent_query_engine_ui::Engine>
+        where
+            Self: Sized,
+        {
+            unimplemented!("not needed by timeline cache tests")
+        }
+
+        fn query_bundle(
+            &self,
+            _query_id: Uuid,
+        ) -> AnalyzerResult<quent_query_engine_ui::QueryBundle<Self::EntityRef>> {
+            unimplemented!("not needed by timeline cache tests")
+        }
+
+        fn query_engine_model(&self) -> &impl QueryEngineModel {
+            &self.model
+        }
+
+        fn single_resource_timeline(
+            &self,
+            _request: quent_ui::timeline::request::SingleTimelineRequest<
+                Self::TimelineGlobalParams,
+                Self::TimelineParams,
+            >,
+        ) -> AnalyzerResult<SingleTimelineResponse> {
+            unimplemented!("not needed by bulk cache tests")
+        }
+
+        fn bulk_resource_timeline(
+            &self,
+            request: BulkTimelineRequest<Self::TimelineGlobalParams, Self::TimelineParams>,
+        ) -> AnalyzerResult<BulkTimelinesResponse> {
+            let mut call = request
+                .entries
+                .iter()
+                .map(|(key, entry)| BulkCallEntry {
+                    key: key.clone(),
+                    start: entry.config().start,
+                    end: entry.config().end,
+                    operator_id: entry_params(entry).operator_id,
+                })
+                .collect::<Vec<_>>();
+            call.sort_by(|a, b| a.key.cmp(&b.key));
+            self.calls.lock().unwrap().push(call);
+
+            let entries = request
+                .entries
+                .into_iter()
+                .map(|(key, entry)| response_entry(key, entry))
+                .collect::<AnalyzerResult<HashMap<_, _>>>()?;
+
+            Ok(BulkTimelinesResponse { entries })
+        }
+    }
+
+    fn entry_params(entry: &TimelineRequest<TestTimelineParams>) -> &TestTimelineParams {
+        match entry {
+            TimelineRequest::Resource(req) => &req.application,
+            TimelineRequest::ResourceGroup(req) => &req.app_params,
+        }
+    }
+
+    fn response_entry(
+        key: String,
+        entry: TimelineRequest<TestTimelineParams>,
+    ) -> AnalyzerResult<(String, BulkTimelinesResponseEntry)> {
+        let params = entry_params(&entry);
+        if params.series_offset == 999 {
+            return Ok((
+                key,
+                BulkTimelinesResponseEntry::Error {
+                    message: "bad entry".to_string(),
+                },
+            ));
+        }
+
+        let config = entry.config().clone().try_into_binned_span(0)?;
+        let config_secs = config.try_to_secs_relative(0)?;
+        let values = (0..config.num_bins.get())
+            .map(|idx| {
+                let bin = config.bin(idx).unwrap();
+                to_secs_relative(bin.start(), 0) + params.series_offset as f64
+            })
+            .collect::<Vec<_>>();
+        let long_fsms = params
+            .operator_id
+            .map(|id| FiniteStateMachine {
+                id,
+                type_name: "task".to_string(),
+                instance_name: format!("operator-{id}"),
+                transitions: vec![
+                    FsmTransition {
+                        name: "start".to_string(),
+                        usages: vec![],
+                        timestamp: config_secs.span.start(),
+                    },
+                    FsmTransition {
+                        name: "end".to_string(),
+                        usages: vec![],
+                        timestamp: config_secs.span.end(),
+                    },
+                ],
+            })
+            .into_iter()
+            .collect();
+        let data = ResourceTimeline::Binned(ResourceTimelineBinned {
+            config: config_secs,
+            capacities_values: HashMap::from([("capacity".to_string(), values)]),
+            long_fsms,
+        });
+
+        Ok((
+            key,
+            BulkTimelinesResponseEntry::Ok {
+                message: String::new(),
+                config: config_secs,
+                data,
+            },
+        ))
+    }
+
+    fn request(
+        entries: Vec<(&str, f64, f64, u32, Option<Uuid>)>,
+    ) -> BulkTimelineRequest<TestGlobalParams, TestTimelineParams> {
+        BulkTimelineRequest {
+            entries: entries
+                .into_iter()
+                .map(|(key, start, end, series_offset, operator_id)| {
+                    (
+                        key.to_string(),
+                        TimelineRequest::Resource(ResourceTimelineRequest {
+                            resource_id: Uuid::from_u128(2),
+                            long_entities_threshold_s: Some(0.0),
+                            entity_filter: EntityFilter {
+                                entity_type_name: None,
+                            },
+                            application: TestTimelineParams {
+                                operator_id,
+                                series_offset,
+                            },
+                            config: TimelineConfig {
+                                num_bins: 4,
+                                start,
+                                end,
+                            },
+                        }),
+                    )
+                })
+                .collect(),
+            app_params: TestGlobalParams {
+                query_id: Uuid::from_u128(3),
+            },
+        }
+    }
+
+    fn values(response: &BulkTimelinesResponse, key: &str) -> Vec<f64> {
+        match response.entries.get(key).unwrap() {
+            BulkTimelinesResponseEntry::Ok {
+                data: ResourceTimeline::Binned(data),
+                ..
+            } => data.capacities_values["capacity"].clone(),
+            _ => panic!("expected binned ok response"),
+        }
+    }
+
+    fn response_span(response: &BulkTimelinesResponse, key: &str) -> (f64, f64) {
+        match response.entries.get(key).unwrap() {
+            BulkTimelinesResponseEntry::Ok { config, .. } => {
+                (config.span.start(), config.span.end())
+            }
+            _ => panic!("expected ok response"),
+        }
+    }
+
+    fn fsm_ids(response: &BulkTimelinesResponse, key: &str) -> Vec<Uuid> {
+        match response.entries.get(key).unwrap() {
+            BulkTimelinesResponseEntry::Ok {
+                data: ResourceTimeline::Binned(data),
+                ..
+            } => data.long_fsms.iter().map(|fsm| fsm.id).collect(),
+            _ => panic!("expected binned ok response"),
+        }
+    }
+
+    fn assert_error(response: &BulkTimelinesResponse, key: &str) {
+        assert!(
+            matches!(
+                response.entries.get(key),
+                Some(BulkTimelinesResponseEntry::Error { .. })
+            ),
+            "expected error entry for {key}, got {:?}",
+            response.entries
+        );
+    }
+
+    fn assert_close(actual: &[f64], expected: &[f64]) {
+        assert_eq!(actual.len(), expected.len());
+        for (idx, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (actual - expected).abs() < 1e-9,
+                "value at index {idx} differs: actual={actual}, expected={expected}"
+            );
+        }
+    }
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn cold_bulk_fetches_canonical_chunks_not_original_viewport() {
+        block_on(async {
+            let analyzer = Arc::new(TestAnalyzer::new());
+            let cache = TimelineCache::new();
+
+            let response = cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![("a", 30.0, 80.0, 0, None)]),
+                )
+                .await
+                .unwrap();
+
+            let spans = analyzer
+                .call_entries()
+                .into_iter()
+                .map(|call| (call.start, call.end))
+                .collect::<Vec<_>>();
+            assert_eq!(spans, vec![(25.0, 50.0), (50.0, 75.0), (75.0, 100.0)]);
+            assert_close(
+                &values(&response, "a"),
+                &[25.0, 31.25, 37.5, 43.75, 50.0, 56.25, 62.5, 68.75, 75.0],
+            );
+            assert_close(
+                &[
+                    response_span(&response, "a").0,
+                    response_span(&response, "a").1,
+                ],
+                &[25.0, 81.25],
+            );
+        });
+    }
+
+    #[test]
+    fn panned_bulk_view_reuses_overlapping_cached_chunks() {
+        block_on(async {
+            let analyzer = Arc::new(TestAnalyzer::new());
+            let cache = TimelineCache::new();
+
+            cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![("a", 25.0, 75.0, 0, None)]),
+                )
+                .await
+                .unwrap();
+            let response = cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![("a", 30.0, 80.0, 0, None)]),
+                )
+                .await
+                .unwrap();
+
+            let spans = analyzer
+                .call_entries()
+                .into_iter()
+                .map(|call| (call.start, call.end))
+                .collect::<Vec<_>>();
+            assert_eq!(spans, vec![(25.0, 50.0), (50.0, 75.0), (75.0, 100.0)]);
+            assert_close(
+                &values(&response, "a"),
+                &[25.0, 31.25, 37.5, 43.75, 50.0, 56.25, 62.5, 68.75, 75.0],
+            );
+        });
+    }
+
+    #[test]
+    fn partial_bulk_entry_miss_fetches_only_new_entry_for_cached_chunks() {
+        block_on(async {
+            let analyzer = Arc::new(TestAnalyzer::new());
+            let cache = TimelineCache::new();
+
+            cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![
+                        ("a", 25.0, 75.0, 0, None),
+                        ("b", 25.0, 75.0, 100, None),
+                    ]),
+                )
+                .await
+                .unwrap();
+            let response = cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![
+                        ("a", 25.0, 75.0, 0, None),
+                        ("b", 25.0, 75.0, 100, None),
+                        ("c", 25.0, 75.0, 200, None),
+                    ]),
+                )
+                .await
+                .unwrap();
+
+            let calls = analyzer.call_keys_by_call();
+            assert_eq!(
+                calls
+                    .iter()
+                    .filter(|keys| keys.as_slice() == ["a", "b"])
+                    .count(),
+                2
+            );
+            assert_eq!(
+                calls.iter().filter(|keys| keys.as_slice() == ["c"]).count(),
+                2
+            );
+            assert_close(
+                &values(&response, "c"),
+                &[225.0, 231.25, 237.5, 243.75, 250.0, 256.25, 262.5, 268.75],
+            );
+        });
+    }
+
+    #[test]
+    fn operator_filter_is_part_of_chunk_cache_key() {
+        block_on(async {
+            let analyzer = Arc::new(TestAnalyzer::new());
+            let cache = TimelineCache::new();
+            let first_operator = Uuid::from_u128(6);
+            let second_operator = Uuid::from_u128(7);
+
+            cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![("a", 25.0, 75.0, 0, Some(first_operator))]),
+                )
+                .await
+                .unwrap();
+            let response = cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![("a", 25.0, 75.0, 0, Some(second_operator))]),
+                )
+                .await
+                .unwrap();
+
+            let operator_ids = analyzer
+                .call_entries()
+                .into_iter()
+                .map(|call| call.operator_id)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                operator_ids
+                    .iter()
+                    .filter(|id| **id == Some(first_operator))
+                    .count(),
+                2
+            );
+            assert_eq!(
+                operator_ids
+                    .iter()
+                    .filter(|id| **id == Some(second_operator))
+                    .count(),
+                2
+            );
+            assert_eq!(fsm_ids(&response, "a"), vec![second_operator]);
+        });
+    }
+
+    #[test]
+    fn bulk_entry_errors_are_not_dropped_on_cold_or_partial_miss() {
+        block_on(async {
+            let analyzer = Arc::new(TestAnalyzer::new());
+            let cache = TimelineCache::new();
+
+            let cold_response = cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![("bad", 25.0, 75.0, 999, None)]),
+                )
+                .await
+                .unwrap();
+            assert_error(&cold_response, "bad");
+
+            cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![("a", 25.0, 75.0, 0, None)]),
+                )
+                .await
+                .unwrap();
+            let partial_response = cache
+                .cached_bulk_timeline(
+                    Arc::clone(&analyzer),
+                    analyzer.engine_id,
+                    request(vec![
+                        ("a", 25.0, 75.0, 0, None),
+                        ("bad", 25.0, 75.0, 999, None),
+                    ]),
+                )
+                .await
+                .unwrap();
+            assert_error(&partial_response, "bad");
+            assert_close(
+                &values(&partial_response, "a"),
+                &[25.0, 31.25, 37.5, 43.75, 50.0, 56.25, 62.5, 68.75],
+            );
+        });
+    }
 }

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -199,8 +199,7 @@ impl TimelineCache {
             let mut error_entries = HashMap::new();
             self.fetch_missing_chunks(
                 Arc::clone(&analyzer),
-                &request.entries,
-                &request.app_params,
+                &request,
                 &chunk_misses,
                 &ctx,
                 &mut entry_chunks,
@@ -257,8 +256,10 @@ impl TimelineCache {
     async fn fetch_missing_chunks<A>(
         &self,
         analyzer: Arc<A>,
-        entries: &HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>>,
-        app_params: &<A as UiAnalyzer>::TimelineGlobalParams,
+        request: &BulkTimelineRequest<
+            <A as UiAnalyzer>::TimelineGlobalParams,
+            <A as UiAnalyzer>::TimelineParams,
+        >,
         chunk_misses: &HashMap<u64, Vec<String>>,
         ctx: &CacheRequestContext<'_>,
         entry_chunks: &mut HashMap<String, Vec<SingleTimelineResponse>>,
@@ -319,11 +320,11 @@ impl TimelineCache {
         let chunked_entries: HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>> =
             miss_entry_keys
                 .iter()
-                .map(|k| (k.clone(), entries[k].clone()))
+                .map(|k| (k.clone(), request.entries[k].clone()))
                 .collect();
 
         let a = Arc::clone(&analyzer);
-        let app_params_clone = app_params.clone();
+        let app_params_clone = request.app_params.clone();
         let response = tokio::task::spawn_blocking(move || {
             a.bulk_chunked_resource_timeline(BulkChunkedTimelineRequest {
                 entries: chunked_entries,

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -764,8 +764,8 @@ fn selected_bin_span(
     let chunk_start = epoch + to_nanosecs(chunk.config.span.start());
     let bin_duration_ns = to_nanosecs(chunk.config.bin_duration);
     (
-        chunk_start + start_idx as u64 * bin_duration_ns,
-        chunk_start + end_idx as u64 * bin_duration_ns,
+        chunk_start + (start_idx as u64 * bin_duration_ns),
+        chunk_start + (end_idx as u64 * bin_duration_ns),
     )
 }
 

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -280,8 +280,7 @@ impl TimelineCache {
         // For each entry that missed at least one chunk, the set of chunk indices
         // it missed. Used to discard responses for pairs the analyzer recomputed
         // redundantly when entries have non-uniform miss patterns (rare).
-        let mut entry_miss_chunks: HashMap<String, std::collections::HashSet<u64>> =
-            HashMap::new();
+        let mut entry_miss_chunks: HashMap<String, std::collections::HashSet<u64>> = HashMap::new();
         for (chunk_idx, keys) in chunk_misses {
             for k in keys {
                 entry_miss_chunks

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -285,7 +285,8 @@ impl TimelineCache {
             .flat_map(|(chunk_idx, keys)| keys.iter().map(move |k| (k.clone(), *chunk_idx)))
             .collect();
 
-        let mut miss_entry_keys: HashSet<String> = HashSet::new();
+        let mut miss_entry_keys: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         for keys in chunk_misses.values() {
             for k in keys {
                 miss_entry_keys.insert(k.clone());
@@ -668,8 +669,8 @@ fn combine_chunks(
             }
             total_bins += (end_idx - start_idx) as u64;
             let (bin_start, bin_end) = selected_bin_span(chunk, start_idx, end_idx, epoch);
-            combined_start = Some(combined_start.map_or(bin_start, |start| start.min(bin_start)));
-            combined_end = Some(combined_end.map_or(bin_end, |end| end.max(bin_end)));
+            combined_start.get_or_insert(bin_start);
+            combined_end = Some(bin_end);
 
             if let ResourceTimeline::BinnedByState(ref data) = chunk.data {
                 for (cap_name, states) in &data.capacities_states_values {
@@ -718,8 +719,8 @@ fn combine_chunks(
             }
             total_bins += (end_idx - start_idx) as u64;
             let (bin_start, bin_end) = selected_bin_span(chunk, start_idx, end_idx, epoch);
-            combined_start = Some(combined_start.map_or(bin_start, |start| start.min(bin_start)));
-            combined_end = Some(combined_end.map_or(bin_end, |end| end.max(bin_end)));
+            combined_start.get_or_insert(bin_start);
+            combined_end = Some(bin_end);
 
             if let ResourceTimeline::Binned(ref data) = chunk.data {
                 for (cap_name, values) in &data.capacities_values {
@@ -1006,7 +1007,7 @@ mod tests {
             ));
         }
 
-        let config = entry.config().clone().try_into_binned_span(0)?;
+        let config = entry.config().try_into_binned_span(0)?;
         let config_secs = config.try_to_secs_relative(0)?;
         let values = (0..config.num_bins.get())
             .map(|idx| {

--- a/domains/query_engine/server/src/timeline_cache.rs
+++ b/domains/query_engine/server/src/timeline_cache.rs
@@ -13,7 +13,10 @@ use quent_analyzer::Span;
 use quent_query_engine_analyzer::{QueryEngineModel, ui::UiAnalyzer};
 use quent_time::{SpanNanoSec, TimeNanoSec, bin::BinnedSpan, to_nanosecs, to_secs_relative};
 use quent_ui::timeline::{
-    request::{BulkTimelineRequest, SingleTimelineRequest, TimelineConfig, TimelineRequest},
+    request::{
+        BulkChunkedTimelineRequest, BulkTimelineRequest, SingleTimelineRequest, TimelineConfig,
+        TimelineRequest,
+    },
     response::{
         BulkTimelinesResponse, BulkTimelinesResponseEntry, ResourceTimeline,
         ResourceTimelineBinned, ResourceTimelineBinnedByState, SingleTimelineResponse,
@@ -105,7 +108,6 @@ struct CacheCheckResult {
     entry_chunks: HashMap<String, Vec<SingleTimelineResponse>>,
     /// Entry keys that missed, grouped by chunk index.
     chunk_misses: HashMap<u64, Vec<String>>,
-    any_cache_hit: bool,
     hit_count: u64,
     miss_count: u64,
 }
@@ -187,12 +189,6 @@ impl TimelineCache {
             "bulk timeline cache check"
         );
 
-        if !cache_result.any_cache_hit {
-            return self
-                .cold_fetch_and_cache(Arc::clone(&analyzer), request, &ctx)
-                .await;
-        }
-
         let CacheCheckResult {
             mut entry_chunks,
             chunk_misses,
@@ -201,7 +197,7 @@ impl TimelineCache {
 
         if !chunk_misses.is_empty() {
             let mut error_entries = HashMap::new();
-            self.partial_fetch_and_cache(
+            self.fetch_missing_chunks(
                 Arc::clone(&analyzer),
                 &request.entries,
                 &request.app_params,
@@ -224,7 +220,6 @@ impl TimelineCache {
     async fn check_cache(&self, ctx: &CacheRequestContext<'_>) -> CacheCheckResult {
         let mut entry_chunks: HashMap<String, Vec<SingleTimelineResponse>> = HashMap::new();
         let mut chunk_misses: HashMap<u64, Vec<String>> = HashMap::new();
-        let mut any_cache_hit = false;
         let mut hit_count = 0u64;
         let mut miss_count = 0u64;
 
@@ -239,7 +234,6 @@ impl TimelineCache {
                 };
 
                 if let Some(cached) = self.chunks.get(&cache_key).await {
-                    any_cache_hit = true;
                     hit_count += 1;
                     entry_chunks.entry(key.clone()).or_default().push(cached);
                 } else {
@@ -252,58 +246,15 @@ impl TimelineCache {
         CacheCheckResult {
             entry_chunks,
             chunk_misses,
-            any_cache_hit,
             hit_count,
             miss_count,
         }
     }
 
-    /// Cold-cache path: fetch canonical chunks for all entries, then assemble the requested view.
-    async fn cold_fetch_and_cache<A>(
-        &self,
-        analyzer: Arc<A>,
-        request: BulkTimelineRequest<
-            <A as UiAnalyzer>::TimelineGlobalParams,
-            <A as UiAnalyzer>::TimelineParams,
-        >,
-        ctx: &CacheRequestContext<'_>,
-    ) -> ServerResult<BulkTimelinesResponse>
-    where
-        A: UiAnalyzer + Send + Sync + 'static,
-        <A as UiAnalyzer>::TimelineGlobalParams: Clone + Send + 'static,
-        <A as UiAnalyzer>::TimelineParams: Clone + Send + 'static,
-    {
-        debug!(
-            n_entries = request.entries.len(),
-            zoom_level = ctx.geometry.zoom_level,
-            "bulk timeline cold cache: fetching canonical chunks"
-        );
-
-        let chunk_misses: HashMap<u64, Vec<String>> = (ctx.geometry.first_chunk
-            ..=ctx.geometry.last_chunk)
-            .map(|chunk_idx| (chunk_idx, request.entries.keys().cloned().collect()))
-            .collect();
-        let mut entry_chunks = HashMap::new();
-        let mut error_entries = HashMap::new();
-
-        self.partial_fetch_and_cache(
-            analyzer,
-            &request.entries,
-            &request.app_params,
-            &chunk_misses,
-            ctx,
-            &mut entry_chunks,
-            &mut error_entries,
-        )
-        .await?;
-
-        let mut response = assemble_bulk_response(entry_chunks, &request.entries, ctx.geometry)?;
-        response.entries.extend(error_entries);
-        Ok(response)
-    }
-
-    /// Partial-hit path: fetch only the (entry, chunk) pairs that missed the cache.
-    async fn partial_fetch_and_cache<A>(
+    /// Fetch every (entry, chunk) pair flagged as a miss, in a single chunked
+    /// analyzer call. Caches the canonical chunks and accumulates per-entry
+    /// chunk responses; per-entry errors land in `error_entries`.
+    async fn fetch_missing_chunks<A>(
         &self,
         analyzer: Arc<A>,
         entries: &HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>>,
@@ -318,49 +269,81 @@ impl TimelineCache {
         <A as UiAnalyzer>::TimelineGlobalParams: Clone + Send + 'static,
         <A as UiAnalyzer>::TimelineParams: Clone + Send + 'static,
     {
-        let n_miss_entries: usize = chunk_misses.values().map(|v| v.len()).sum();
+        // Union of missed chunk indices, sorted for stable response slot ordering.
+        let mut miss_chunk_indices: Vec<u64> = chunk_misses.keys().copied().collect();
+        miss_chunk_indices.sort();
+        if miss_chunk_indices.is_empty() {
+            return Ok(());
+        }
+
+        // Set of (entry_key, chunk_idx) pairs that actually missed. Used to
+        // discard responses for pairs the analyzer recomputed redundantly when
+        // entries have non-uniform miss patterns (rare).
+        let miss_pairs: std::collections::HashSet<(String, u64)> = chunk_misses
+            .iter()
+            .flat_map(|(chunk_idx, keys)| keys.iter().map(move |k| (k.clone(), *chunk_idx)))
+            .collect();
+
+        // Union of entries that missed any chunk.
+        let mut miss_entry_keys: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for keys in chunk_misses.values() {
+            for k in keys {
+                miss_entry_keys.insert(k.clone());
+            }
+        }
+
         debug!(
-            n_miss_chunks = chunk_misses.len(),
-            n_miss_entries,
+            n_miss_chunks = miss_chunk_indices.len(),
+            n_miss_entries = miss_entry_keys.len(),
             zoom_level = ctx.geometry.zoom_level,
-            "bulk timeline partial cache: fetching missing chunks"
+            "bulk timeline: fetching missing chunks"
         );
 
-        for (chunk_idx, miss_keys) in chunk_misses {
-            let chunk_start = ctx.geometry.epoch + chunk_idx * ctx.geometry.chunk_duration;
-            let chunk_end = if *chunk_idx == ctx.geometry.zoom_level - 1 {
-                ctx.geometry.engine_end
-            } else {
-                ctx.geometry.epoch + (chunk_idx + 1) * ctx.geometry.chunk_duration
-            };
-            let timeline_config = TimelineConfig {
-                num_bins: ctx.geometry.num_bins,
-                start: to_secs_relative(chunk_start, ctx.geometry.epoch),
-                end: to_secs_relative(chunk_end, ctx.geometry.epoch),
-            };
-
-            let chunk_entries: HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>> =
-                miss_keys
-                    .iter()
-                    .map(|key| {
-                        (
-                            key.clone(),
-                            entries[key].clone().with_config(timeline_config.clone()),
-                        )
-                    })
-                    .collect();
-
-            let a = Arc::clone(&analyzer);
-            let app_params_clone = app_params.clone();
-            let response = tokio::task::spawn_blocking(move || {
-                a.bulk_resource_timeline(BulkTimelineRequest {
-                    entries: chunk_entries,
-                    app_params: app_params_clone,
-                })
+        // Build canonical chunk configs aligned with `miss_chunk_indices`.
+        let configs: Vec<TimelineConfig> = miss_chunk_indices
+            .iter()
+            .map(|&chunk_idx| {
+                let chunk_start = ctx.geometry.epoch + chunk_idx * ctx.geometry.chunk_duration;
+                let chunk_end = if chunk_idx == ctx.geometry.zoom_level - 1 {
+                    ctx.geometry.engine_end
+                } else {
+                    ctx.geometry.epoch + (chunk_idx + 1) * ctx.geometry.chunk_duration
+                };
+                TimelineConfig {
+                    num_bins: ctx.geometry.num_bins,
+                    start: to_secs_relative(chunk_start, ctx.geometry.epoch),
+                    end: to_secs_relative(chunk_end, ctx.geometry.epoch),
+                }
             })
-            .await??;
+            .collect();
 
-            for (key, entry_resp) in response.entries {
+        let chunked_entries: HashMap<String, TimelineRequest<<A as UiAnalyzer>::TimelineParams>> =
+            miss_entry_keys
+                .iter()
+                .map(|k| (k.clone(), entries[k].clone()))
+                .collect();
+
+        let a = Arc::clone(&analyzer);
+        let app_params_clone = app_params.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            a.bulk_chunked_resource_timeline(BulkChunkedTimelineRequest {
+                entries: chunked_entries,
+                configs,
+                app_params: app_params_clone,
+            })
+        })
+        .await??;
+
+        for (key, per_chunk) in response.entries {
+            for (slot_idx, entry_resp) in per_chunk.into_iter().enumerate() {
+                let chunk_idx = miss_chunk_indices[slot_idx];
+                // Skip slots that weren't actually a miss for this entry —
+                // mixed miss patterns can lead the analyzer to recompute pairs
+                // we already have cached. Don't double-push or overwrite.
+                if !miss_pairs.contains(&(key.clone(), chunk_idx)) {
+                    continue;
+                }
                 match entry_resp {
                     BulkTimelinesResponseEntry::Ok { config, data, .. } => {
                         let single = SingleTimelineResponse { config, data };
@@ -368,14 +351,17 @@ impl TimelineCache {
                             engine_id: ctx.engine_id,
                             params_hash: ctx.entry_hashes[&key],
                             zoom_level: ctx.geometry.zoom_level,
-                            chunk_idx: *chunk_idx,
+                            chunk_idx,
                             num_bins: ctx.geometry.num_bins,
                         };
                         self.chunks.insert(cache_key, single.clone()).await;
-                        entry_chunks.entry(key).or_default().push(single);
+                        entry_chunks.entry(key.clone()).or_default().push(single);
                     }
                     BulkTimelinesResponseEntry::Error { message } => {
-                        error_entries.insert(key, BulkTimelinesResponseEntry::Error { message });
+                        error_entries.insert(
+                            key.clone(),
+                            BulkTimelinesResponseEntry::Error { message },
+                        );
                     }
                 }
             }

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -659,7 +659,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
         let mut slots: HashMap<String, Vec<Option<BulkTimelinesResponseEntry>>> = request
             .entries
             .keys()
-            .map(|k| (k.clone(), (0..n_configs).map(|_| None).collect()))
+            .map(|k| (k.clone(), vec![None; n_configs]))
             .collect();
 
         for slot in plain_builders {

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -53,6 +53,24 @@ pub struct SimulatorUiAnalyzer {
     pub model: SimulatorModel,
 }
 
+/// `(entry_id, config_idx, builder, resource_id_filter, task_filter)` for the
+/// chunked bulk path. Carries the entry and config bookkeeping needed to slot
+/// each builder back into the per-entry response Vec at finalize time.
+type PlainBuilderSlot<'a> = (
+    String,
+    usize,
+    ResourceTimelineBuilder<'a>,
+    HashSet<Uuid>,
+    TaskFilter,
+);
+type PerStateBuilderSlot<'a> = (
+    String,
+    usize,
+    ResourceTimelineByKeyBuilder<'a, &'a str>,
+    HashSet<Uuid>,
+    TaskFilter,
+);
+
 impl UiAnalyzer for SimulatorUiAnalyzer {
     type Event = SimulatorEvent;
     type EntityRef = EntityRef;
@@ -528,22 +546,10 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
 
         let n_configs = request.configs.len();
 
-        // Builder tuples carry entry_id + config_idx so finalize can slot them
-        // back into the per-entry Vec in `configs` order.
-        let mut plain_builders: Vec<(
-            String,
-            usize,
-            ResourceTimelineBuilder,
-            HashSet<Uuid>,
-            TaskFilter,
-        )> = Vec::with_capacity(request.entries.len() * n_configs);
-        let mut per_state_builders: Vec<(
-            String,
-            usize,
-            ResourceTimelineByKeyBuilder<&str>,
-            HashSet<Uuid>,
-            TaskFilter,
-        )> = Vec::with_capacity(request.entries.len() * n_configs);
+        let mut plain_builders: Vec<PlainBuilderSlot<'_>> =
+            Vec::with_capacity(request.entries.len() * n_configs);
+        let mut per_state_builders: Vec<PerStateBuilderSlot<'_>> =
+            Vec::with_capacity(request.entries.len() * n_configs);
 
         // Per-entry prep runs once; the builders for that entry's N configs all share it.
         for (entry_id, entry) in &request.entries {

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -256,7 +256,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
         let epoch = self
             .query_engine_model()
             .query_epoch(request.app_params.query_id)?;
-        let config = request.entry.config().clone().try_into_binned_span(epoch)?;
+        let config = request.entry.config().try_into_binned_span(epoch)?;
         let config_secs = config.try_to_secs_relative(epoch)?;
 
         match request.entry {
@@ -391,7 +391,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
         )> = Vec::new();
 
         for (entry_id, entry) in request.entries {
-            let entry_config = entry.config().clone().try_into_binned_span(epoch)?;
+            let entry_config = entry.config().try_into_binned_span(epoch)?;
             let BulkEntryPrep {
                 resource_type,
                 resource_id_filter,
@@ -562,7 +562,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
             } = self.try_prepare_bulk_entry(entry.clone(), &resource_tree)?;
 
             for (config_idx, config) in request.configs.iter().enumerate() {
-                let entry_config = config.clone().try_into_binned_span(epoch)?;
+                let entry_config = config.try_into_binned_span(epoch)?;
                 if entity_filter.entity_type_name.is_some() {
                     per_state_builders.push((
                         entry_id.clone(),

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -659,7 +659,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
         let mut slots: HashMap<String, Vec<Option<BulkTimelinesResponseEntry>>> = request
             .entries
             .keys()
-            .map(|k| (k.clone(), vec![None; n_configs]))
+            .map(|k| (k.clone(), (0..n_configs).map(|_| None).collect()))
             .collect();
 
         for slot in plain_builders {
@@ -670,7 +670,10 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                 config,
                 data: self.timeline_to_ui(built, epoch)?,
             };
-            slots.get_mut(&slot.entry_id).unwrap()[slot.config_idx] = Some(resp);
+            slots
+                .get_mut(&slot.entry_id)
+                .unwrap_or_else(|| panic!("known key, instead found unknown key {}", slot.entry_id))
+                [slot.config_idx] = Some(resp);
         }
         for slot in per_state_builders {
             let built = slot.builder.build();
@@ -680,7 +683,10 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                 config,
                 data: self.timeline_to_ui_keyed(built, epoch)?,
             };
-            slots.get_mut(&slot.entry_id).unwrap()[slot.config_idx] = Some(resp);
+            slots
+                .get_mut(&slot.entry_id)
+                .unwrap_or_else(|| panic!("known key, instead found unknown key {}", slot.entry_id))
+                [slot.config_idx] = Some(resp);
         }
 
         let entries = slots

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -9,9 +9,12 @@ use quent_ui::{
     FiniteStateMachine, ResourceGroupNode, ResourceTree, convert_resource_tree,
     quantity::QuantitySpec,
     timeline::{
-        request::{BulkTimelineRequest, EntityFilter, SingleTimelineRequest, TimelineRequest},
+        request::{
+            BulkChunkedTimelineRequest, BulkTimelineRequest, EntityFilter, SingleTimelineRequest,
+            TimelineRequest,
+        },
         response::{
-            BulkTimelinesResponse, BulkTimelinesResponseEntry,
+            BulkChunkedTimelinesResponse, BulkTimelinesResponse, BulkTimelinesResponseEntry,
             ResourceTimeline as UiResourceTimeline, ResourceTimelineBinned,
             ResourceTimelineBinnedByState, SingleTimelineResponse,
         },
@@ -511,6 +514,197 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
         }
 
         Ok(BulkTimelinesResponse { entries })
+    }
+
+    fn bulk_chunked_resource_timeline(
+        &self,
+        request: BulkChunkedTimelineRequest<Self::TimelineGlobalParams, Self::TimelineParams>,
+    ) -> AnalyzerResult<BulkChunkedTimelinesResponse> {
+        let epoch = self
+            .query_engine_model()
+            .query_epoch(request.app_params.query_id)?;
+        let view = self.model.query_view(request.app_params.query_id)?;
+        let resource_tree = view.resource_tree()?;
+
+        let n_configs = request.configs.len();
+
+        // One slot per (entry, config_idx). Builder tuples carry their entry_id
+        // and config_idx so finalize can reassemble the per-entry Vec in order.
+        let mut plain_builders: Vec<(
+            String,
+            usize,
+            ResourceTimelineBuilder,
+            HashSet<Uuid>,
+            TaskFilter,
+        )> = Vec::with_capacity(request.entries.len() * n_configs);
+        let mut per_state_builders: Vec<(
+            String,
+            usize,
+            ResourceTimelineByKeyBuilder<&str>,
+            HashSet<Uuid>,
+            TaskFilter,
+        )> = Vec::with_capacity(request.entries.len() * n_configs);
+
+        // Per-entry prep happens once; per-config builders share the prep's
+        // resource_id_filter, entity_filter, task_filter, and threshold.
+        for (entry_id, entry) in &request.entries {
+            let BulkEntryPrep {
+                resource_type,
+                resource_id_filter,
+                entity_filter,
+                task_filter,
+                long_entities_threshold,
+            } = self.try_prepare_bulk_entry(entry.clone(), &resource_tree)?;
+
+            for (config_idx, config) in request.configs.iter().enumerate() {
+                let entry_config = config.clone().try_into_binned_span(epoch)?;
+                if entity_filter.entity_type_name.is_some() {
+                    per_state_builders.push((
+                        entry_id.clone(),
+                        config_idx,
+                        ResourceTimelineByKeyBuilder::try_new(
+                            resource_type,
+                            entry_config,
+                            long_entities_threshold,
+                        )?,
+                        resource_id_filter.clone(),
+                        task_filter.clone(),
+                    ));
+                } else {
+                    plain_builders.push((
+                        entry_id.clone(),
+                        config_idx,
+                        ResourceTimelineBuilder::try_new(
+                            resource_type,
+                            entry_config,
+                            long_entities_threshold,
+                        )?,
+                        resource_id_filter.clone(),
+                        task_filter.clone(),
+                    ));
+                }
+            }
+        }
+
+        // Reverse index: resource_id -> all builder indices that care about it.
+        let plain_index: HashMap<Uuid, Vec<usize>> = plain_builders
+            .iter()
+            .enumerate()
+            .flat_map(|(builder_idx, builder)| {
+                builder
+                    .3
+                    .iter()
+                    .map(move |&resource_id| (resource_id, builder_idx))
+            })
+            .fold(
+                HashMap::default(),
+                |mut acc, (resource_id, builder_idx)| {
+                    acc.entry(resource_id).or_default().push(builder_idx);
+                    acc
+                },
+            );
+        let per_state_index: HashMap<Uuid, Vec<usize>> = per_state_builders
+            .iter()
+            .enumerate()
+            .flat_map(|(builder_idx, builder)| {
+                builder
+                    .3
+                    .iter()
+                    .map(move |&resource_id| (resource_id, builder_idx))
+            })
+            .fold(
+                HashMap::default(),
+                |mut acc, (resource_id, builder_idx)| {
+                    acc.entry(resource_id).or_default().push(builder_idx);
+                    acc
+                },
+            );
+
+        // Single pass over all tasks/usages — the dominant cost — dispatched to
+        // every matching (entry, config) builder. Builders filter by their own
+        // span internally, so out-of-window usages are no-ops.
+        for task in self.model.tasks.values() {
+            let task_operator_id = task.operator_id();
+            for usage in task.usages() {
+                let resource_id = usage.resource_id();
+                if let Some(builder_indices) = plain_index.get(&resource_id) {
+                    for &builder_idx in builder_indices {
+                        let builder = &plain_builders[builder_idx];
+                        if builder
+                            .4
+                            .operator_id
+                            .is_none_or(|op| task_operator_id == Some(op))
+                        {
+                            plain_builders[builder_idx].2.try_push(&usage)?;
+                        }
+                    }
+                }
+            }
+            for (state_name, usage) in task.usages_with_state_names() {
+                let resource_id = usage.resource_id();
+                if let Some(builder_indices) = per_state_index.get(&resource_id) {
+                    for &builder_idx in builder_indices {
+                        let builder = &per_state_builders[builder_idx];
+                        if builder
+                            .4
+                            .operator_id
+                            .is_none_or(|op| task_operator_id == Some(op))
+                        {
+                            per_state_builders[builder_idx]
+                                .2
+                                .try_push(state_name, &usage)?;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Reassemble per-entry Vec aligned with `request.configs` order. Slots
+        // start as `None` and must all be filled by the end — every (entry,
+        // config_idx) had a builder, and every builder produces an `Ok`.
+        let mut slots: HashMap<String, Vec<Option<BulkTimelinesResponseEntry>>> = request
+            .entries
+            .keys()
+            .map(|k| (k.clone(), (0..n_configs).map(|_| None).collect()))
+            .collect();
+
+        for (entry_id, config_idx, builder, _, _) in plain_builders {
+            let built = builder.build();
+            let config = built.config.try_to_secs_relative(epoch)?;
+            let resp = BulkTimelinesResponseEntry::Ok {
+                message: String::new(),
+                config,
+                data: self.timeline_to_ui(built, epoch)?,
+            };
+            slots.get_mut(&entry_id).unwrap()[config_idx] = Some(resp);
+        }
+        for (entry_id, config_idx, builder, _, _) in per_state_builders {
+            let built = builder.build();
+            let config = built.config.try_to_secs_relative(epoch)?;
+            let resp = BulkTimelinesResponseEntry::Ok {
+                message: String::new(),
+                config,
+                data: self.timeline_to_ui_keyed(built, epoch)?,
+            };
+            slots.get_mut(&entry_id).unwrap()[config_idx] = Some(resp);
+        }
+
+        let entries = slots
+            .into_iter()
+            .map(|(k, v)| {
+                let v = v
+                    .into_iter()
+                    .map(|opt| {
+                        opt.ok_or(AnalyzerError::BrokenImpl(
+                            "chunked bulk: missing builder slot",
+                        ))
+                    })
+                    .collect::<AnalyzerResult<Vec<_>>>()?;
+                Ok((k, v))
+            })
+            .collect::<AnalyzerResult<std::collections::HashMap<_, _>>>()?;
+
+        Ok(BulkChunkedTimelinesResponse { entries })
     }
 }
 

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -528,8 +528,8 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
 
         let n_configs = request.configs.len();
 
-        // One slot per (entry, config_idx). Builder tuples carry their entry_id
-        // and config_idx so finalize can reassemble the per-entry Vec in order.
+        // Builder tuples carry entry_id + config_idx so finalize can slot them
+        // back into the per-entry Vec in `configs` order.
         let mut plain_builders: Vec<(
             String,
             usize,
@@ -545,8 +545,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
             TaskFilter,
         )> = Vec::with_capacity(request.entries.len() * n_configs);
 
-        // Per-entry prep happens once; per-config builders share the prep's
-        // resource_id_filter, entity_filter, task_filter, and threshold.
+        // Per-entry prep runs once; the builders for that entry's N configs all share it.
         for (entry_id, entry) in &request.entries {
             let BulkEntryPrep {
                 resource_type,
@@ -586,7 +585,6 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
             }
         }
 
-        // Reverse index: resource_id -> all builder indices that care about it.
         let plain_index: HashMap<Uuid, Vec<usize>> = plain_builders
             .iter()
             .enumerate()

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -594,13 +594,10 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                     .iter()
                     .map(move |&resource_id| (resource_id, builder_idx))
             })
-            .fold(
-                HashMap::default(),
-                |mut acc, (resource_id, builder_idx)| {
-                    acc.entry(resource_id).or_default().push(builder_idx);
-                    acc
-                },
-            );
+            .fold(HashMap::default(), |mut acc, (resource_id, builder_idx)| {
+                acc.entry(resource_id).or_default().push(builder_idx);
+                acc
+            });
         let per_state_index: HashMap<Uuid, Vec<usize>> = per_state_builders
             .iter()
             .enumerate()
@@ -610,13 +607,10 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                     .iter()
                     .map(move |&resource_id| (resource_id, builder_idx))
             })
-            .fold(
-                HashMap::default(),
-                |mut acc, (resource_id, builder_idx)| {
-                    acc.entry(resource_id).or_default().push(builder_idx);
-                    acc
-                },
-            );
+            .fold(HashMap::default(), |mut acc, (resource_id, builder_idx)| {
+                acc.entry(resource_id).or_default().push(builder_idx);
+                acc
+            });
 
         // Single pass over all tasks/usages — the dominant cost — dispatched to
         // every matching (entry, config) builder. Builders filter by their own

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -670,10 +670,9 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                 config,
                 data: self.timeline_to_ui(built, epoch)?,
             };
-            slots
-                .get_mut(&slot.entry_id)
-                .unwrap_or_else(|| panic!("known key, instead found unknown key {}", slot.entry_id))
-                [slot.config_idx] = Some(resp);
+            slots.get_mut(&slot.entry_id).unwrap_or_else(|| {
+                panic!("known key, instead found unknown key {}", slot.entry_id)
+            })[slot.config_idx] = Some(resp);
         }
         for slot in per_state_builders {
             let built = slot.builder.build();
@@ -683,10 +682,9 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                 config,
                 data: self.timeline_to_ui_keyed(built, epoch)?,
             };
-            slots
-                .get_mut(&slot.entry_id)
-                .unwrap_or_else(|| panic!("known key, instead found unknown key {}", slot.entry_id))
-                [slot.config_idx] = Some(resp);
+            slots.get_mut(&slot.entry_id).unwrap_or_else(|| {
+                panic!("known key, instead found unknown key {}", slot.entry_id)
+            })[slot.config_idx] = Some(resp);
         }
 
         let entries = slots

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -22,6 +22,7 @@ use quent_ui::{
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::HashMap as StdHashMap;
+use std::sync::Arc;
 use tracing::debug;
 
 use quent_analyzer::{
@@ -57,7 +58,7 @@ struct PlainBuilderSlot<'a> {
     entry_id: String,
     config_idx: usize,
     builder: ResourceTimelineBuilder<'a>,
-    resource_id_filter: HashSet<Uuid>,
+    resource_id_filter: Arc<HashSet<Uuid>>,
     task_filter: TaskFilter,
 }
 
@@ -65,7 +66,7 @@ struct PerStateBuilderSlot<'a> {
     entry_id: String,
     config_idx: usize,
     builder: ResourceTimelineByKeyBuilder<'a, &'a str>,
-    resource_id_filter: HashSet<Uuid>,
+    resource_id_filter: Arc<HashSet<Uuid>>,
     task_filter: TaskFilter,
 }
 
@@ -559,6 +560,9 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                 long_entities_threshold,
             } = self.try_prepare_bulk_entry(entry.clone(), &resource_tree)?;
 
+            // Wrap the filter once so per-config slots share one allocation.
+            let resource_id_filter = Arc::new(resource_id_filter);
+
             for (config_idx, config) in request.configs.iter().enumerate() {
                 let entry_config = config.try_into_binned_span(epoch)?;
                 if entity_filter.entity_type_name.is_some() {
@@ -570,7 +574,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                             entry_config,
                             long_entities_threshold,
                         )?,
-                        resource_id_filter: resource_id_filter.clone(),
+                        resource_id_filter: Arc::clone(&resource_id_filter),
                         task_filter: task_filter.clone(),
                     });
                 } else {
@@ -582,7 +586,7 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                             entry_config,
                             long_entities_threshold,
                         )?,
-                        resource_id_filter: resource_id_filter.clone(),
+                        resource_id_filter: Arc::clone(&resource_id_filter),
                         task_filter: task_filter.clone(),
                     });
                 }

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -53,23 +53,21 @@ pub struct SimulatorUiAnalyzer {
     pub model: SimulatorModel,
 }
 
-/// `(entry_id, config_idx, builder, resource_id_filter, task_filter)` for the
-/// chunked bulk path. Carries the entry and config bookkeeping needed to slot
-/// each builder back into the per-entry response Vec at finalize time.
-type PlainBuilderSlot<'a> = (
-    String,
-    usize,
-    ResourceTimelineBuilder<'a>,
-    HashSet<Uuid>,
-    TaskFilter,
-);
-type PerStateBuilderSlot<'a> = (
-    String,
-    usize,
-    ResourceTimelineByKeyBuilder<'a, &'a str>,
-    HashSet<Uuid>,
-    TaskFilter,
-);
+struct PlainBuilderSlot<'a> {
+    entry_id: String,
+    config_idx: usize,
+    builder: ResourceTimelineBuilder<'a>,
+    resource_id_filter: HashSet<Uuid>,
+    task_filter: TaskFilter,
+}
+
+struct PerStateBuilderSlot<'a> {
+    entry_id: String,
+    config_idx: usize,
+    builder: ResourceTimelineByKeyBuilder<'a, &'a str>,
+    resource_id_filter: HashSet<Uuid>,
+    task_filter: TaskFilter,
+}
 
 impl UiAnalyzer for SimulatorUiAnalyzer {
     type Event = SimulatorEvent;
@@ -564,29 +562,29 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
             for (config_idx, config) in request.configs.iter().enumerate() {
                 let entry_config = config.try_into_binned_span(epoch)?;
                 if entity_filter.entity_type_name.is_some() {
-                    per_state_builders.push((
-                        entry_id.clone(),
+                    per_state_builders.push(PerStateBuilderSlot {
+                        entry_id: entry_id.clone(),
                         config_idx,
-                        ResourceTimelineByKeyBuilder::try_new(
+                        builder: ResourceTimelineByKeyBuilder::try_new(
                             resource_type,
                             entry_config,
                             long_entities_threshold,
                         )?,
-                        resource_id_filter.clone(),
-                        task_filter.clone(),
-                    ));
+                        resource_id_filter: resource_id_filter.clone(),
+                        task_filter: task_filter.clone(),
+                    });
                 } else {
-                    plain_builders.push((
-                        entry_id.clone(),
+                    plain_builders.push(PlainBuilderSlot {
+                        entry_id: entry_id.clone(),
                         config_idx,
-                        ResourceTimelineBuilder::try_new(
+                        builder: ResourceTimelineBuilder::try_new(
                             resource_type,
                             entry_config,
                             long_entities_threshold,
                         )?,
-                        resource_id_filter.clone(),
-                        task_filter.clone(),
-                    ));
+                        resource_id_filter: resource_id_filter.clone(),
+                        task_filter: task_filter.clone(),
+                    });
                 }
             }
         }
@@ -594,9 +592,8 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
         let plain_index: HashMap<Uuid, Vec<usize>> = plain_builders
             .iter()
             .enumerate()
-            .flat_map(|(builder_idx, builder)| {
-                builder
-                    .3
+            .flat_map(|(builder_idx, slot)| {
+                slot.resource_id_filter
                     .iter()
                     .map(move |&resource_id| (resource_id, builder_idx))
             })
@@ -607,9 +604,8 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
         let per_state_index: HashMap<Uuid, Vec<usize>> = per_state_builders
             .iter()
             .enumerate()
-            .flat_map(|(builder_idx, builder)| {
-                builder
-                    .3
+            .flat_map(|(builder_idx, slot)| {
+                slot.resource_id_filter
                     .iter()
                     .map(move |&resource_id| (resource_id, builder_idx))
             })
@@ -627,13 +623,13 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                 let resource_id = usage.resource_id();
                 if let Some(builder_indices) = plain_index.get(&resource_id) {
                     for &builder_idx in builder_indices {
-                        let builder = &plain_builders[builder_idx];
-                        if builder
-                            .4
+                        let slot = &plain_builders[builder_idx];
+                        if slot
+                            .task_filter
                             .operator_id
                             .is_none_or(|op| task_operator_id == Some(op))
                         {
-                            plain_builders[builder_idx].2.try_push(&usage)?;
+                            plain_builders[builder_idx].builder.try_push(&usage)?;
                         }
                     }
                 }
@@ -642,14 +638,14 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
                 let resource_id = usage.resource_id();
                 if let Some(builder_indices) = per_state_index.get(&resource_id) {
                     for &builder_idx in builder_indices {
-                        let builder = &per_state_builders[builder_idx];
-                        if builder
-                            .4
+                        let slot = &per_state_builders[builder_idx];
+                        if slot
+                            .task_filter
                             .operator_id
                             .is_none_or(|op| task_operator_id == Some(op))
                         {
                             per_state_builders[builder_idx]
-                                .2
+                                .builder
                                 .try_push(state_name, &usage)?;
                         }
                     }
@@ -666,25 +662,25 @@ impl UiAnalyzer for SimulatorUiAnalyzer {
             .map(|k| (k.clone(), (0..n_configs).map(|_| None).collect()))
             .collect();
 
-        for (entry_id, config_idx, builder, _, _) in plain_builders {
-            let built = builder.build();
+        for slot in plain_builders {
+            let built = slot.builder.build();
             let config = built.config.try_to_secs_relative(epoch)?;
             let resp = BulkTimelinesResponseEntry::Ok {
                 message: String::new(),
                 config,
                 data: self.timeline_to_ui(built, epoch)?,
             };
-            slots.get_mut(&entry_id).unwrap()[config_idx] = Some(resp);
+            slots.get_mut(&slot.entry_id).unwrap()[slot.config_idx] = Some(resp);
         }
-        for (entry_id, config_idx, builder, _, _) in per_state_builders {
-            let built = builder.build();
+        for slot in per_state_builders {
+            let built = slot.builder.build();
             let config = built.config.try_to_secs_relative(epoch)?;
             let resp = BulkTimelinesResponseEntry::Ok {
                 message: String::new(),
                 config,
                 data: self.timeline_to_ui_keyed(built, epoch)?,
             };
-            slots.get_mut(&entry_id).unwrap()[config_idx] = Some(resp);
+            slots.get_mut(&slot.entry_id).unwrap()[slot.config_idx] = Some(resp);
         }
 
         let entries = slots


### PR DESCRIPTION
This PR fixes two related issues in the bulk timeline caching path:      

1. A correctness bug in the original bulk caching commit (#111) where cached data didn't match its cache-key labels, causing timelines to shift on pan, highlights to drift, and leaf timelines to disagree with their aggregated parents.                                              
2. A performance regression that the correctness fix introduced — cold bulk requests went from one analyzer call to N sequential calls (one per canonical chunk).

**Background: the original bug**                                             
   
The bulk cache uses `ChunkCacheKey { engine_id, params_hash, zoom_level, chunk_idx, num_bins }`. Each chunk represents a canonical span - e.g., on an engine [0, 100] at zoom level 4, chunks are [0,25], [25,50], [50,75], [75,100].

The correctness invariant is: data cached under chunk key `chunk_idx=N` must contain the bins for the canonical span of chunk `N`, regardless of what viewport triggered the fetch. The original cold-fetch path (`cold_fetch_and_cache`) violated this. It:
1. Called `bulk_resource_timeline()` with the user's exact viewport (e.g., [30, 80]).
2. Sliced the viewport response into chunk-sized pieces via `split_response_into_chunks`.                                              
3. Cached each piece under its canonical `chunk_idx` key — but the data inside was sliced at the viewport's bin boundaries, not the chunk's.

**Fix layer 1: canonical chunk fetches**

The first commit (`c25b2ce`) replaces the slice-the-viewport  approach with direct canonical-chunk fetching. Cold and partial paths now both fetch (`canonical_chunk_span`, `num_bins`) configs and cache the responses unaltered.
  
Tests added in `timeline_cache.rs::tests` lock in the correctness invariant:
- `cold_bulk_fetches_canonical_chunks_not_original_viewport` directly asserts canonical spans (25,50), (50,75), (75,100) for a viewport-misaligned request — would fail against the old code.
- `panned_bulk_view_reuses_overlapping_cached_chunks` asserts the cache-reuse path no longer drifts.
- Plus tests for partial-miss merging, error preservation, and operator-filter cache key correctness.                        
                                                                           
`combine_chunks` was also fixed to derive the response span from actual contributing bin boundaries instead of `req_span`, eliminating a smaller related label/data drift when chunk boundaries don't align with the viewport.

**Why c25b2ce alone wasn't enough**
         
Cold cache went from one bulk call to N sequential calls (one per canonical chunk). The dominant cost in `bulk_resource_timeline` is the `for task in self.model.tasks.values()` loop - it scales with engine size, not viewport, and is paid per call. Original #111 explicitly aimed for cold-cache parity with pre-caching; the correctness fix regressed it.

**Fix: chunked analyzer call**

New trait method `UiAnalyzer::bulk_chunked_resource_timeline` accepts `N` time windows per entry and emits `N` outputs per entry. The default impl loops over `bulk_resource_timeline` once per config. `SimulatorUiAnalyzer` overrides with a single-pass version: `N×M` builders (one per (entry, config)), one iteration over `model.tasks`, each usage dispatched to all matching builders via the existing reverse index. Restores cold-cache parity. New `BulkChunkedTimelineRequest` / `BulkChunkedTimelinesResponse` are server-internal - the bulk endpoint shape is unchanged.                                

**Test plan**                                                                

- All 5 `timeline_cache::tests` pass (canonical-span cold fetch, pan reuse, partial-miss merging, operator-filter cache key, error preservation).
- Manually verified in the dev server: no timeline shift on pan, no highlight drift, leaf timelines match aggregated parents.                
                             
**Future considerations / known limitations**                                

1. `long_entities_threshold_s` across chunk boundaries (pre-existing). Threshold is evaluated per builder, i.e. per chunk. An entity that's long globally but short within each chunk window may be classified inconsistently. Not introduced here but worth a separate ticket if the intent is "global duration."
2. Default trait impl is the regressed path. Only `SimulatorUiAnalyzer` overrides it. Any future `UiAnalyzer` impl inherits the N-call behavior unless it also overrides. Doc comment flags this.
3. `bulk_resource_timeline` is becoming vestigial. The cache only calls the chunked method now; the old method survives as a fallback for degenerate inputs (empty entries, zero-duration engine) and as the underpinning of the default trait impl. Follow-up candidate for consolidation.           
4. No automated equivalence test for the simulator override. The simulator analyzer crate has no test fixtures (data/ ndjson files are gitignored), and synthetic event construction is non-trivial. A small committed fixture would unlock a property test ("chunked output ≡ N independent `bulk_resource_timeline calls`") protecting both methods against future drift. Validation here was manual.