### PR TITLE
refactor(ui): trigger dev tools with env var

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -167,10 +167,26 @@ pnpm dlx shadcn@latest add dropdown-menu
 
 ## Development Tools
 
-The application includes development tools for debugging:
+The application can render TanStack devtools for debugging:
 
 - **TanStack Router Devtools** - Visual router debugging
 - **TanStack Query Devtools** - Query state inspection
 
-These are automatically included in development mode and removed in production
-builds.
+Both are off by default and gated behind the `VITE_DEBUG` env var, so they
+won't appear in normal `pnpm dev` sessions or in production builds.
+
+To enable them, start the dev server with `VITE_DEBUG=1`:
+
+```bash
+VITE_DEBUG=1 pnpm dev
+```
+
+To leave them on for every dev session on your machine, create a
+`ui/.env.development.local` file (already gitignored via `*.local`):
+
+```bash
+VITE_DEBUG=1
+```
+
+Then a plain `pnpm dev` will pick it up. Restart the dev server after
+changing env vars — Vite does not hot-reload `import.meta.env` changes.

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -27,7 +27,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
+      {import.meta.env.VITE_DEBUG && !import.meta.env.TEST && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -68,7 +68,7 @@ function RootComponent() {
           </main>
         </div>
       </ThemeProvider>
-      {import.meta.env.DEV && !import.meta.env.TEST && <TanStackRouterDevtools />}
+      {import.meta.env.VITE_DEBUG && !import.meta.env.TEST && <TanStackRouterDevtools />}
     </>
   );
 }


### PR DESCRIPTION
Currently these are on for all dev environments, but they are pretty intrusive for how frequently they are needed. Push them back behind an env variable setup for debugging.

Fixes #137 
