### PR TITLE
fix(ui): ensure consistent timeline group highlighting

### DIFF
--- a/ui/packages/@quent/components/src/ui/tree-view.tsx
+++ b/ui/packages/@quent/components/src/ui/tree-view.tsx
@@ -50,6 +50,7 @@ type TreeProps<T extends TreeDataItem = TreeDataItem> = React.HTMLAttributes<HTM
   defaultLeafIcon?: React.ComponentType<{ className?: string }>;
   onDocumentDrag?: (sourceItem: T, targetItem: T) => void;
   renderItem?: (params: TreeRenderItemParams<T>) => React.ReactNode;
+  onItemHover?: (item: T | null) => void;
 };
 
 /** Recursive tree view with drag-and-drop, selection, and custom rendering support. */
@@ -64,6 +65,7 @@ function TreeView<T extends TreeDataItem = TreeDataItem>({
   className,
   onDocumentDrag,
   renderItem,
+  onItemHover,
   ...props
 }: TreeProps<T>) {
   const [selectedItemId, setSelectedItemId] = React.useState<string | undefined>(
@@ -144,6 +146,7 @@ function TreeView<T extends TreeDataItem = TreeDataItem>({
         handleDrop={handleDrop}
         draggedItem={draggedItem}
         renderItem={renderItem}
+        onItemHover={onItemHover}
         level={0}
         {...props}
       />
@@ -177,6 +180,7 @@ function TreeItem<T extends TreeDataItem = TreeDataItem>({
   handleDrop,
   draggedItem,
   renderItem,
+  onItemHover,
   level,
   ...props
 }: TreeItemProps<T>) {
@@ -204,6 +208,7 @@ function TreeItem<T extends TreeDataItem = TreeDataItem>({
                 handleDrop={handleDrop}
                 draggedItem={draggedItem}
                 renderItem={renderItem}
+                onItemHover={onItemHover}
               />
             ) : (
               <TreeLeaf
@@ -216,6 +221,7 @@ function TreeItem<T extends TreeDataItem = TreeDataItem>({
                 handleDrop={handleDrop}
                 draggedItem={draggedItem}
                 renderItem={renderItem}
+                onItemHover={onItemHover}
               />
             )}
           </li>
@@ -238,6 +244,7 @@ function TreeNode<T extends TreeDataItem = TreeDataItem>({
   handleDrop,
   draggedItem,
   renderItem,
+  onItemHover,
   level = 0,
 }: {
   item: T;
@@ -250,6 +257,7 @@ function TreeNode<T extends TreeDataItem = TreeDataItem>({
   handleDrop?: (item: T) => void;
   draggedItem: T | null;
   renderItem?: (params: TreeRenderItemParams<T>) => React.ReactNode;
+  onItemHover?: (item: T | null) => void;
   level?: number;
 }) {
   const [value, setValue] = React.useState(expandedItemIds.includes(item.id) ? [item.id] : []);
@@ -299,6 +307,8 @@ function TreeNode<T extends TreeDataItem = TreeDataItem>({
           onDragOver={onDragOver}
           onDragLeave={onDragLeave}
           onDrop={onDrop}
+          onMouseEnter={onItemHover ? () => onItemHover(item) : undefined}
+          onMouseLeave={onItemHover ? () => onItemHover(null) : undefined}
         >
           <div
             className="flex items-center flex-1"
@@ -343,6 +353,7 @@ function TreeNode<T extends TreeDataItem = TreeDataItem>({
             handleDrop={handleDrop}
             draggedItem={draggedItem}
             renderItem={renderItem}
+            onItemHover={onItemHover}
             level={level + 1}
           />
         </AccordionContent>
@@ -362,6 +373,7 @@ function TreeLeaf<T extends TreeDataItem = TreeDataItem>({
   handleDrop,
   draggedItem,
   renderItem,
+  onItemHover,
   ...props
 }: React.HTMLAttributes<HTMLDivElement> & {
   item: T;
@@ -373,6 +385,7 @@ function TreeLeaf<T extends TreeDataItem = TreeDataItem>({
   handleDrop?: (item: T) => void;
   draggedItem: T | null;
   renderItem?: (params: TreeRenderItemParams<T>) => React.ReactNode;
+  onItemHover?: (item: T | null) => void;
 }) {
   const [isDragOver, setIsDragOver] = React.useState(false);
   const isSelected = selectedItemId === item.id;
@@ -425,6 +438,8 @@ function TreeLeaf<T extends TreeDataItem = TreeDataItem>({
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onDrop={onDrop}
+      onMouseEnter={onItemHover ? () => onItemHover(item) : undefined}
+      onMouseLeave={onItemHover ? () => onItemHover(null) : undefined}
       {...props}
     >
       {renderItem ? (

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -98,11 +98,7 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
 
   const renderItem = ({ item, hasChildren }: { item: QueryPlanDataItem; hasChildren: boolean }) => {
     return (
-      <div
-        className="flex flex-col items-start py-0.5 pl-1"
-        onMouseEnter={() => item.workerId && setHoveredWorkerId(item.workerId)}
-        onMouseLeave={() => setHoveredWorkerId(null)}
-      >
+      <div className="flex flex-col items-start py-0.5 pl-1">
         {singleQueryPlan ? (
           <span className="text-xs">
             Query: <DataText>{item.queryId}</DataText>
@@ -156,6 +152,7 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
             initialSelectedItemId={planId}
             selectedItemId={planId}
             onSelectChange={handlePlanSelect}
+            onItemHover={item => setHoveredWorkerId(item?.workerId ?? null)}
             renderItem={renderItem}
           />
         </ResizablePanel>


### PR DESCRIPTION
Previously, when hovering over a query plan to highlight a timeline group, the hovering itself was very inconsistent - it would randomly stop working. The issue was due to where the hover handlers were being attached; this creates a new prop in the base UI component and attaches the events to the actual row containers to ensure consistent highlighting. This also makes a small improvement, as previously `onMouseLeave` didn't have a `item.workerId` guard, so leaving a workerless plan could clobber a highlight set by another row.

Fixes: #132