### PR TITLE
feat(ui): add error handling

### DIFF
--- a/ui/src/components/RouteError.tsx
+++ b/ui/src/components/RouteError.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useRouter } from '@tanstack/react-router';
+import { Button } from '@quent/components';
+
+interface RouteErrorProps {
+  error: Error;
+}
+
+export function RouteError({ error }: RouteErrorProps) {
+  const router = useRouter();
+  const message = error.message || 'An unexpected error occurred.';
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full min-h-48 gap-4 p-8 text-center">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-destructive">Something went wrong</h2>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+      <Button variant="outline" size="sm" onClick={() => void router.history.back()}>
+        Go back
+      </Button>
+    </div>
+  );
+}

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -75,7 +75,7 @@ function RootNotFoundComponent() {
           The page you&#39;re looking for doesn&#39;t exist.
         </p>
       </div>
-      <Button size="sm" asChild>
+      <Button variant="outline" size="sm" asChild>
         <Link to="/profile">Go to profile</Link>
       </Button>
     </div>

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -15,54 +15,82 @@ import {
 } from '@quent/components';
 import { cn } from '@quent/utils';
 
+function AppNav({ highlightProfile }: { highlightProfile?: boolean }) {
+  return (
+    <nav className="sticky top-0 z-50 w-full border-b bg-card shadow-sm">
+      <div className="w-full flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-semibold text-primary">
+            QUENT <span className="font-light text-muted-foreground">UI</span>
+          </h1>
+        </div>
+        <div className="flex-1 flex items-center justify-center">
+          <NavBarNavigator />
+        </div>
+        <div className="flex items-center gap-2">
+          <NavigationMenu>
+            <NavigationMenuList>
+              <NavigationMenuItem>
+                <NavigationMenuLink asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    asChild
+                    className={cn(highlightProfile && 'bg-accent text-accent-foreground font-semibold')}
+                  >
+                    <Link to="/profile">Profile</Link>
+                  </Button>
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+            </NavigationMenuList>
+          </NavigationMenu>
+          <ThemeToggle />
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+function RootErrorComponent({ error }: { error: Error }) {
+  const message = error.message || 'An unexpected error occurred.';
+  return (
+    <div className="flex flex-col items-center justify-center h-full min-h-64 gap-4 p-8 text-center">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-destructive">Something went wrong</h2>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+      <Button variant="outline" size="sm" asChild>
+        <Link to="/profile">Go to profile</Link>
+      </Button>
+    </div>
+  );
+}
+
+function RootNotFoundComponent() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full min-h-64 gap-4 p-8 text-center">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold">Page not found</h2>
+        <p className="text-sm text-muted-foreground">
+          The page you&#39;re looking for doesn&#39;t exist.
+        </p>
+      </div>
+      <Button size="sm" asChild>
+        <Link to="/profile">Go to profile</Link>
+      </Button>
+    </div>
+  );
+}
+
 function RootComponent() {
   const routerState = useRouterState();
-  const currentPath = routerState.location.pathname;
-
-  const isActive = (path: string) => {
-    if (path === '/') {
-      return currentPath === '/';
-    }
-    return currentPath.startsWith(path);
-  };
+  const isProfileActive = routerState.location.pathname.startsWith('/profile');
 
   return (
     <>
       <ThemeProvider>
         <div className="min-h-screen flex flex-col bg-background">
-          <nav className="sticky top-0 z-50 w-full border-b bg-card shadow-sm">
-            <div className="w-full flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
-              <div className="flex items-center gap-3">
-                <h1 className="text-2xl font-semibold text-primary">
-                  QUENT <span className="font-light text-muted-foreground">UI</span>
-                </h1>
-              </div>
-              <div className="flex-1 flex items-center justify-center">
-                <NavBarNavigator />
-              </div>
-              <div className="flex items-center gap-2">
-                <NavigationMenu>
-                  <NavigationMenuList>
-                    <NavigationMenuItem>
-                      <NavigationMenuLink asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          asChild
-                          className={cn(
-                            isActive('/profile') && 'bg-accent text-accent-foreground font-semibold'
-                          )}
-                        >
-                          <Link to="/profile">Profile</Link>
-                        </Button>
-                      </NavigationMenuLink>
-                    </NavigationMenuItem>
-                  </NavigationMenuList>
-                </NavigationMenu>
-                <ThemeToggle />
-              </div>
-            </div>
-          </nav>
+          <AppNav highlightProfile={isProfileActive} />
           <main className="flex-1 w-full">
             <Outlet />
           </main>
@@ -75,4 +103,6 @@ function RootComponent() {
 
 export const Route = createRootRoute({
   component: RootComponent,
+  errorComponent: RootErrorComponent,
+  notFoundComponent: RootNotFoundComponent,
 });

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -36,7 +36,9 @@ function AppNav({ highlightProfile }: { highlightProfile?: boolean }) {
                     variant="ghost"
                     size="sm"
                     asChild
-                    className={cn(highlightProfile && 'bg-accent text-accent-foreground font-semibold')}
+                    className={cn(
+                      highlightProfile && 'bg-accent text-accent-foreground font-semibold'
+                    )}
                   >
                     <Link to="/profile">Profile</Link>
                   </Button>

--- a/ui/src/routes/profile.engine.$engineId.query.$queryId.tsx
+++ b/ui/src/routes/profile.engine.$engineId.query.$queryId.tsx
@@ -6,9 +6,11 @@ import { queryBundleQueryOptions } from '@quent/client';
 import { queryClient } from '@/lib/queryClient';
 import type { QueryBundle, EntityRef } from '@quent/utils';
 import { cn } from '@quent/utils';
+import { RouteError } from '@/components/RouteError';
 
 export const Route = createFileRoute('/profile/engine/$engineId/query/$queryId')({
   component: QueryLayout,
+  errorComponent: RouteError,
   loader: async ({ params }): Promise<QueryBundle<EntityRef>> => {
     const { engineId, queryId } = params;
     return await queryClient.ensureQueryData(queryBundleQueryOptions({ engineId, queryId }));


### PR DESCRIPTION
Handles errors and creates error components to display when errors are triggered. Adds two types of error pages - one for when the user tries to access an invalid URL, and one for when there is an API error, which displays the error information. 

Page not found error:
<img width="3790" height="2030" alt="error-page_page-not-found2" src="https://github.com/user-attachments/assets/6ac24222-a7c6-4a2d-9cf6-add9d36f3466" />

API error:
<img width="3790" height="2030" alt="error-page_api-error" src="https://github.com/user-attachments/assets/ad360597-f879-4922-a9fd-0b0e40301ae7" />

Fixes: #154 