### PR TITLE
fix(ui): theme change resets zoom range

### DIFF
--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -98,7 +98,6 @@ export {
   buildTimelineMarks,
   collectVisibleEntries,
   getAdaptiveNumBins,
-  getChartGroupZoomState,
   getFsmTypeName,
   getLongEntitiesThreshold,
   getLongFsms,

--- a/ui/packages/@quent/components/src/lib/timeline.utils.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.ts
@@ -30,7 +30,7 @@ import { entityRefToEntitiesKey } from './queryBundle.utils';
 import { collectResourceTypesFromTree, getIconForType } from './resource.utils';
 import { EntityTypeValue, EntityRefKey, EntityTypeKey } from '@quent/utils';
 import type { EChartsInstance } from 'echarts-for-react';
-import { connect, getInstanceByDom } from './echarts';
+import { connect } from './echarts';
 import { CHART_GROUP } from '../timeline/Timeline';
 
 // Suppress unused import warning — getColorForKey is used by consumers of this module
@@ -354,50 +354,30 @@ export function getTimelineXAxisIntervalMs(spanMs: number, targetSplits: number 
   return maxAllowedStep;
 }
 
-function findExistingChartInGroup(chartGroup: string): EChartsInstance | null {
-  const chartElements = document.querySelectorAll('[_echarts_instance_]');
-  for (const el of chartElements) {
-    const instance = getInstanceByDom(el as HTMLElement);
-    if (instance && instance.group === chartGroup) {
-      return instance as unknown as EChartsInstance;
-    }
-  }
-  return null;
-}
-
 /**
- * Get the current zoom state from any existing chart in the group.
- * Returns null if no charts exist or no zoom state is set.
+ * Join `instance` to the named connect group and seed its dataZoom from the
+ * caller-supplied zoom percentages. Callers (React components/hooks) are
+ * expected to read the live zoom from `zoomRangeAtom` and pass it in here —
+ * the atom is the single source of truth, so this utility never touches it
+ * directly (per `ui/AGENTS.md` atoms are React-only).
+ *
+ * Pass `zoomPct = null` to skip seeding (e.g. when no zoom has been
+ * established yet, like a 0-duration query).
  */
-export function getChartGroupZoomState(
-  chartGroup: string = CHART_GROUP
-): { start: number; end: number } | null {
-  const existingInstance = findExistingChartInGroup(chartGroup);
-  if (existingInstance) {
-    const existingOption = existingInstance.getOption();
-    const dataZoomOption = existingOption.dataZoom as Array<{ start?: number; end?: number }>;
-
-    if (dataZoomOption?.[0]?.start !== undefined && dataZoomOption?.[0]?.end !== undefined) {
-      return { start: dataZoomOption[0].start, end: dataZoomOption[0].end };
-    }
-  }
-  return null;
-}
-
 export const connectChart = (
   instance: EChartsInstance,
   chartGroup: string = CHART_GROUP,
-  activateBrushSelect = true
+  activateBrushSelect = true,
+  zoomPct: { start: number; end: number } | null = null
 ) => {
   // Apply current zoom to this chart without replacing its dataZoom components.
   // setOption({ dataZoom: [zoomState] }) would replace the array and break slider/inside config.
-  const zoomState = getChartGroupZoomState(chartGroup);
-  if (zoomState) {
+  if (zoomPct) {
     instance.dispatchAction({
       type: 'dataZoom',
       dataZoomIndex: 0,
-      start: zoomState.start,
-      end: zoomState.end,
+      start: zoomPct.start,
+      end: zoomPct.end,
     });
   }
 

--- a/ui/packages/@quent/components/src/lib/useChartConnect.ts
+++ b/ui/packages/@quent/components/src/lib/useChartConnect.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+import type { EChartsInstance } from 'echarts-for-react';
+import { useZoomRange } from '@quent/hooks';
+import { connectChart } from './timeline.utils';
+
+export interface UseChartConnectOptions {
+  /** Full query duration in seconds. Used to convert zoomRangeAtom seconds → percent. */
+  durationSeconds: number;
+  /** Connect-group name. Defaults to the timeline sync group. */
+  chartGroup?: string;
+  /** Forwarded to {@link connectChart}; enables ECharts' brush-select cursor. */
+  activateBrushSelect?: boolean;
+  /**
+   * Component-specific setup invoked after the standard connect-group join.
+   * Use this for DOM listeners, ECharts events, axis-pointer sync, etc.
+   */
+  onReady?: (instance: EChartsInstance) => void;
+}
+
+export interface UseChartConnectResult {
+  /** Pass to `<ReactEChartsComponent onChartReady={...} />`. */
+  handleChartReady: (instance: EChartsInstance) => void;
+  /** Live ref to the active ECharts instance, or null before first ready. */
+  instanceRef: MutableRefObject<EChartsInstance | null>;
+}
+
+/**
+ * Shared `onChartReady` handler for charts that participate in the timeline
+ * connect group.
+ *
+ * Reads the live zoom from `zoomRangeAtom` via {@link useZoomRange} on every
+ * render and stashes both the zoom and the current `durationSeconds` in refs,
+ * so the returned `handleChartReady` always seeds new instances with the
+ * up-to-date values without rebuilding the callback. This is what keeps a
+ * user's saved zoom intact across theme switches (which simultaneously dispose
+ * and recreate every chart in the group).
+ *
+ * The component-specific bits — DOM event listeners, axis-pointer sync,
+ * ready-tick state, etc. — are passed in via `onReady`, which fires after
+ * the standard {@link connectChart} call.
+ */
+export function useChartConnect({
+  durationSeconds,
+  chartGroup,
+  activateBrushSelect = false,
+  onReady,
+}: UseChartConnectOptions): UseChartConnectResult {
+  const zoomRange = useZoomRange();
+
+  const instanceRef = useRef<EChartsInstance | null>(null);
+  const zoomRangeRef = useRef(zoomRange);
+  zoomRangeRef.current = zoomRange;
+  const durationSecondsRef = useRef(durationSeconds);
+  durationSecondsRef.current = durationSeconds;
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
+
+  const handleChartReady = useCallback(
+    (instance: EChartsInstance) => {
+      instanceRef.current = instance;
+      const dur = durationSecondsRef.current;
+      const range = zoomRangeRef.current;
+      const zoomPct =
+        dur > 0 ? { start: (range.start / dur) * 100, end: (range.end / dur) * 100 } : null;
+      connectChart(instance, chartGroup, activateBrushSelect, zoomPct);
+      onReadyRef.current?.(instance);
+    },
+    [chartGroup, activateBrushSelect]
+  );
+
+  return { handleChartReady, instanceRef };
+}

--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import ReactEChartsComponent from 'echarts-for-react';
 
 import type { EChartsOption } from '../lib/echarts';
@@ -9,10 +9,10 @@ import type { EChartsInstance } from 'echarts-for-react';
 import type { CustomSeriesOption } from 'echarts/charts';
 import {
   nanosToMs,
-  connectChart,
   registerAxisPointerSync,
   unregisterAxisPointerSync,
 } from '../lib/timeline.utils';
+import { useChartConnect } from '../lib/useChartConnect';
 import { echarts } from '../lib/echarts';
 import { CHART_GROUP } from '../timeline/Timeline';
 import { useTimelineEchartsTheme } from '../timeline/timelineEchartsTheme';
@@ -23,7 +23,6 @@ import {
   useSetSelectedPlanId,
   useNodeColoringValue,
   useNodeColorPalette,
-  useZoomRange,
 } from '@quent/hooks';
 import { continuousColor, withOpacity } from '@quent/utils';
 import {
@@ -69,15 +68,6 @@ export function OperatorGanttChart({
   const [nodePalette] = useNodeColorPalette();
   const barLabelTextColor = textColor;
   const selectedNodeIds = useSelectedNodeIds();
-  const zoomRange = useZoomRange();
-  // Refs feed the latest persisted zoom into handleChartReady without re-creating
-  // the callback. Reading from refs lets us seed the chart's dataZoom on every
-  // (re)mount — including the simultaneous remount of all charts on a theme
-  // switch — directly from the zoomRangeAtom that React owns.
-  const zoomRangeRef = useRef(zoomRange);
-  zoomRangeRef.current = zoomRange;
-  const durationSecondsRef = useRef(durationSeconds);
-  durationSecondsRef.current = durationSeconds;
   const startTimeMs = useMemo(() => nanosToMs(startTime), [startTime]);
   const xAxisMax = useMemo(
     () => startTimeMs + durationSeconds * 1_000,
@@ -325,8 +315,6 @@ export function OperatorGanttChart({
     ]
   );
 
-  const instanceRef = useRef<EChartsInstance | null>(null);
-
   const handleClick = useMemo(
     () => ({
       click: (params: { dataIndex: number; seriesName?: string }) => {
@@ -348,16 +336,10 @@ export function OperatorGanttChart({
     [operators, selectedNodeIds, setSelectedNodeIds, setSelectedOperatorLabel, setSelectedPlanId]
   );
 
-  const handleChartReady = useCallback((instance: EChartsInstance) => {
-    instanceRef.current = instance;
-    // Join timeline-sync-group for frame-rate-level x-axis zoom sync via ECharts connect().
-    // The y-axis dataZoom (index 3, when present) has a unique component ID and does not
-    // propagate to resource timelines that have no matching component.
-    const dur = durationSecondsRef.current;
-    const range = zoomRangeRef.current;
-    const zoomPct =
-      dur > 0 ? { start: (range.start / dur) * 100, end: (range.end / dur) * 100 } : null;
-    connectChart(instance, CHART_GROUP, false, zoomPct);
+  // Join timeline-sync-group for frame-rate-level x-axis zoom sync via ECharts connect().
+  // The y-axis dataZoom (index 3, when present) has a unique component ID and does not
+  // propagate to resource timelines that have no matching component.
+  const onChartReady = useCallback((instance: EChartsInstance) => {
     registerAxisPointerSync(instance, 0, { receiveShowTip: false });
     const dom = instance.getDom();
     dom.addEventListener(
@@ -368,6 +350,12 @@ export function OperatorGanttChart({
       { capture: true, passive: false }
     );
   }, []);
+
+  const { handleChartReady, instanceRef } = useChartConnect({
+    durationSeconds,
+    chartGroup: CHART_GROUP,
+    onReady: onChartReady,
+  });
 
   useEffect(() => {
     return () => {

--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -23,6 +23,7 @@ import {
   useSetSelectedPlanId,
   useNodeColoringValue,
   useNodeColorPalette,
+  useZoomRange,
 } from '@quent/hooks';
 import { continuousColor, withOpacity } from '@quent/utils';
 import {
@@ -68,6 +69,15 @@ export function OperatorGanttChart({
   const [nodePalette] = useNodeColorPalette();
   const barLabelTextColor = textColor;
   const selectedNodeIds = useSelectedNodeIds();
+  const zoomRange = useZoomRange();
+  // Refs feed the latest persisted zoom into handleChartReady without re-creating
+  // the callback. Reading from refs lets us seed the chart's dataZoom on every
+  // (re)mount — including the simultaneous remount of all charts on a theme
+  // switch — directly from the zoomRangeAtom that React owns.
+  const zoomRangeRef = useRef(zoomRange);
+  zoomRangeRef.current = zoomRange;
+  const durationSecondsRef = useRef(durationSeconds);
+  durationSecondsRef.current = durationSeconds;
   const startTimeMs = useMemo(() => nanosToMs(startTime), [startTime]);
   const xAxisMax = useMemo(
     () => startTimeMs + durationSeconds * 1_000,
@@ -343,7 +353,11 @@ export function OperatorGanttChart({
     // Join timeline-sync-group for frame-rate-level x-axis zoom sync via ECharts connect().
     // The y-axis dataZoom (index 3, when present) has a unique component ID and does not
     // propagate to resource timelines that have no matching component.
-    connectChart(instance, CHART_GROUP, false);
+    const dur = durationSecondsRef.current;
+    const range = zoomRangeRef.current;
+    const zoomPct =
+      dur > 0 ? { start: (range.start / dur) * 100, end: (range.end / dur) * 100 } : null;
+    connectChart(instance, CHART_GROUP, false, zoomPct);
     registerAxisPointerSync(instance, 0, { receiveShowTip: false });
     const dom = instance.getDom();
     dom.addEventListener(

--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -27,7 +27,8 @@ import {
   ROLLUP_TIMELINE_COLOR_LIGHT,
   useTimelineEchartsTheme,
 } from './timelineEchartsTheme';
-import { connectChart, MIN_ZOOM_WINDOW_S, nanosToMs } from '../lib/timeline.utils';
+import { MIN_ZOOM_WINDOW_S, nanosToMs } from '../lib/timeline.utils';
+import { useChartConnect } from '../lib/useChartConnect';
 
 export const CHART_GROUP = 'timeline-sync-group';
 const DIMMED_OPACITY = 0.25;
@@ -59,15 +60,6 @@ export function Timeline({
   const zoomRange = useZoomRange();
   const windowMsRef = useRef(0);
   windowMsRef.current = (zoomRange.end - zoomRange.start) * 1000;
-
-  // Refs feed the latest persisted zoom into handleChartReady without re-creating
-  // the callback. Reading from refs lets us seed the chart's dataZoom on every
-  // (re)mount — including the simultaneous remount of all charts on a theme
-  // switch — directly from the zoomRangeAtom that React owns.
-  const zoomRangeRef = useRef(zoomRange);
-  zoomRangeRef.current = zoomRange;
-  const durationSecondsRef = useRef(durationSeconds);
-  durationSecondsRef.current = durationSeconds;
 
   const maxMarkCountRef = useRef(0);
 
@@ -335,17 +327,9 @@ export function Timeline({
     marks,
   ]);
 
-  const instanceRef = useRef<EChartsInstance | null>(null);
   const isDraggingRef = useRef(false);
 
-  const handleChartReady = useCallback((instance: EChartsInstance) => {
-    instanceRef.current = instance;
-    const dur = durationSecondsRef.current;
-    const range = zoomRangeRef.current;
-    const zoomPct =
-      dur > 0 ? { start: (range.start / dur) * 100, end: (range.end / dur) * 100 } : null;
-    connectChart(instance, CHART_GROUP, false, zoomPct);
-
+  const onChartReady = useCallback((instance: EChartsInstance) => {
     const dom = instance.getDom();
     dom.addEventListener('pointerdown', () => {
       isDraggingRef.current = true;
@@ -391,6 +375,12 @@ export function Timeline({
       { passive: false }
     );
   }, []);
+
+  const { handleChartReady } = useChartConnect({
+    durationSeconds,
+    chartGroup: CHART_GROUP,
+    onReady: onChartReady,
+  });
 
   return (
     <ReactEChartsComponent

--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -60,6 +60,15 @@ export function Timeline({
   const windowMsRef = useRef(0);
   windowMsRef.current = (zoomRange.end - zoomRange.start) * 1000;
 
+  // Refs feed the latest persisted zoom into handleChartReady without re-creating
+  // the callback. Reading from refs lets us seed the chart's dataZoom on every
+  // (re)mount — including the simultaneous remount of all charts on a theme
+  // switch — directly from the zoomRangeAtom that React owns.
+  const zoomRangeRef = useRef(zoomRange);
+  zoomRangeRef.current = zoomRange;
+  const durationSecondsRef = useRef(durationSeconds);
+  durationSecondsRef.current = durationSeconds;
+
   const maxMarkCountRef = useRef(0);
 
   const seriesOptions = useMemo(() => {
@@ -331,7 +340,11 @@ export function Timeline({
 
   const handleChartReady = useCallback((instance: EChartsInstance) => {
     instanceRef.current = instance;
-    connectChart(instance, CHART_GROUP, false);
+    const dur = durationSecondsRef.current;
+    const range = zoomRangeRef.current;
+    const zoomPct =
+      dur > 0 ? { start: (range.start / dur) * 100, end: (range.end / dur) * 100 } : null;
+    connectChart(instance, CHART_GROUP, false, zoomPct);
 
     const dom = instance.getDom();
     dom.addEventListener('pointerdown', () => {

--- a/ui/packages/@quent/components/src/timeline/TimelineController.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineController.tsx
@@ -293,17 +293,24 @@ export function TimelineController({
 
   const instanceRef = useRef<EChartsInstance | null>(null);
   const selfTriggeredRef = useRef(false);
-  const [chartReady, setChartReady] = useState(false);
+  // Increments on every chart-ready event so the restore effect re-fires when
+  // the underlying ECharts instance is recreated (e.g. on theme change, which
+  // disposes and re-creates the chart and would otherwise leave the new
+  // instance at its default 0–100% zoom).
+  const [readyTick, setReadyTick] = useState(0);
 
   const zoomRange = useZoomRange();
+  const zoomRangeRef = useRef(zoomRange);
+  zoomRangeRef.current = zoomRange;
+  const durationSecondsRef = useRef(durationSeconds);
+  durationSecondsRef.current = durationSeconds;
 
-  // Restore the dataZoom slider position from the persisted atom whenever
-  // either the zoom range changes or the chart instance becomes ready.
-  // Gating on `chartReady` is required so that on remount (e.g. tab switch
-  // back to /timeline) the saved zoom is re-applied after `handleChartReady`
-  // sets `instanceRef.current`.
+  // Restore the dataZoom slider position from the persisted atom whenever the
+  // zoom range changes or a (re)created chart instance becomes ready. The
+  // `readyTick` dependency ensures recreated instances inherit the saved zoom
+  // even when the atom value itself is unchanged across the remount.
   useEffect(() => {
-    if (!chartReady) return;
+    if (readyTick === 0) return;
     if (selfTriggeredRef.current) {
       selfTriggeredRef.current = false;
       return;
@@ -314,19 +321,27 @@ export function TimelineController({
     const startPct = (zoomRange.start / durationSeconds) * 100;
     const endPct = (zoomRange.end / durationSeconds) * 100;
 
+    // Mute the dataZoom event our own dispatch is about to emit, so the
+    // recreated chart's initial restore doesn't echo back through onZoomChange
+    // and overwrite the atom (which would visibly snap the bounds back).
+    selfTriggeredRef.current = true;
     instance.dispatchAction({
       type: 'dataZoom',
       dataZoomIndex: 0,
       start: startPct,
       end: endPct,
     });
-  }, [chartReady, zoomRange, durationSeconds]);
+  }, [readyTick, zoomRange, durationSeconds]);
 
   const handleChartReady = useCallback((instance: EChartsInstance) => {
     instanceRef.current = instance;
-    connectChart(instance);
+    const dur = durationSecondsRef.current;
+    const range = zoomRangeRef.current;
+    const zoomPct =
+      dur > 0 ? { start: (range.start / dur) * 100, end: (range.end / dur) * 100 } : null;
+    connectChart(instance, undefined, true, zoomPct);
     registerAxisPointerSync(instance, 0);
-    setChartReady(true);
+    setReadyTick(t => t + 1);
   }, []);
 
   useEffect(() => {

--- a/ui/packages/@quent/components/src/timeline/TimelineController.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineController.tsx
@@ -11,7 +11,6 @@ import { formatDuration } from '@quent/utils';
 import type { ZoomRange } from '@quent/utils';
 import {
   buildBinnedTimelineSeries,
-  connectChart,
   getAdaptiveNumBins,
   getTimelineXAxisIntervalMs,
   MIN_ZOOM_WINDOW_S,
@@ -19,6 +18,7 @@ import {
   registerAxisPointerSync,
   unregisterAxisPointerSync,
 } from '../lib/timeline.utils';
+import { useChartConnect } from '../lib/useChartConnect';
 import { TIMELINE_X_AXIS_ANIMATION, TIMELINE_SPACING } from './types';
 import type { SingleTimelineResponse } from '@quent/utils';
 import { useTimelineEchartsTheme } from './timelineEchartsTheme';
@@ -291,7 +291,6 @@ export function TimelineController({
     };
   }, [onZoomChange, durationSeconds]);
 
-  const instanceRef = useRef<EChartsInstance | null>(null);
   const selfTriggeredRef = useRef(false);
   // Increments on every chart-ready event so the restore effect re-fires when
   // the underlying ECharts instance is recreated (e.g. on theme change, which
@@ -300,10 +299,17 @@ export function TimelineController({
   const [readyTick, setReadyTick] = useState(0);
 
   const zoomRange = useZoomRange();
-  const zoomRangeRef = useRef(zoomRange);
-  zoomRangeRef.current = zoomRange;
-  const durationSecondsRef = useRef(durationSeconds);
-  durationSecondsRef.current = durationSeconds;
+
+  const onChartReady = useCallback((instance: EChartsInstance) => {
+    registerAxisPointerSync(instance, 0);
+    setReadyTick(t => t + 1);
+  }, []);
+
+  const { handleChartReady, instanceRef } = useChartConnect({
+    durationSeconds,
+    activateBrushSelect: true,
+    onReady: onChartReady,
+  });
 
   // Restore the dataZoom slider position from the persisted atom whenever the
   // zoom range changes or a (re)created chart instance becomes ready. The
@@ -331,18 +337,7 @@ export function TimelineController({
       start: startPct,
       end: endPct,
     });
-  }, [readyTick, zoomRange, durationSeconds]);
-
-  const handleChartReady = useCallback((instance: EChartsInstance) => {
-    instanceRef.current = instance;
-    const dur = durationSecondsRef.current;
-    const range = zoomRangeRef.current;
-    const zoomPct =
-      dur > 0 ? { start: (range.start / dur) * 100, end: (range.end / dur) * 100 } : null;
-    connectChart(instance, undefined, true, zoomPct);
-    registerAxisPointerSync(instance, 0);
-    setReadyTick(t => t + 1);
-  }, []);
+  }, [readyTick, zoomRange, durationSeconds, instanceRef]);
 
   useEffect(() => {
     return () => {
@@ -351,7 +346,7 @@ export function TimelineController({
         instanceRef.current = null;
       }
     };
-  }, []);
+  }, [instanceRef]);
 
   return (
     <ReactEChartsComponent


### PR DESCRIPTION
When changing theme all timeline charts re-render so getting zoom range from chart instances via DOM is not viable strategy.

Consolidates a couple pieces of zoom handling logic:
1. Use the `zoomRangeAtom` as single source of truth
2. Creates a `useChartConnect` to capture common `connect` logic between all of our chart types
Fixes #131 