### PR TITLE
refactor(ui): stats panel re-design

### DIFF
--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -43,7 +43,6 @@ import {
 import type { DAGData } from '../services/query-plan/types';
 import { QueryPlanNode, type QueryPlanNodeData } from '../query-plan/QueryPlanNode';
 import { DAGLegend } from './DAGLegend';
-import { DAGNodeInfoPanel } from './DAGNodeInfoPanel';
 import { parseCustomStatistics } from '../lib/queryBundle.utils';
 import { continuousColor, getOperationTypeColor, buildOperatorColorMap } from '@quent/utils';
 import { inferFieldFormatter } from '../services/query-plan/dagFieldProcessing';
@@ -482,7 +481,6 @@ const FlowLayout = ({
     >
       <Background />
       <DAGLegend isDark={isDark} />
-      <DAGNodeInfoPanel />
       <MiniMap
         pannable
         zoomable

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState } from 'react';
-import { Panel } from '@xyflow/react';
-import { Pin, ChevronUp, ChevronDown } from 'lucide-react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 import { useSelectedNodeData } from '@quent/hooks';
 import { DataText } from '../ui/data-text';
 import { thinScrollbarClass } from '../ui/thin-scroll';
@@ -11,89 +10,80 @@ import { inferFieldFormatter } from '../services/query-plan/dagFieldProcessing';
 
 export const DAGNodeInfoPanel = () => {
   const selectedNodeData = useSelectedNodeData();
-  const [isMinimized, setIsMinimized] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
     if (!selectedNodeData) {
-      setIsMinimized(true);
+      setIsExpanded(false);
     }
   }, [selectedNodeData]);
 
   return (
-    <Panel
-      position="bottom-left"
-      className="nodrag nopan mb-2 ml-2"
-    >
-      <div className="w-72 rounded-md border bg-popover px-4 py-2 text-popover-foreground shadow-md">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-muted-foreground font-medium">Operator Details</span>
-          <button
-            onClick={() => setIsMinimized(!isMinimized)}
-            disabled={!selectedNodeData}
-            className="rounded p-1 hover:bg-muted transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-auto disabled:hover:bg-transparent"
-            aria-label="Toggle panel"
-          >
-            {isMinimized ? (
-              <ChevronUp className="h-3 w-3 text-muted-foreground" />
-            ) : (
-              <ChevronDown className="h-3 w-3 text-muted-foreground" />
-            )}
-          </button>
-        </div>
-        {!isMinimized && (
-          <>
-            <div className="flex items-center justify-between gap-2 mt-2">
-              <DataText className="font-semibold text-sm truncate">
-                {selectedNodeData?.label}
+    <div className="border-t bg-card flex-shrink-0">
+      <div className="flex items-center justify-between px-4 py-1.5 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 overflow-hidden">
+          <span className="text-xs text-muted-foreground font-medium flex-shrink-0">
+            Operator Details
+          </span>
+          {selectedNodeData && (
+            <>
+              <span className="text-muted-foreground text-xs flex-shrink-0">·</span>
+              <DataText className="text-xs font-medium truncate">{selectedNodeData.label}</DataText>
+              <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded flex-shrink-0">
+                {selectedNodeData.operationType}
               </DataText>
-              <div className="flex items-center gap-1 flex-shrink-0">
-                <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded">
-                  {selectedNodeData?.operationType}
-                </DataText>
-              </div>
-            </div>
-            <DataText as="div" className="text-xs text-muted-foreground truncate mt-0.5">
-              {selectedNodeData?.nodeId}
-            </DataText>
-            {(selectedNodeData?.statistics?.length ?? 0) > 0 && (
-              <div
-                className={`mt-1 border-t pt-1.5 max-h-56 overflow-y-auto ${thinScrollbarClass}`}
-              >
-                <div className="flex flex-col gap-1 pr-3">
-                  {selectedNodeData?.statistics.map(({ key, value }) => (
-                    <div key={key} className="text-xs mt-1">
-                      {Array.isArray(value) ? (
-                        <div className="flex items-center justify-between gap-0.5">
-                          <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
-                          <div className="ml-2 flex flex-col gap-0.5">
-                            {value.map((item, i) => (
-                              <DataText
-                                key={i}
-                                className="text-muted-foreground whitespace-pre-line"
-                              >
-                                {item}
-                              </DataText>
-                            ))}
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="flex items-center justify-between">
-                          <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
-                          <DataText className="text-muted-foreground ml-1">
-                            {typeof value === 'number'
-                              ? inferFieldFormatter(key)(value)
-                              : String(value)}
-                          </DataText>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </>
-        )}
+            </>
+          )}
+        </div>
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          disabled={!selectedNodeData}
+          className="ml-2 rounded p-1 hover:bg-muted transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-auto disabled:hover:bg-transparent flex-shrink-0"
+          aria-label="Toggle operator details"
+        >
+          {isExpanded ? (
+            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+          ) : (
+            <ChevronUp className="h-3 w-3 text-muted-foreground" />
+          )}
+        </button>
       </div>
-    </Panel>
+
+      {isExpanded && selectedNodeData && (
+        <div className={`border-t px-4 pb-2 h-48 overflow-y-auto ${thinScrollbarClass}`}>
+          <div className="flex flex-col gap-1 pr-2 pt-1.5">
+            <div className="text-xs flex items-center justify-between">
+              <DataText className="capitalize">ID:</DataText>
+              <DataText className="text-muted-foreground ml-1 truncate">
+                {selectedNodeData.nodeId}
+              </DataText>
+            </div>
+            {selectedNodeData.statistics?.map(({ key, value }) => (
+              <div key={key} className="text-xs">
+                {Array.isArray(value) ? (
+                  <div className="flex items-center justify-between gap-0.5">
+                    <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
+                    <div className="ml-2 flex flex-col gap-0.5">
+                      {value.map((item, i) => (
+                        <DataText key={i} className="text-muted-foreground whitespace-pre-line">
+                          {item}
+                        </DataText>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-center justify-between">
+                    <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
+                    <DataText className="text-muted-foreground ml-1">
+                      {typeof value === 'number' ? inferFieldFormatter(key)(value) : String(value)}
+                    </DataText>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
   );
 };

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -59,7 +59,7 @@ export const DAGNodeInfoPanel = () => {
             <DataText as="div" className="text-xs text-muted-foreground truncate mt-0.5">
               {selectedNodeData?.nodeId}
             </DataText>
-            {selectedNodeData?.statistics.length > 0 && (
+            {(selectedNodeData?.statistics?.length ?? 0) > 0 && (
               <div
                 className={`mt-1 border-t pt-1.5 max-h-56 overflow-y-auto ${thinScrollbarClass}`}
               >

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from 'react';
 import { Panel } from '@xyflow/react';
-import { Pin } from 'lucide-react';
+import { Pin, Maximize2 } from 'lucide-react';
 import { useSelectedNodeIds, useHoveredNodeData, useSelectedNodeData } from '@quent/hooks';
 import { DataText } from '../ui/data-text';
 import { thinScrollbarClass } from '../ui/thin-scroll';
@@ -16,11 +17,15 @@ export const DAGNodeInfoPanel = () => {
   const selectedNodeIds = useSelectedNodeIds();
   const hoveredNodeData = useHoveredNodeData();
   const selectedNodeData = useSelectedNodeData();
+  const [isMinimized, setIsMinimized] = useState(true);
 
-  const isPinned = selectedNodeIds.size > 0;
-  const displayData = isPinned ? selectedNodeData : hoveredNodeData;
+  // const isPinned = selectedNodeIds.size > 0;
+  const isPinned = true;
+  // const displayData = !isMinimized ? selectedNodeData : hoveredNodeData;
+  const displayData = selectedNodeData ?? hoveredNodeData;
 
-  if (!displayData) return null;
+  // if (!displayData) return null;
+  console.log(displayData);
   return (
     <Panel
       position="bottom-left"
@@ -28,22 +33,31 @@ export const DAGNodeInfoPanel = () => {
       style={isPinned ? undefined : { pointerEvents: 'none' }}
     >
       <div className="w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md">
+        <div className="flex">
+          <button
+            onClick={() => setIsMinimized(!isMinimized)}
+            className="rounded p-1 hover:bg-muted transition-colors"
+            aria-label="Toggle panel"
+          >
+            <Maximize2 className="h-3 w-3 text-muted-foreground" />
+          </button>
+        </div>
         <div className="flex items-center justify-between gap-2">
-          <DataText className="font-semibold text-sm truncate">{displayData.label}</DataText>
+          <DataText className="font-semibold text-sm truncate">{displayData?.label}</DataText>
           <div className="flex items-center gap-1 flex-shrink-0">
             {isPinned && <Pin className="h-3 w-3 text-muted-foreground" />}
             <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded">
-              {displayData.operationType}
+              {displayData?.operationType}
             </DataText>
           </div>
         </div>
         <DataText as="div" className="text-xs text-muted-foreground truncate mt-0.5">
-          {displayData.nodeId}
+          {displayData?.nodeId}
         </DataText>
-        {displayData.statistics.length > 0 && (
+        {displayData?.statistics.length > 0 && !isMinimized && (
           <div className={`mt-1 border-t pt-1.5 max-h-56 overflow-y-auto ${thinScrollbarClass}`}>
             <div className="flex flex-col gap-1 pr-3">
-              {displayData.statistics.map(({ key, value }) => (
+              {displayData?.statistics.map(({ key, value }) => (
                 <div key={key} className="text-xs mt-1">
                   {Array.isArray(value) ? (
                     <div className="flex items-center justify-between gap-0.5">

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -4,13 +4,12 @@
 import { useEffect, useState } from 'react';
 import { Panel } from '@xyflow/react';
 import { Pin, ChevronUp, ChevronDown } from 'lucide-react';
-import { useSelectedNodeIds, useSelectedNodeData } from '@quent/hooks';
+import { useSelectedNodeData } from '@quent/hooks';
 import { DataText } from '../ui/data-text';
 import { thinScrollbarClass } from '../ui/thin-scroll';
 import { inferFieldFormatter } from '../services/query-plan/dagFieldProcessing';
 
 export const DAGNodeInfoPanel = () => {
-  const selectedNodeIds = useSelectedNodeIds();
   const selectedNodeData = useSelectedNodeData();
   const [isMinimized, setIsMinimized] = useState(true);
 

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -23,7 +23,6 @@ export const DAGNodeInfoPanel = () => {
     <Panel
       position="bottom-left"
       className="nodrag nopan mb-2 ml-2"
-      style={pointerEvents: 'none'}
     >
       <div className="w-72 rounded-md border bg-popover px-4 py-2 text-popover-foreground shadow-md">
         <div className="flex items-center justify-between">
@@ -48,7 +47,6 @@ export const DAGNodeInfoPanel = () => {
                 {selectedNodeData?.label}
               </DataText>
               <div className="flex items-center gap-1 flex-shrink-0">
-                {isPinned && <Pin className="h-3 w-3 text-muted-foreground" />}
                 <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded">
                   {selectedNodeData?.operationType}
                 </DataText>

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -13,8 +13,6 @@ export const DAGNodeInfoPanel = () => {
   const selectedNodeData = useSelectedNodeData();
   const [isMinimized, setIsMinimized] = useState(true);
 
-  const isPinned = true;
-
   useEffect(() => {
     if (!selectedNodeData) {
       setIsMinimized(true);
@@ -25,7 +23,7 @@ export const DAGNodeInfoPanel = () => {
     <Panel
       position="bottom-left"
       className="nodrag nopan mb-2 ml-2"
-      style={isPinned ? undefined : { pointerEvents: 'none' }}
+      style={pointerEvents: 'none'}
     >
       <div className="w-72 rounded-md border bg-popover px-4 py-2 text-popover-foreground shadow-md">
         <div className="flex items-center justify-between">

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -1,89 +1,102 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Panel } from '@xyflow/react';
-import { Pin, Maximize2 } from 'lucide-react';
-import { useSelectedNodeIds, useHoveredNodeData, useSelectedNodeData } from '@quent/hooks';
+import { Pin, ChevronUp, ChevronDown } from 'lucide-react';
+import { useSelectedNodeIds, useSelectedNodeData } from '@quent/hooks';
 import { DataText } from '../ui/data-text';
 import { thinScrollbarClass } from '../ui/thin-scroll';
 import { inferFieldFormatter } from '../services/query-plan/dagFieldProcessing';
 
-/**
- * Floating panel anchored to the DAG canvas that surfaces details for the
- * hovered node, or, while a node is selected, pins the selection's details.
- */
 export const DAGNodeInfoPanel = () => {
   const selectedNodeIds = useSelectedNodeIds();
-  const hoveredNodeData = useHoveredNodeData();
   const selectedNodeData = useSelectedNodeData();
   const [isMinimized, setIsMinimized] = useState(true);
 
-  // const isPinned = selectedNodeIds.size > 0;
   const isPinned = true;
-  // const displayData = !isMinimized ? selectedNodeData : hoveredNodeData;
-  const displayData = selectedNodeData ?? hoveredNodeData;
 
-  // if (!displayData) return null;
-  console.log(displayData);
+  useEffect(() => {
+    if (!selectedNodeData) {
+      setIsMinimized(true);
+    }
+  }, [selectedNodeData]);
+
   return (
     <Panel
       position="bottom-left"
       className="nodrag nopan mb-2 ml-2"
       style={isPinned ? undefined : { pointerEvents: 'none' }}
     >
-      <div className="w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md">
-        <div className="flex">
+      <div className="w-72 rounded-md border bg-popover px-4 py-2 text-popover-foreground shadow-md">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground font-medium">Operator Details</span>
           <button
             onClick={() => setIsMinimized(!isMinimized)}
-            className="rounded p-1 hover:bg-muted transition-colors"
+            disabled={!selectedNodeData}
+            className="rounded p-1 hover:bg-muted transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-auto disabled:hover:bg-transparent"
             aria-label="Toggle panel"
           >
-            <Maximize2 className="h-3 w-3 text-muted-foreground" />
+            {isMinimized ? (
+              <ChevronUp className="h-3 w-3 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            )}
           </button>
         </div>
-        <div className="flex items-center justify-between gap-2">
-          <DataText className="font-semibold text-sm truncate">{displayData?.label}</DataText>
-          <div className="flex items-center gap-1 flex-shrink-0">
-            {isPinned && <Pin className="h-3 w-3 text-muted-foreground" />}
-            <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded">
-              {displayData?.operationType}
-            </DataText>
-          </div>
-        </div>
-        <DataText as="div" className="text-xs text-muted-foreground truncate mt-0.5">
-          {displayData?.nodeId}
-        </DataText>
-        {displayData?.statistics.length > 0 && !isMinimized && (
-          <div className={`mt-1 border-t pt-1.5 max-h-56 overflow-y-auto ${thinScrollbarClass}`}>
-            <div className="flex flex-col gap-1 pr-3">
-              {displayData?.statistics.map(({ key, value }) => (
-                <div key={key} className="text-xs mt-1">
-                  {Array.isArray(value) ? (
-                    <div className="flex items-center justify-between gap-0.5">
-                      <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
-                      <div className="ml-2 flex flex-col gap-0.5">
-                        {value.map((item, i) => (
-                          <DataText key={i} className="text-muted-foreground whitespace-pre-line">
-                            {item}
-                          </DataText>
-                        ))}
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="flex items-center justify-between">
-                      <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
-                      <DataText className="text-muted-foreground ml-1">
-                        {typeof value === 'number'
-                          ? inferFieldFormatter(key)(value)
-                          : String(value)}
-                      </DataText>
-                    </div>
-                  )}
-                </div>
-              ))}
+        {!isMinimized && (
+          <>
+            <div className="flex items-center justify-between gap-2 mt-2">
+              <DataText className="font-semibold text-sm truncate">
+                {selectedNodeData?.label}
+              </DataText>
+              <div className="flex items-center gap-1 flex-shrink-0">
+                {isPinned && <Pin className="h-3 w-3 text-muted-foreground" />}
+                <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded">
+                  {selectedNodeData?.operationType}
+                </DataText>
+              </div>
             </div>
-          </div>
+            <DataText as="div" className="text-xs text-muted-foreground truncate mt-0.5">
+              {selectedNodeData?.nodeId}
+            </DataText>
+            {selectedNodeData?.statistics.length > 0 && (
+              <div
+                className={`mt-1 border-t pt-1.5 max-h-56 overflow-y-auto ${thinScrollbarClass}`}
+              >
+                <div className="flex flex-col gap-1 pr-3">
+                  {selectedNodeData?.statistics.map(({ key, value }) => (
+                    <div key={key} className="text-xs mt-1">
+                      {Array.isArray(value) ? (
+                        <div className="flex items-center justify-between gap-0.5">
+                          <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
+                          <div className="ml-2 flex flex-col gap-0.5">
+                            {value.map((item, i) => (
+                              <DataText
+                                key={i}
+                                className="text-muted-foreground whitespace-pre-line"
+                              >
+                                {item}
+                              </DataText>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex items-center justify-between">
+                          <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
+                          <DataText className="text-muted-foreground ml-1">
+                            {typeof value === 'number'
+                              ? inferFieldFormatter(key)(value)
+                              : String(value)}
+                          </DataText>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
     </Panel>

--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -21,6 +21,7 @@ import {
   useSelectedNodeIds,
   useSetSelectedNodeIds,
   useSetSelectedOperatorLabel,
+  useSetSelectedNodeData,
   useSetSelectedPlanId,
   useNodeColoringValue,
   useNodeColorPalette,
@@ -61,6 +62,7 @@ export function OperatorGanttChart({
   const setSelectedNodeIds = useSetSelectedNodeIds();
   const setSelectedOperatorLabel = useSetSelectedOperatorLabel();
   const setSelectedPlanId = useSetSelectedPlanId();
+  const setSelectedNodeData = useSetSelectedNodeData();
   const { themeName, textColor } = useTimelineEchartsTheme(isDark);
   const nodeColoring = useNodeColoringValue();
   const [nodePalette] = useNodeColorPalette();
@@ -296,16 +298,30 @@ export function OperatorGanttChart({
         if (selectedNodeIds.has(op.operatorId)) {
           setSelectedNodeIds(new Set());
           setSelectedOperatorLabel(null);
+          setSelectedNodeData(null);
         } else {
           setSelectedNodeIds(new Set([op.operatorId]));
           setSelectedOperatorLabel(op.label);
+          setSelectedNodeData({
+            nodeId: op.operatorId,
+            label: op.label,
+            operationType: op.typeName,
+            statistics: op.statistics,
+          });
           if (op.planId) {
             setSelectedPlanId(op.planId);
           }
         }
       },
     }),
-    [operators, selectedNodeIds, setSelectedNodeIds, setSelectedOperatorLabel, setSelectedPlanId]
+    [
+      operators,
+      selectedNodeIds,
+      setSelectedNodeIds,
+      setSelectedOperatorLabel,
+      setSelectedPlanId,
+      setSelectedNodeData,
+    ]
   );
 
   // Join timeline-sync-group for frame-rate-level x-axis zoom sync via ECharts connect().

--- a/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
+++ b/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
@@ -21,7 +21,6 @@ import {
   useNodeColorPalette,
   useEffectiveHighlightedNodeIds,
   useEffectiveHoveredStat,
-  useSetHoveredNodeData,
   useSetHighlightedNodeIds,
 } from '@quent/hooks';
 import { parseCustomStatistics } from '../lib/queryBundle.utils';
@@ -101,7 +100,6 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
   const [nodeLabelField] = useSelectedNodeLabelField();
   const { fieldColor, isDimmed, isSelected, colorField } = useNodeColoring(operatorId, isDark);
   const [isHoveredLocal, setIsHoveredLocal] = useState(false);
-  const setHoveredNodeData = useSetHoveredNodeData();
 
   const resolvedLabel = useMemo(() => {
     if (nodeLabelField === NODE_LABEL_FIELD.ID) return data.metadata?.rawNode?.id ?? data.nodeId;
@@ -144,12 +142,6 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
 
   const onMouseEnter = useCallback(() => {
     setIsHoveredLocal(true);
-    setHoveredNodeData({
-      nodeId: data.nodeId,
-      label: data.label,
-      operationType: data.operationType,
-      statistics,
-    });
     if (operatorId) {
       setHighlightState(prev => ({
         ...prev,
@@ -158,24 +150,15 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
         primaryOperatorId: operatorId,
       }));
     }
-  }, [
-    data.nodeId,
-    data.label,
-    data.operationType,
-    statistics,
-    operatorId,
-    setHighlightState,
-    setHoveredNodeData,
-  ]);
+  }, [operatorId, setHighlightState]);
   const onMouseLeave = useCallback(() => {
     setIsHoveredLocal(false);
-    setHoveredNodeData(null);
     setHighlightState(prev =>
       prev.source === 'dag' && prev.ids?.size === 1 && prev.ids.has(operatorId)
         ? { ...prev, ids: null, source: null, primaryOperatorId: null }
         : prev
     );
-  }, [operatorId, setHighlightState, setHoveredNodeData]);
+  }, [operatorId, setHighlightState]);
 
   const nodeContent = (
     <div

--- a/ui/packages/@quent/hooks/src/atoms/dagControls.ts
+++ b/ui/packages/@quent/hooks/src/atoms/dagControls.ts
@@ -42,9 +42,6 @@ export interface InspectedNodeData {
   statistics: Array<{ key: string; value: StatValue }>;
 }
 
-/** Data for the node currently being hovered (drives the preview panel) */
-export const hoveredNodeDataAtom = atom<InspectedNodeData | null>(null);
-
 /** Data for the currently selected/pinned node (persists in the panel after click) */
 export const selectedNodeDataAtom = atom<InspectedNodeData | null>(null);
 

--- a/ui/packages/@quent/hooks/src/dag/dagControlSelectors.ts
+++ b/ui/packages/@quent/hooks/src/dag/dagControlSelectors.ts
@@ -15,7 +15,6 @@ import {
   edgeColoringAtom,
   edgeColorPaletteAtom,
   selectedNodeLabelFieldAtom,
-  hoveredNodeDataAtom,
   selectedNodeDataAtom,
   highlightedNodeIdsAtom,
   effectiveHighlightedNodeIdsAtom,
@@ -62,13 +61,6 @@ export function useEdgeColorPalette() {
 
 export function useSelectedNodeLabelField() {
   return useAtom(selectedNodeLabelFieldAtom);
-}
-
-export function useHoveredNodeData() {
-  return useAtomValue(hoveredNodeDataAtom);
-}
-export function useSetHoveredNodeData() {
-  return useSetAtom(hoveredNodeDataAtom);
 }
 
 export function useSelectedNodeData() {

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -75,8 +75,6 @@ export {
   useEdgeColoring,
   useEdgeColorPalette,
   useSelectedNodeLabelField,
-  useHoveredNodeData,
-  useSetHoveredNodeData,
   useSelectedNodeData,
   useSetSelectedNodeData,
   useHighlightedNodeIds,

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -9,7 +9,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@quent/com
 import { thinScrollbarClass, type QueryPlanDataItem } from '@quent/components';
 import { Network } from 'lucide-react';
 import { useSelectedPlanId, useSetSelectedPlanId, useSetHoveredWorkerId } from '@quent/hooks';
-import { DAGControls } from '@quent/components';
+import { DAGControls, DAGNodeInfoPanel } from '@quent/components';
 import {
   useDagNodeColoring,
   useDagEdgeWidthConfig,
@@ -175,15 +175,20 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
           collapsedSize="0%"
           className="overflow-hidden"
         >
-          <Suspense
-            fallback={
-              <div className="flex items-center justify-center h-full text-muted-foreground">
-                Loading visualization...
-              </div>
-            }
-          >
-            <DAGChart data={dagData} height="100%" isDark={isDark} />
-          </Suspense>
+          <div className="flex flex-col h-full">
+            <div className="flex-1 min-h-0">
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center h-full text-muted-foreground">
+                    Loading visualization...
+                  </div>
+                }
+              >
+                <DAGChart data={dagData} height="100%" isDark={isDark} />
+              </Suspense>
+            </div>
+            <DAGNodeInfoPanel />
+          </div>
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
Re-designs the stats panel so users can filter operators from the DAG without always having it take up real estate on the chart. Previously, whenever you selected an operator, the stats panel would always appear, and there was no way to close it.

Now, the stats panel has two states - a minimzed state and an expanded state. The panel always sits in the minimized state, but can be expanded by clicking a button. The button is only active when an operator is selected. When an operator is selected, the panel can be expanded to view operator details. The panel will stay expanded, allowing users to select other operators without having to re-open the panel. If a user clicks elsewhere on the DAG to de-select the current operator (or de-selects via clicking the same operator again), the stats panel will automatically collapse.

This is the second iteration of PR #168, as instead of having the panel sit on top of the DAG chart, it now sits in a panel below the DAG - when it is expanded, instead of overlaying, it pushes the DAG upwards to prevent it from blocking part of the chart. 

Also, previously selected operator statistics weren't being set in state by the gant chart, so added that so that the stats panel can be utilized when viewing operators selected on the gant chart.

Fixes: #133