### PR TITLE
refactor(ui): Use json-custom-numbers to parse big ints

### DIFF
--- a/ui/packages/@quent/utils/package.json
+++ b/ui/packages/@quent/utils/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "json-custom-numbers": "3.1.1",
     "tailwind-merge": "^3.5.0"
   }
 }

--- a/ui/packages/@quent/utils/src/parseJsonWithBigInt.test.ts
+++ b/ui/packages/@quent/utils/src/parseJsonWithBigInt.test.ts
@@ -60,6 +60,21 @@ describe('parseJsonWithBigInt', () => {
       expect(result.id).toBe('12345678901234567890');
       expect(typeof result.id).toBe('string');
     });
+
+    it('should preserve string values containing long number-like tokens', () => {
+      const json = '{"message": "worker id: 1704067200000000000, still just text", "value": 1}';
+      const result = parseJsonWithBigInt<{ message: string; value: number }>(json);
+
+      expect(result.message).toBe('worker id: 1704067200000000000, still just text');
+      expect(result.value).toBe(1);
+    });
+
+    it('should preserve strings that look like legacy BigInt sentinels', () => {
+      const json = '{"value": "__bigint__9007199254740993"}';
+      const result = parseJsonWithBigInt<{ value: string }>(json);
+
+      expect(result.value).toBe('__bigint__9007199254740993');
+    });
   });
 
   describe('BigInt conversion', () => {

--- a/ui/packages/@quent/utils/src/parseJsonWithBigInt.ts
+++ b/ui/packages/@quent/utils/src/parseJsonWithBigInt.ts
@@ -1,31 +1,29 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { parse } from 'json-custom-numbers';
+
 /**
- * TODO: Figure out a more permanent solution for this
- * Parse JSON with BigInt support for large integers.
- * Integers larger than Number.MAX_SAFE_INTEGER are converted to BigInt.
+ * Parse JSON with BigInt support for large integer number tokens.
+ *
+ * Integers outside the safe JavaScript number range are converted to BigInt.
+ * Strings are parsed as strings, even when their contents look like large
+ * integers.
  */
 export function parseJsonWithBigInt<T>(text: string): T {
-  // Match integers that are too large for Number (and not floats)
-  // This regex finds: a number boundary, optional minus, digits only (no decimal/exponent)
-  // We convert integers > MAX_SAFE_INTEGER to BigInt
-  const processed = text.replace(
-    /([:\s[,]|^)(-?\d{16,})(?=[,\s}\]]|$)/g,
-    (match, prefix, numStr) => {
-      const num = Number(numStr);
-      // Only convert if it exceeds safe integer range
-      if (!Number.isSafeInteger(num)) {
-        return `${prefix}"__bigint__${numStr}"`;
-      }
-      return match;
-    }
-  );
+  return parse(text, undefined, parseUnsafeInteger) as T;
+}
 
-  return JSON.parse(processed, (_key, value) => {
-    if (typeof value === 'string' && value.startsWith('__bigint__')) {
-      return BigInt(value.slice(10));
-    }
-    return value;
-  });
+function parseUnsafeInteger(_key: string | number | undefined, source: string): number | bigint {
+  const value = Number(source);
+
+  if (isIntegerLiteral(source) && !Number.isSafeInteger(value)) {
+    return BigInt(source);
+  }
+
+  return value;
+}
+
+function isIntegerLiteral(source: string): boolean {
+  return !source.includes('.') && !source.includes('e') && !source.includes('E');
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      json-custom-numbers:
+        specifier: 3.1.1
+        version: 3.1.1
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -2380,6 +2383,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-custom-numbers@3.1.1:
+    resolution: {integrity: sha512-rYIAIuiIRy58aax2tuZb7HawKFATBG848PiguybJh/R+pvC8jxjEOVBQHj4J3U2D4/Y4acBCO4A/glILW8wPoA==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -5246,6 +5252,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-custom-numbers@3.1.1: {}
 
   json-schema-traverse@0.4.1: {}
 


### PR DESCRIPTION
Sentinel value big int parser was a temporary fix to keep development moving, not optimal.

This uses a small fast secure dep instead to parse big ints from JSON which keeps it as a client only fix, as opposed to sending the big int as a string and parsing in the UI. 