### PR TITLE
fix(ui): zoom out too 100% does not reload bulk data

### DIFF
--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -34,9 +34,10 @@ export {
   useHydrateTimelineAtoms,
 } from './timeline/useTimelineAtoms';
 
-// Timeline cache key helper (consumers need this to address per-item data)
+// Timeline cache key helpers (consumers need these to address per-item data)
 export { timelineCacheKey } from './atoms/timeline';
 export type { TimelineCacheParams, TimelineHoverState } from './atoms/timeline';
+export { bulkEntryId } from './timeline/timeline.utils';
 
 // Complex timeline hooks
 export { useBulkTimelines } from './timeline/useBulkTimelines';

--- a/ui/packages/@quent/hooks/src/timeline/timeline.utils.ts
+++ b/ui/packages/@quent/hooks/src/timeline/timeline.utils.ts
@@ -16,6 +16,11 @@ export function getFsmTypeName(params: TimelineRequest<TaskFilter>): string | nu
   return params.Resource.entity_filter.entity_type_name;
 }
 
+/** Stable request-entry key for bulk timeline fetches. Omit operatorId for the base variant. */
+export function bulkEntryId(resourceId: string, operatorId?: string | null): string {
+  return operatorId ? `${resourceId}:op:${operatorId}` : `${resourceId}:base`;
+}
+
 /** Clone entries and set operator_id on each TimelineRequest */
 export function setOperatorOnEntry(
   entry: TimelineRequest<TaskFilter>,

--- a/ui/packages/@quent/hooks/src/timeline/useBulkTimelineFetch.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useBulkTimelineFetch.ts
@@ -12,7 +12,7 @@ import type {
   ZoomRange,
   SingleTimelineResponse,
 } from '@quent/utils';
-import { getResourceTypeName, getFsmTypeName, setOperatorOnEntry } from './timeline.utils';
+import { getResourceTypeName, getFsmTypeName, setOperatorOnEntry, bulkEntryId } from './timeline.utils';
 import { timelineCacheKey, timelineDataMapAtom } from '../atoms/timeline';
 
 /**
@@ -68,14 +68,14 @@ export function buildMergedBulkEntries(
   for (const [resourceId, params] of Object.entries(baseEntries)) {
     const resourceTypeName = getResourceTypeName(params);
     const fsmTypeName = getFsmTypeName(params);
-    const baseUuid = crypto.randomUUID();
-    entries[baseUuid] = params;
-    idToMeta.set(baseUuid, { resourceId, resourceTypeName, operatorId: null, fsmTypeName });
+    const baseId = bulkEntryId(resourceId);
+    entries[baseId] = params;
+    idToMeta.set(baseId, { resourceId, resourceTypeName, operatorId: null, fsmTypeName });
     if (operatorId) {
-      const opUuid = crypto.randomUUID();
+      const opId = bulkEntryId(resourceId, operatorId);
       const withOperator = setOperatorOnEntry(params, operatorId);
-      entries[opUuid] = withOperator;
-      idToMeta.set(opUuid, { resourceId, resourceTypeName, operatorId, fsmTypeName });
+      entries[opId] = withOperator;
+      idToMeta.set(opId, { resourceId, resourceTypeName, operatorId, fsmTypeName });
     }
   }
 

--- a/ui/packages/@quent/hooks/src/timeline/useBulkTimelineFetch.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useBulkTimelineFetch.ts
@@ -12,7 +12,12 @@ import type {
   ZoomRange,
   SingleTimelineResponse,
 } from '@quent/utils';
-import { getResourceTypeName, getFsmTypeName, setOperatorOnEntry, bulkEntryId } from './timeline.utils';
+import {
+  getResourceTypeName,
+  getFsmTypeName,
+  setOperatorOnEntry,
+  bulkEntryId,
+} from './timeline.utils';
 import { timelineCacheKey, timelineDataMapAtom } from '../atoms/timeline';
 
 /**


### PR DESCRIPTION
Change to cache keys to be deterministic. 

When the react query cache HIT (zoom at 0-100 an easy hit), `buildMergedBulkEntries` would be called again, but would generate new UUIDs so the jotai cache would not hit for resource timelines, and they would render their existing dat. 

fixes #152 