### PR TITLE
feat: add FSM constraint crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-fsm"
+version = "0.1.0"
+dependencies = [
+ "petgraph",
+ "quent-constraints",
+ "quent-schema",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     # Unused preliminary crates of https://github.com/rapidsai/quent/issues/191
     "crates/constraints",
     "crates/schema",
+    "crates/fsm",
 ]
 
 # default-members excludes any crate that activates `quent-time/__test-clock-override`.
@@ -99,6 +100,7 @@ publish = false
 [workspace.dependencies]
 async-trait = "0.1.89"
 log = {version = "0.4.28", features = ["kv"]}
+petgraph = "0.8.3"
 postcard = { version = "1", features = ["alloc"] }
 prost = "0.14.1"
 rmp-serde = "1"

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quent-fsm"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+quent-schema = { path = "../schema", features = ["serde"] }
+quent-constraints = { path = "../constraints" }
+petgraph.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -3,7 +3,7 @@
 
 use quent_schema::{entity::Entity, identifier::Identifier};
 
-use crate::{Fsm, FsmError, Transition, check_entity};
+use crate::{ExitStates, Fsm, FsmError, Transition, check_entity};
 
 /// Builds an [`Fsm`] for a specific [`Entity`], validating it on
 /// [`FsmBuilder::build`].
@@ -11,16 +11,23 @@ pub struct FsmBuilder<'a> {
     entity: &'a Entity,
     initial_state: Identifier,
     transitions: Vec<Transition>,
-    exit_from_states: Vec<Identifier>,
+    exit_from_states: ExitStates,
 }
 
 impl<'a> FsmBuilder<'a> {
-    pub(crate) fn new(entity: &'a Entity, initial_state: Identifier) -> Self {
+    pub(crate) fn new(
+        entity: &'a Entity,
+        initial_state: Identifier,
+        exit_state: Identifier,
+    ) -> Self {
         Self {
             entity,
             initial_state,
             transitions: Vec::new(),
-            exit_from_states: Vec::new(),
+            exit_from_states: ExitStates {
+                state: exit_state,
+                others: Vec::new(),
+            },
         }
     }
 
@@ -30,10 +37,10 @@ impl<'a> FsmBuilder<'a> {
         self
     }
 
-    /// Add a transition from `state` to exit (i.e. the FSM entity goes out of
+    /// Add another state the FSM may exit from (i.e. the FSM entity goes out of
     /// existence).
     pub fn exit_from(mut self, state: Identifier) -> Self {
-        self.exit_from_states.push(state);
+        self.exit_from_states.others.push(state);
         self
     }
 

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use quent_schema::{entity::Entity, identifier::Identifier};
+
+use crate::{Fsm, FsmError, Transition, check_entity};
+
+/// Builds an [`Fsm`] for a specific [`Entity`], validating it on
+/// [`FsmBuilder::build`].
+pub struct FsmBuilder<'a> {
+    entity: &'a Entity,
+    initial_state: Identifier,
+    transitions: Vec<Transition>,
+    exit_from_states: Vec<Identifier>,
+}
+
+impl<'a> FsmBuilder<'a> {
+    pub(crate) fn new(entity: &'a Entity, initial_state: Identifier) -> Self {
+        Self {
+            entity,
+            initial_state,
+            transitions: Vec::new(),
+            exit_from_states: Vec::new(),
+        }
+    }
+
+    /// Add a transition from `source` to `target`.
+    pub fn transition(mut self, source: Identifier, target: Identifier) -> Self {
+        self.transitions.push(Transition { source, target });
+        self
+    }
+
+    /// Add a transition from `state` to exit (i.e. the FSM entity goes out of
+    /// existence).
+    pub fn exit_from(mut self, state: Identifier) -> Self {
+        self.exit_from_states.push(state);
+        self
+    }
+
+    /// Validate the FSM topology against the entity and return the FSM
+    /// constraint, or return any violations found.
+    pub fn build(self) -> Result<Fsm, FsmError> {
+        let fsm = Fsm {
+            initial_state: self.initial_state,
+            transitions: self.transitions,
+            exit_from_states: self.exit_from_states,
+        };
+        let mut errors = Vec::new();
+        check_entity(self.entity, &fsm, &mut errors);
+        match errors.len() {
+            0 => Ok(fsm),
+            1 => Err(errors.pop().unwrap()),
+            _ => Err(FsmError::Multiple(errors)),
+        }
+    }
+}

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -40,6 +40,14 @@ impl Transition {
     }
 }
 
+/// A non-empty set of states from which an `Fsm` can transition out of
+/// existence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ExitStates {
+    state: Identifier,
+    others: Vec<Identifier>,
+}
+
 /// The state-transition topology of a finite state machine.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fsm {
@@ -48,15 +56,21 @@ pub struct Fsm {
     initial_state: Identifier,
     /// The possible transitions of this FSM.
     transitions: Vec<Transition>,
-    /// The names of states from which this FSM can exit to go out of existence.
-    exit_from_states: Vec<Identifier>,
+    /// The states (at least one) from which this FSM can exit to go out of
+    /// existence.
+    exit_from_states: ExitStates,
 }
 
 impl Fsm {
     /// Return a builder for an [`Fsm`] constraint over `entity`, beginning in
-    /// `initial_state`.
-    pub fn builder(entity: &Entity, initial_state: Identifier) -> FsmBuilder<'_> {
-        FsmBuilder::new(entity, initial_state)
+    /// `initial_state` and able to exit from `exit_state`. Further exit states
+    /// can be added on the builder.
+    pub fn builder(
+        entity: &Entity,
+        initial_state: Identifier,
+        exit_state: Identifier,
+    ) -> FsmBuilder<'_> {
+        FsmBuilder::new(entity, initial_state, exit_state)
     }
 
     /// The name of the initial state this FSM transitions into when it comes
@@ -65,14 +79,17 @@ impl Fsm {
         &self.initial_state
     }
 
-    /// The transitions of this FSM.
+    /// The transitions of this FSM between states.
+    ///
+    /// This excludes exit transitions. Obtain these through
+    /// [`Self::exit_from_states`].
     pub fn transitions(&self) -> &[Transition] {
         &self.transitions
     }
 
-    /// The names of states from which this FSM can exit to go out of existence.
-    pub fn exit_from_states(&self) -> &[Identifier] {
-        &self.exit_from_states
+    /// The states from which this FSM can exit to go out of existence.
+    pub fn exit_from_states(&self) -> impl Iterator<Item = &Identifier> {
+        std::iter::once(&self.exit_from_states.state).chain(self.exit_from_states.others.iter())
     }
 }
 
@@ -106,13 +123,13 @@ impl Fsm {
 /// For every entity carrying this constraint:
 ///
 /// 1. No event in the entity may be named `exit` (case-insensitively).
-/// 2. There is at least one exit transition.
-/// 3. Every state named by the FSM corresponds to an event name in the entity.
-/// 4. Every event in the entity appears as a state in the FSM.
-/// 5. Every state is reachable from the initial state.
-/// 6. An exit transition is reachable from every state.
-/// 7. A state on a cycle has [`Cardinality::Multi`], otherwise
+/// 2. Every state named by the FSM corresponds to an event name in the entity.
+/// 3. Every event in the entity appears as a state in the FSM.
+/// 4. Every state is reachable from the initial state.
+/// 5. An exit transition is reachable from every state.
+/// 6. A state on a cycle has [`Cardinality::Multi`], otherwise
 ///    [`Cardinality::Once`].
+/// 7. At least one exit transition exists (enforced by [`ExitStates`]).
 pub struct FsmConstraint;
 
 impl Constraint for FsmConstraint {
@@ -171,13 +188,6 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
         }
     }
 
-    // Requirement 2: there is at least one exit transition.
-    if fsm.exit_from_states.is_empty() {
-        errors.push(FsmError::NoExit {
-            entity: entity.name.clone(),
-        });
-    }
-
     let event_names: HashSet<&Identifier> = entity.events.iter().map(|e| &e.name).collect();
     let cardinality_by_event: BTreeMap<&Identifier, Cardinality> = entity
         .events
@@ -188,27 +198,23 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
     // Gather every state named
     let states: HashSet<&Identifier> = std::iter::once(&fsm.initial_state)
         .chain(fsm.transitions.iter().flat_map(|t| [&t.source, &t.target]))
-        .chain(&fsm.exit_from_states)
+        .chain(fsm.exit_from_states())
         .collect();
 
-    // Requirement 3: every state name corresponds to an entity event name.
-    for &state in &states {
-        if !event_names.contains(state) {
-            errors.push(FsmError::UnknownState {
-                entity: entity.name.clone(),
-                state: state.clone(),
-            });
-        }
+    // Requirement 2: every state name corresponds to an entity event name.
+    for &state in states.difference(&event_names) {
+        errors.push(FsmError::UnknownState {
+            entity: entity.name.clone(),
+            state: state.clone(),
+        });
     }
 
-    // Requirement 4: every entity event appears as a state.
-    for event in &entity.events {
-        if !states.contains(&event.name) {
-            errors.push(FsmError::UncoveredEvent {
-                entity: entity.name.clone(),
-                event: event.name.clone(),
-            });
-        }
+    // Requirement 3: every entity event appears as a state.
+    for &event in event_names.difference(&states) {
+        errors.push(FsmError::UncoveredEvent {
+            entity: entity.name.clone(),
+            event: event.clone(),
+        });
     }
 
     // Graph of states + transitions
@@ -220,13 +226,12 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
                     .map(|t| (GraphNode::Named(&t.source), GraphNode::Named(&t.target), ())),
             )
             .chain(
-                fsm.exit_from_states
-                    .iter()
+                fsm.exit_from_states()
                     .map(|x| (GraphNode::Named(x), GraphNode::Exit, ())),
             )
             .collect();
 
-    // Requirement 5: every state is reachable from the initial state.
+    // Requirement 4: every state is reachable from the initial state.
     let reachable_from_init: HashSet<GraphNode> =
         Bfs::new(&graph, GraphNode::Init).iter(&graph).collect();
     for &name in &states {
@@ -238,25 +243,20 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
         }
     }
 
-    // Requirement 6: an exit transition is reachable from every state.
-    //
-    // Skipped when there is no exit transition: req 2 already reports that, and
-    // the check would otherwise flag every state.
-    if !fsm.exit_from_states.is_empty() {
-        let reversed = Reversed(&graph);
-        let reaches_exit: HashSet<GraphNode> =
-            Bfs::new(reversed, GraphNode::Exit).iter(reversed).collect();
-        for &name in &states {
-            if !reaches_exit.contains(&GraphNode::Named(name)) {
-                errors.push(FsmError::CannotReachExit {
-                    entity: entity.name.clone(),
-                    state: name.clone(),
-                });
-            }
+    // Requirement 5: an exit transition is reachable from every state.
+    let reversed = Reversed(&graph);
+    let reaches_exit: HashSet<GraphNode> =
+        Bfs::new(reversed, GraphNode::Exit).iter(reversed).collect();
+    for &name in &states {
+        if !reaches_exit.contains(&GraphNode::Named(name)) {
+            errors.push(FsmError::CannotReachExit {
+                entity: entity.name.clone(),
+                state: name.clone(),
+            });
         }
     }
 
-    // Requirement 7: a state on a cycle is Multi, otherwise Once.
+    // Requirement 6: a state on a cycle is Multi, otherwise Once.
     let on_cycle = find_cyclic(&graph, fsm);
     for &name in &states {
         let expected_cardinality = if on_cycle.contains(name) {
@@ -318,8 +318,6 @@ pub enum FsmError {
         entity: Identifier,
         name: &'static str,
     },
-    #[error("entity \"{entity}\" fsm: has no exit transitions")]
-    NoExit { entity: Identifier },
     #[error("entity \"{entity}\" fsm: state \"{state}\" is unreachable from the initial state")]
     UnreachableFromInit {
         entity: Identifier,

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Quent built-in FSM constraint
+
+use std::collections::{BTreeMap, HashSet};
+
+use petgraph::{
+    algo::tarjan_scc,
+    graphmap::DiGraphMap,
+    visit::{Bfs, Reversed, Walker},
+};
+use quent_constraints::Constraint;
+use quent_schema::{Schema, event::Cardinality, identifier::Identifier};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A node in an [`Fsm`] topology.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum State {
+    /// A special state that, when transitioned from, describes the FSM came into existence.
+    Entry,
+    /// A special state that, when transitioned into, describes an FSM going out of existence.
+    Exit,
+    /// A regular state, named after the event that transitions into it.
+    Named(Identifier),
+}
+
+/// A directed transition between two [`State`]s in an [`Fsm`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Transition {
+    pub source: State,
+    pub target: State,
+}
+
+/// The state-transition topology of a finite state machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Fsm {
+    pub transitions: Vec<Transition>,
+}
+
+/// Constrains the order of an entity's events by a Finite-State-Machine
+/// topology.
+///
+/// Through this constraint, the behavior of an entity can be modeled as an FSM.
+/// The event order is restricted by a certain topology of "states" and
+/// "transitions" between those states, where events represent the moment in
+/// time the FSM transitions into a state with the name of the event.
+///
+/// Modeling entities as FSMs is useful to trace a specific restricted lifecycle
+/// of the entity. Possible states include the special "entry" and "exit" states,
+/// such that:
+/// - there is exactly one transition from the "entry" state into some initial
+///   state, and
+/// - from each state, there exists a sequence of transitions to the "exit" state.
+///
+/// The moment an entity modeled as an FSM in the client code transitions
+/// between states, the transition event is to be emitted. At that time, both
+/// trigger conditions and state outputs can be captured in the event's
+/// attributes. Where applicable, if users desire to capture changes to an FSM's
+/// outputs as a function of its inputs without advancing to a different state,
+/// this can be modeled as a self-transition that updates those attributes.
+///
+/// Be aware that Quent's concept of an FSM is a strict subset of what can
+/// typically be expressed in full-fledged finite-state-automata theory.
+///
+/// ## Requirements
+///
+/// For every entity carrying this constraint:
+///
+/// 1. No event in the entity may be named `entry` or `exit` (case-insensitively).
+/// 2. Exactly one transition has [`State::Entry`] as its source, and no
+///    transition has [`State::Entry`] as its target.
+/// 3. At least one transition has [`State::Exit`] as its target, and no
+///    transition has [`State::Exit`] as its source.
+/// 4. There is at least one [`State::Named`] state.
+/// 5. Every [`State::Named`] state is reachable from [`State::Entry`].
+/// 6. Every [`State::Named`] state can reach [`State::Exit`].
+/// 7. Every [`State::Named`] state corresponds to an event in the entity.
+/// 8. Every event in the entity appears as some [`State::Named`] state.
+/// 9. A state on a cycle has [`Cardinality::Multi`], otherwise
+///    [`Cardinality::Once`].
+pub struct FsmConstraint;
+
+impl Constraint for FsmConstraint {
+    const NAME: &'static str = "quent.fsm.v1";
+
+    fn validate(&self, schema: &Schema) -> Result<(), Box<dyn std::error::Error>> {
+        let mut errors = Vec::new();
+        for entity in &schema.entities {
+            let Some(constraint) = entity
+                .annotations
+                .constraints
+                .iter()
+                .find(|c| c.name == Self::NAME)
+            else {
+                continue;
+            };
+            let raw = match constraint.data.as_deref() {
+                Some(s) => s,
+                None => {
+                    errors.push(FsmError::InvalidData {
+                        entity: entity.name.clone(),
+                        message: "constraint data is missing".to_string(),
+                    });
+                    continue;
+                }
+            };
+            let fsm = match serde_json::from_str::<Fsm>(raw) {
+                Ok(f) => f,
+                Err(e) => {
+                    errors.push(FsmError::InvalidData {
+                        entity: entity.name.clone(),
+                        message: format!("failed to decode fsm: {e}"),
+                    });
+                    continue;
+                }
+            };
+            check_entity(entity, &fsm, &mut errors);
+        }
+
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors.pop().unwrap().into()),
+            _ => Err(FsmError::Multiple(errors).into()),
+        }
+    }
+}
+
+fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut Vec<FsmError>) {
+    // Requirement 1: no event may be named "entry" or "exit".
+    for event in &entity.events {
+        let lower = event.name.to_ascii_lowercase();
+        if lower == "entry" || lower == "exit" {
+            errors.push(FsmError::ReservedStateName {
+                entity: entity.name.clone(),
+                name: if lower == "entry" { "entry" } else { "exit" },
+            });
+        }
+    }
+
+    // Requirement 2: exactly one transition has Entry as its source.
+    let entry_transitions = fsm
+        .transitions
+        .iter()
+        .filter(|t| matches!(t.source, State::Entry))
+        .count();
+    if entry_transitions != 1 {
+        errors.push(FsmError::WrongEntryCount {
+            entity: entity.name.clone(),
+            found: entry_transitions,
+        });
+    }
+    // Entry is only ever transitioned from, never into.
+    if fsm
+        .transitions
+        .iter()
+        .any(|t| matches!(t.target, State::Entry))
+    {
+        errors.push(FsmError::TransitionIntoEntry {
+            entity: entity.name.clone(),
+        });
+    }
+
+    // Requirement 3: at least one transition has Exit as its target.
+    let exit_transitions = fsm
+        .transitions
+        .iter()
+        .filter(|t| matches!(t.target, State::Exit))
+        .count();
+    if exit_transitions == 0 {
+        errors.push(FsmError::NoExit {
+            entity: entity.name.clone(),
+        });
+    }
+    // Exit is only ever transitioned into, never from.
+    if fsm
+        .transitions
+        .iter()
+        .any(|t| matches!(t.source, State::Exit))
+    {
+        errors.push(FsmError::TransitionOutOfExit {
+            entity: entity.name.clone(),
+        });
+    }
+
+    let event_names: HashSet<&Identifier> = entity.events.iter().map(|e| &e.name).collect();
+    let cardinality_by_event: BTreeMap<&Identifier, Cardinality> = entity
+        .events
+        .iter()
+        .map(|e| (&e.name, e.cardinality))
+        .collect();
+
+    let named_states: HashSet<&Identifier> = fsm
+        .transitions
+        .iter()
+        .flat_map(|t| [&t.source, &t.target])
+        .filter_map(|s| match s {
+            State::Named(name) => Some(name),
+            _ => None,
+        })
+        .collect();
+
+    // Requirement 4: the FSM has at least one named state.
+    if named_states.is_empty() {
+        errors.push(FsmError::NoNamedStates {
+            entity: entity.name.clone(),
+        });
+    }
+
+    // Requirement 7: every named state corresponds to an entity event.
+    for &state in &named_states {
+        if !event_names.contains(state) {
+            errors.push(FsmError::UnknownState {
+                entity: entity.name.clone(),
+                state: state.clone(),
+            });
+        }
+    }
+
+    // Requirement 8: every entity event appears as a named state.
+    for event in &entity.events {
+        if !named_states.contains(&event.name) {
+            errors.push(FsmError::UncoveredEvent {
+                entity: entity.name.clone(),
+                event: event.name.clone(),
+            });
+        }
+    }
+
+    let graph: DiGraphMap<GraphNode, ()> = fsm
+        .transitions
+        .iter()
+        .map(|t| (GraphNode::from(&t.source), GraphNode::from(&t.target), ()))
+        .collect();
+
+    // Requirement 5: every named state is reachable from Entry
+    if entry_transitions != 0 {
+        let reachable_from_entry: HashSet<GraphNode> =
+            Bfs::new(&graph, GraphNode::Entry).iter(&graph).collect();
+        for &name in &named_states {
+            if !reachable_from_entry.contains(&GraphNode::Named(name)) {
+                errors.push(FsmError::UnreachableFromEntry {
+                    entity: entity.name.clone(),
+                    state: name.clone(),
+                });
+            }
+        }
+    }
+
+    // Requirement 6: every named state can reach Exit.
+    if exit_transitions != 0 {
+        let reversed = Reversed(&graph);
+        let reaches_exit: HashSet<GraphNode> =
+            Bfs::new(reversed, GraphNode::Exit).iter(reversed).collect();
+        for &name in &named_states {
+            if !reaches_exit.contains(&GraphNode::Named(name)) {
+                errors.push(FsmError::CannotReachExit {
+                    entity: entity.name.clone(),
+                    state: name.clone(),
+                });
+            }
+        }
+    }
+
+    // Requirement 9: a state on a cycle is Multi, otherwise Once.
+    let on_cycle = find_cyclic(&graph, fsm);
+    for &name in &named_states {
+        let expected_cardinality = if on_cycle.contains(name) {
+            Cardinality::Multi
+        } else {
+            Cardinality::Once
+        };
+        let Some(actual) = cardinality_by_event.get(name) else {
+            continue;
+        };
+        if *actual != expected_cardinality {
+            errors.push(FsmError::CardinalityMismatch {
+                entity: entity.name.clone(),
+                state: name.clone(),
+                expected: expected_cardinality,
+                found: *actual,
+            });
+        }
+    }
+}
+
+/// Compute the states that lie on a cycle in the transition graph.
+fn find_cyclic<'a>(graph: &DiGraphMap<GraphNode<'a>, ()>, fsm: &'a Fsm) -> HashSet<&'a Identifier> {
+    let mut on_cycle = HashSet::new();
+    // A node is on a cycle if it sits in a strongly connected component of more
+    // than one node.
+    for scc in tarjan_scc(graph) {
+        if scc.len() > 1 {
+            for node in scc {
+                if let GraphNode::Named(name) = node {
+                    on_cycle.insert(name);
+                }
+            }
+        }
+    }
+    // It also sits on a cycle if it has a self-loop, but `tarjan_scc` does not
+    // report those as cyclic, so do them separately:
+    for t in &fsm.transitions {
+        if t.source == t.target
+            && let State::Named(n) = &t.source
+        {
+            on_cycle.insert(n);
+        }
+    }
+    on_cycle
+}
+
+#[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+enum GraphNode<'a> {
+    Entry,
+    Exit,
+    Named(&'a Identifier),
+}
+
+impl<'a> From<&'a State> for GraphNode<'a> {
+    fn from(state: &'a State) -> Self {
+        match state {
+            State::Entry => GraphNode::Entry,
+            State::Exit => GraphNode::Exit,
+            State::Named(name) => GraphNode::Named(name),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum FsmError {
+    #[error("entity \"{entity}\" fsm: {message}")]
+    InvalidData { entity: Identifier, message: String },
+    #[error("entity \"{entity}\" fsm: \"{name}\" is a reserved state name")]
+    ReservedStateName {
+        entity: Identifier,
+        name: &'static str,
+    },
+    #[error("entity \"{entity}\" fsm: expected exactly one transition from entry, found {found}")]
+    WrongEntryCount { entity: Identifier, found: usize },
+    #[error("entity \"{entity}\" fsm: no transition reaches exit")]
+    NoExit { entity: Identifier },
+    #[error("entity \"{entity}\" fsm: a transition targets the entry state")]
+    TransitionIntoEntry { entity: Identifier },
+    #[error("entity \"{entity}\" fsm: a transition originates from the exit state")]
+    TransitionOutOfExit { entity: Identifier },
+    #[error("entity \"{entity}\" fsm: has no named states")]
+    NoNamedStates { entity: Identifier },
+    #[error("entity \"{entity}\" fsm: state \"{state}\" is unreachable from entry")]
+    UnreachableFromEntry {
+        entity: Identifier,
+        state: Identifier,
+    },
+    #[error("entity \"{entity}\" fsm: state \"{state}\" cannot reach exit")]
+    CannotReachExit {
+        entity: Identifier,
+        state: Identifier,
+    },
+    #[error("entity \"{entity}\" fsm: state \"{state}\" does not match any event")]
+    UnknownState {
+        entity: Identifier,
+        state: Identifier,
+    },
+    #[error("entity \"{entity}\" fsm: event \"{event}\" is not covered by any transition")]
+    UncoveredEvent {
+        entity: Identifier,
+        event: Identifier,
+    },
+    #[error(
+        "entity \"{entity}\" fsm: state \"{state}\" expects cardinality {expected:?}, but event has {found:?}"
+    )]
+    CardinalityMismatch {
+        entity: Identifier,
+        state: Identifier,
+        expected: Cardinality,
+        found: Cardinality,
+    },
+    #[error("multiple fsm violations:\n{}", join_errors(.0))]
+    Multiple(Vec<FsmError>),
+}
+
+fn join_errors(errors: &[FsmError]) -> String {
+    errors
+        .iter()
+        .map(|e| format!("  - {e}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -11,9 +11,13 @@ use petgraph::{
     visit::{Bfs, Reversed, Walker},
 };
 use quent_constraints::Constraint;
-use quent_schema::{Schema, event::Cardinality, identifier::Identifier};
+use quent_schema::{Schema, entity::Entity, event::Cardinality, identifier::Identifier};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+mod builder;
+
+pub use builder::FsmBuilder;
 
 /// A directed transition between two named states in an [`Fsm`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -22,6 +26,18 @@ pub struct Transition {
     source: Identifier,
     /// The name of the target state.
     target: Identifier,
+}
+
+impl Transition {
+    /// The name of the source state.
+    pub fn source(&self) -> &Identifier {
+        &self.source
+    }
+
+    /// The name of the target state.
+    pub fn target(&self) -> &Identifier {
+        &self.target
+    }
 }
 
 /// The state-transition topology of a finite state machine.
@@ -36,6 +52,30 @@ pub struct Fsm {
     exit_from_states: Vec<Identifier>,
 }
 
+impl Fsm {
+    /// Return a builder for an [`Fsm`] constraint over `entity`, beginning in
+    /// `initial_state`.
+    pub fn builder(entity: &Entity, initial_state: Identifier) -> FsmBuilder<'_> {
+        FsmBuilder::new(entity, initial_state)
+    }
+
+    /// The name of the initial state this FSM transitions into when it comes
+    /// into existence.
+    pub fn initial_state(&self) -> &Identifier {
+        &self.initial_state
+    }
+
+    /// The transitions of this FSM.
+    pub fn transitions(&self) -> &[Transition] {
+        &self.transitions
+    }
+
+    /// The names of states from which this FSM can exit to go out of existence.
+    pub fn exit_from_states(&self) -> &[Identifier] {
+        &self.exit_from_states
+    }
+}
+
 /// Constrains the order of an entity's events by a Finite-State-Machine
 /// topology.
 ///
@@ -45,11 +85,11 @@ pub struct Fsm {
 /// time the FSM transitions into a state with the name of the event.
 ///
 /// Modeling entities as FSMs is useful to trace a specific restricted lifecycle
-/// of the entity. The lifecycle has a single initial state where it comes into
-/// existence and a set of exit states from which it may go out of existence.
-/// The topology must be formed such that every state is reachable from the
-/// initial state, and from every state there exists a sequence of transitions to
-/// some exit state.
+/// of the entity. The lifecycle has a single initial state where the FSM entity
+/// comes into existence, and a set of states from which it may go out of
+/// existence through an "exit" transition. The topology must be formed such
+/// that every state is reachable from the initial state, and from every state
+/// there exists a sequence of states that leads to an exit transition.
 ///
 /// The moment an entity modeled as an FSM in the client code transitions
 /// between states, the transition event is to be emitted. At that time, both
@@ -65,15 +105,12 @@ pub struct Fsm {
 ///
 /// For every entity carrying this constraint:
 ///
-/// 1. No event in the entity may be named `exit` (case-insensitively). This
-///    is reserved such that instrumentation APIs can unambiguously provide an
-///    event-emitting function marking the FSM's transition out of existence
-///    without name clashes with possible user-defined events named "exit".
+/// 1. No event in the entity may be named `exit` (case-insensitively).
 /// 2. There is at least one exit transition.
 /// 3. Every state named by the FSM corresponds to an event name in the entity.
 /// 4. Every event in the entity appears as a state in the FSM.
 /// 5. Every state is reachable from the initial state.
-/// 6. The exit state is reachable from every other state.
+/// 6. An exit transition is reachable from every state.
 /// 7. A state on a cycle has [`Cardinality::Multi`], otherwise
 ///    [`Cardinality::Once`].
 pub struct FsmConstraint;
@@ -123,7 +160,7 @@ impl Constraint for FsmConstraint {
     }
 }
 
-fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut Vec<FsmError>) {
+pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError>) {
     // Requirement 1: no event may be named "exit".
     for event in &entity.events {
         if event.name.to_ascii_lowercase() == "exit" {
@@ -201,7 +238,8 @@ fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut V
         }
     }
 
-    // Requirement 6: every state can reach exit.
+    // Requirement 6: an exit transition is reachable from every state.
+    //
     // Skipped when there is no exit transition: req 2 already reports that, and
     // the check would otherwise flag every state.
     if !fsm.exit_from_states.is_empty() {
@@ -280,14 +318,14 @@ pub enum FsmError {
         entity: Identifier,
         name: &'static str,
     },
-    #[error("entity \"{entity}\" fsm: has no exit states")]
+    #[error("entity \"{entity}\" fsm: has no exit transitions")]
     NoExit { entity: Identifier },
-    #[error("entity \"{entity}\" fsm: state \"{state}\" is unreachable from the intial state")]
+    #[error("entity \"{entity}\" fsm: state \"{state}\" is unreachable from the initial state")]
     UnreachableFromInit {
         entity: Identifier,
         state: Identifier,
     },
-    #[error("entity \"{entity}\" fsm: state \"{state}\" cannot reach exit")]
+    #[error("entity \"{entity}\" fsm: state \"{state}\" cannot reach any exit transition")]
     CannotReachExit {
         entity: Identifier,
         state: Identifier,

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -15,28 +15,25 @@ use quent_schema::{Schema, event::Cardinality, identifier::Identifier};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// A node in an [`Fsm`] topology.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum State {
-    /// A special state that, when transitioned from, describes the FSM came into existence.
-    Entry,
-    /// A special state that, when transitioned into, describes an FSM going out of existence.
-    Exit,
-    /// A regular state, named after the event that transitions into it.
-    Named(Identifier),
-}
-
-/// A directed transition between two [`State`]s in an [`Fsm`].
+/// A directed transition between two named states in an [`Fsm`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Transition {
-    pub source: State,
-    pub target: State,
+    /// The name of the source state.
+    source: Identifier,
+    /// The name of the target state.
+    target: Identifier,
 }
 
 /// The state-transition topology of a finite state machine.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fsm {
-    pub transitions: Vec<Transition>,
+    /// The name of the initial state this FSM transitions into when it comes
+    /// into existence.
+    initial_state: Identifier,
+    /// The possible transitions of this FSM.
+    transitions: Vec<Transition>,
+    /// The names of states from which this FSM can exit to go out of existence.
+    exit_from_states: Vec<Identifier>,
 }
 
 /// Constrains the order of an entity's events by a Finite-State-Machine
@@ -48,11 +45,11 @@ pub struct Fsm {
 /// time the FSM transitions into a state with the name of the event.
 ///
 /// Modeling entities as FSMs is useful to trace a specific restricted lifecycle
-/// of the entity. Possible states include the special "entry" and "exit" states,
-/// such that:
-/// - there is exactly one transition from the "entry" state into some initial
-///   state, and
-/// - from each state, there exists a sequence of transitions to the "exit" state.
+/// of the entity. The lifecycle has a single initial state where it comes into
+/// existence and a set of exit states from which it may go out of existence.
+/// The topology must be formed such that every state is reachable from the
+/// initial state, and from every state there exists a sequence of transitions to
+/// some exit state.
 ///
 /// The moment an entity modeled as an FSM in the client code transitions
 /// between states, the transition event is to be emitted. At that time, both
@@ -68,17 +65,16 @@ pub struct Fsm {
 ///
 /// For every entity carrying this constraint:
 ///
-/// 1. No event in the entity may be named `entry` or `exit` (case-insensitively).
-/// 2. Exactly one transition has [`State::Entry`] as its source, and no
-///    transition has [`State::Entry`] as its target.
-/// 3. At least one transition has [`State::Exit`] as its target, and no
-///    transition has [`State::Exit`] as its source.
-/// 4. There is at least one [`State::Named`] state.
-/// 5. Every [`State::Named`] state is reachable from [`State::Entry`].
-/// 6. Every [`State::Named`] state can reach [`State::Exit`].
-/// 7. Every [`State::Named`] state corresponds to an event in the entity.
-/// 8. Every event in the entity appears as some [`State::Named`] state.
-/// 9. A state on a cycle has [`Cardinality::Multi`], otherwise
+/// 1. No event in the entity may be named `exit` (case-insensitively). This
+///    is reserved such that instrumentation APIs can unambiguously provide an
+///    event-emitting function marking the FSM's transition out of existence
+///    without name clashes with possible user-defined events named "exit".
+/// 2. There is at least one exit transition.
+/// 3. Every state named by the FSM corresponds to an event name in the entity.
+/// 4. Every event in the entity appears as a state in the FSM.
+/// 5. Every state is reachable from the initial state.
+/// 6. The exit state is reachable from every other state.
+/// 7. A state on a cycle has [`Cardinality::Multi`], otherwise
 ///    [`Cardinality::Once`].
 pub struct FsmConstraint;
 
@@ -128,58 +124,19 @@ impl Constraint for FsmConstraint {
 }
 
 fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut Vec<FsmError>) {
-    // Requirement 1: no event may be named "entry" or "exit".
+    // Requirement 1: no event may be named "exit".
     for event in &entity.events {
-        let lower = event.name.to_ascii_lowercase();
-        if lower == "entry" || lower == "exit" {
+        if event.name.to_ascii_lowercase() == "exit" {
             errors.push(FsmError::ReservedStateName {
                 entity: entity.name.clone(),
-                name: if lower == "entry" { "entry" } else { "exit" },
+                name: "exit",
             });
         }
     }
 
-    // Requirement 2: exactly one transition has Entry as its source.
-    let entry_transitions = fsm
-        .transitions
-        .iter()
-        .filter(|t| matches!(t.source, State::Entry))
-        .count();
-    if entry_transitions != 1 {
-        errors.push(FsmError::WrongEntryCount {
-            entity: entity.name.clone(),
-            found: entry_transitions,
-        });
-    }
-    // Entry is only ever transitioned from, never into.
-    if fsm
-        .transitions
-        .iter()
-        .any(|t| matches!(t.target, State::Entry))
-    {
-        errors.push(FsmError::TransitionIntoEntry {
-            entity: entity.name.clone(),
-        });
-    }
-
-    // Requirement 3: at least one transition has Exit as its target.
-    let exit_transitions = fsm
-        .transitions
-        .iter()
-        .filter(|t| matches!(t.target, State::Exit))
-        .count();
-    if exit_transitions == 0 {
+    // Requirement 2: there is at least one exit transition.
+    if fsm.exit_from_states.is_empty() {
         errors.push(FsmError::NoExit {
-            entity: entity.name.clone(),
-        });
-    }
-    // Exit is only ever transitioned into, never from.
-    if fsm
-        .transitions
-        .iter()
-        .any(|t| matches!(t.source, State::Exit))
-    {
-        errors.push(FsmError::TransitionOutOfExit {
             entity: entity.name.clone(),
         });
     }
@@ -191,25 +148,14 @@ fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut V
         .map(|e| (&e.name, e.cardinality))
         .collect();
 
-    let named_states: HashSet<&Identifier> = fsm
-        .transitions
-        .iter()
-        .flat_map(|t| [&t.source, &t.target])
-        .filter_map(|s| match s {
-            State::Named(name) => Some(name),
-            _ => None,
-        })
+    // Gather every state named
+    let states: HashSet<&Identifier> = std::iter::once(&fsm.initial_state)
+        .chain(fsm.transitions.iter().flat_map(|t| [&t.source, &t.target]))
+        .chain(&fsm.exit_from_states)
         .collect();
 
-    // Requirement 4: the FSM has at least one named state.
-    if named_states.is_empty() {
-        errors.push(FsmError::NoNamedStates {
-            entity: entity.name.clone(),
-        });
-    }
-
-    // Requirement 7: every named state corresponds to an entity event.
-    for &state in &named_states {
+    // Requirement 3: every state name corresponds to an entity event name.
+    for &state in &states {
         if !event_names.contains(state) {
             errors.push(FsmError::UnknownState {
                 entity: entity.name.clone(),
@@ -218,9 +164,9 @@ fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut V
         }
     }
 
-    // Requirement 8: every entity event appears as a named state.
+    // Requirement 4: every entity event appears as a state.
     for event in &entity.events {
-        if !named_states.contains(&event.name) {
+        if !states.contains(&event.name) {
             errors.push(FsmError::UncoveredEvent {
                 entity: entity.name.clone(),
                 event: event.name.clone(),
@@ -228,32 +174,41 @@ fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut V
         }
     }
 
-    let graph: DiGraphMap<GraphNode, ()> = fsm
-        .transitions
-        .iter()
-        .map(|t| (GraphNode::from(&t.source), GraphNode::from(&t.target), ()))
-        .collect();
+    // Graph of states + transitions
+    let graph: DiGraphMap<GraphNode, ()> =
+        std::iter::once((GraphNode::Init, GraphNode::Named(&fsm.initial_state), ()))
+            .chain(
+                fsm.transitions
+                    .iter()
+                    .map(|t| (GraphNode::Named(&t.source), GraphNode::Named(&t.target), ())),
+            )
+            .chain(
+                fsm.exit_from_states
+                    .iter()
+                    .map(|x| (GraphNode::Named(x), GraphNode::Exit, ())),
+            )
+            .collect();
 
-    // Requirement 5: every named state is reachable from Entry
-    if entry_transitions != 0 {
-        let reachable_from_entry: HashSet<GraphNode> =
-            Bfs::new(&graph, GraphNode::Entry).iter(&graph).collect();
-        for &name in &named_states {
-            if !reachable_from_entry.contains(&GraphNode::Named(name)) {
-                errors.push(FsmError::UnreachableFromEntry {
-                    entity: entity.name.clone(),
-                    state: name.clone(),
-                });
-            }
+    // Requirement 5: every state is reachable from the initial state.
+    let reachable_from_init: HashSet<GraphNode> =
+        Bfs::new(&graph, GraphNode::Init).iter(&graph).collect();
+    for &name in &states {
+        if !reachable_from_init.contains(&GraphNode::Named(name)) {
+            errors.push(FsmError::UnreachableFromInit {
+                entity: entity.name.clone(),
+                state: name.clone(),
+            });
         }
     }
 
-    // Requirement 6: every named state can reach Exit.
-    if exit_transitions != 0 {
+    // Requirement 6: every state can reach exit.
+    // Skipped when there is no exit transition: req 2 already reports that, and
+    // the check would otherwise flag every state.
+    if !fsm.exit_from_states.is_empty() {
         let reversed = Reversed(&graph);
         let reaches_exit: HashSet<GraphNode> =
             Bfs::new(reversed, GraphNode::Exit).iter(reversed).collect();
-        for &name in &named_states {
+        for &name in &states {
             if !reaches_exit.contains(&GraphNode::Named(name)) {
                 errors.push(FsmError::CannotReachExit {
                     entity: entity.name.clone(),
@@ -263,9 +218,9 @@ fn check_entity(entity: &quent_schema::entity::Entity, fsm: &Fsm, errors: &mut V
         }
     }
 
-    // Requirement 9: a state on a cycle is Multi, otherwise Once.
+    // Requirement 7: a state on a cycle is Multi, otherwise Once.
     let on_cycle = find_cyclic(&graph, fsm);
-    for &name in &named_states {
+    for &name in &states {
         let expected_cardinality = if on_cycle.contains(name) {
             Cardinality::Multi
         } else {
@@ -302,10 +257,8 @@ fn find_cyclic<'a>(graph: &DiGraphMap<GraphNode<'a>, ()>, fsm: &'a Fsm) -> HashS
     // It also sits on a cycle if it has a self-loop, but `tarjan_scc` does not
     // report those as cyclic, so do them separately:
     for t in &fsm.transitions {
-        if t.source == t.target
-            && let State::Named(n) = &t.source
-        {
-            on_cycle.insert(n);
+        if t.source == t.target {
+            on_cycle.insert(&t.source);
         }
     }
     on_cycle
@@ -313,19 +266,9 @@ fn find_cyclic<'a>(graph: &DiGraphMap<GraphNode<'a>, ()>, fsm: &'a Fsm) -> HashS
 
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 enum GraphNode<'a> {
-    Entry,
+    Init,
     Exit,
     Named(&'a Identifier),
-}
-
-impl<'a> From<&'a State> for GraphNode<'a> {
-    fn from(state: &'a State) -> Self {
-        match state {
-            State::Entry => GraphNode::Entry,
-            State::Exit => GraphNode::Exit,
-            State::Named(name) => GraphNode::Named(name),
-        }
-    }
 }
 
 #[derive(Debug, Error)]
@@ -337,18 +280,10 @@ pub enum FsmError {
         entity: Identifier,
         name: &'static str,
     },
-    #[error("entity \"{entity}\" fsm: expected exactly one transition from entry, found {found}")]
-    WrongEntryCount { entity: Identifier, found: usize },
-    #[error("entity \"{entity}\" fsm: no transition reaches exit")]
+    #[error("entity \"{entity}\" fsm: has no exit states")]
     NoExit { entity: Identifier },
-    #[error("entity \"{entity}\" fsm: a transition targets the entry state")]
-    TransitionIntoEntry { entity: Identifier },
-    #[error("entity \"{entity}\" fsm: a transition originates from the exit state")]
-    TransitionOutOfExit { entity: Identifier },
-    #[error("entity \"{entity}\" fsm: has no named states")]
-    NoNamedStates { entity: Identifier },
-    #[error("entity \"{entity}\" fsm: state \"{state}\" is unreachable from entry")]
-    UnreachableFromEntry {
+    #[error("entity \"{entity}\" fsm: state \"{state}\" is unreachable from the intial state")]
+    UnreachableFromInit {
         entity: Identifier,
         state: Identifier,
     },
@@ -362,7 +297,7 @@ pub enum FsmError {
         entity: Identifier,
         state: Identifier,
     },
-    #[error("entity \"{entity}\" fsm: event \"{event}\" is not covered by any transition")]
+    #[error("entity \"{entity}\" fsm: event \"{event}\" does not appear as a state")]
     UncoveredEvent {
         entity: Identifier,
         event: Identifier,

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use quent_constraints::{Constraint as _, Error as ValidatorError, Validator};
-use quent_fsm::{Fsm, FsmConstraint, FsmError, State, Transition};
+use quent_fsm::{Fsm, FsmConstraint, FsmError};
 use quent_schema::{
     Schema,
     annotations::Annotations,
@@ -25,19 +25,41 @@ fn event(name: &str, cardinality: Cardinality) -> Event {
     }
 }
 
-fn fsm_constraint(fsm: &Fsm) -> Constraint {
-    Constraint {
-        name: FsmConstraint::NAME.to_string(),
-        data: Some(serde_json::to_string(fsm).unwrap()),
+fn bare_entity(name: &str, events: Vec<Event>) -> Entity {
+    Entity {
+        name: ident(name),
+        events,
+        annotations: Annotations::default(),
     }
 }
 
-fn entity_with(name: &str, events: Vec<Event>, fsm: &Fsm) -> Entity {
+// Build the constraint's JSON directly so we can build it in an invalid way.
+fn fsm(initial: &str, transitions: &[(&str, &str)], exit: &[&str]) -> String {
+    let transitions: Vec<serde_json::Value> = transitions
+        .iter()
+        .map(|&(source, target)| serde_json::json!({ "source": source, "target": target }))
+        .collect();
+    serde_json::json!({
+        "initial_state": initial,
+        "transitions": transitions,
+        "exit_from_states": exit,
+    })
+    .to_string()
+}
+
+fn fsm_constraint(data: &str) -> Constraint {
+    Constraint {
+        name: FsmConstraint::NAME.to_string(),
+        data: Some(data.to_string()),
+    }
+}
+
+fn entity_with(name: &str, events: Vec<Event>, data: &str) -> Entity {
     Entity {
         name: ident(name),
         events,
         annotations: Annotations {
-            constraints: vec![fsm_constraint(fsm)],
+            constraints: vec![fsm_constraint(data)],
             ..Default::default()
         },
     }
@@ -60,6 +82,7 @@ fn validate(schema: &Schema) -> Vec<FsmError> {
     {
         Ok(()) => Vec::new(),
         Err(ValidatorError::Invalid { failures, .. }) => {
+            // These tests always register the constraint, so `failures` is non-empty.
             let (_, source) = failures.into_iter().next().unwrap();
             match *source.downcast::<FsmError>().unwrap() {
                 FsmError::Multiple(errors) => errors,
@@ -70,29 +93,9 @@ fn validate(schema: &Schema) -> Vec<FsmError> {
     }
 }
 
-fn linear_transitions(named: &[&str]) -> Vec<Transition> {
-    let mut ts = Vec::new();
-    let mut prev = State::Entry;
-    for n in named {
-        let curr = State::Named(ident(n));
-        ts.push(Transition {
-            source: prev,
-            target: curr.clone(),
-        });
-        prev = curr;
-    }
-    ts.push(Transition {
-        source: prev,
-        target: State::Exit,
-    });
-    ts
-}
-
 #[test]
 fn well_formed_linear_fsm_passes() {
-    let fsm = Fsm {
-        transitions: linear_transitions(&["a", "b"]),
-    };
+    let fsm = fsm("a", &[("a", "b")], &["b"]);
     let entity = entity_with(
         "E",
         vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
@@ -103,23 +106,15 @@ fn well_formed_linear_fsm_passes() {
 
 #[test]
 fn well_formed_self_loop_fsm_passes() {
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Exit,
-            },
-        ],
-    };
+    let fsm = fsm("a", &[("a", "a")], &["a"]);
     let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
+    assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn single_state_fsm_passes() {
+    let fsm = fsm("a", &[], &["a"]);
+    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
     assert!(validate(&schema_with(entity)).is_empty());
 }
 
@@ -166,50 +161,8 @@ fn invalid_json_is_rejected() {
 }
 
 #[test]
-fn fsm_with_no_named_states_is_rejected() {
-    // this would appear in an event stream as some freak kind of stateless
-    // single-event FSM, so reject it.
-    let fsm = Fsm {
-        transitions: vec![Transition {
-            source: State::Entry,
-            target: State::Exit,
-        }],
-    };
-    let entity = entity_with("E", vec![], &fsm);
-    let errors = validate(&schema_with(entity));
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::NoNamedStates { .. })),
-    );
-}
-
-#[test]
-fn reserved_name_entry_is_rejected() {
-    let fsm = Fsm {
-        transitions: linear_transitions(&["a"]),
-    };
-    let entity = entity_with(
-        "E",
-        vec![
-            event("Entry", Cardinality::Once),
-            event("a", Cardinality::Once),
-        ],
-        &fsm,
-    );
-    let errors = validate(&schema_with(entity));
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::ReservedStateName { name: "entry", .. })),
-    );
-}
-
-#[test]
 fn reserved_name_exit_is_rejected() {
-    let fsm = Fsm {
-        transitions: linear_transitions(&["a"]),
-    };
+    let fsm = fsm("a", &[], &["a"]);
     let entity = entity_with(
         "E",
         vec![
@@ -227,75 +180,13 @@ fn reserved_name_exit_is_rejected() {
 }
 
 #[test]
-fn no_entry_transition_is_rejected() {
-    let fsm = Fsm {
-        transitions: vec![Transition {
-            source: State::Named(ident("a")),
-            target: State::Exit,
-        }],
-    };
-    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
-    let errors = validate(&schema_with(entity));
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::WrongEntryCount { found: 0, .. })),
-    );
-    // The missing entry transition must not cascade into per-state unreachability.
-    assert!(
-        !errors
-            .iter()
-            .any(|e| matches!(e, FsmError::UnreachableFromEntry { .. })),
-    );
-}
-
-#[test]
-fn two_entry_transitions_are_rejected() {
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("b")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Exit,
-            },
-            Transition {
-                source: State::Named(ident("b")),
-                target: State::Exit,
-            },
-        ],
-    };
-    let entity = entity_with(
-        "E",
-        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
-        &fsm,
-    );
-    let errors = validate(&schema_with(entity));
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::WrongEntryCount { found: 2, .. })),
-    );
-}
-
-#[test]
-fn no_exit_transition_is_rejected() {
-    let fsm = Fsm {
-        transitions: vec![Transition {
-            source: State::Entry,
-            target: State::Named(ident("a")),
-        }],
-    };
+fn no_exit_state_is_rejected() {
+    let fsm = fsm("a", &[], &[]);
     let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
     let errors = validate(&schema_with(entity));
     assert!(errors.iter().any(|e| matches!(e, FsmError::NoExit { .. })),);
-    // if exit is missing just report that
+    // a missing exit must not cascade into every state being flagged as unable
+    // to reach exit.
     assert!(
         !errors
             .iter()
@@ -304,78 +195,9 @@ fn no_exit_transition_is_rejected() {
 }
 
 #[test]
-fn transition_into_entry_is_rejected() {
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Entry,
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Exit,
-            },
-        ],
-    };
-    let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
-    let errors = validate(&schema_with(entity));
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::TransitionIntoEntry { .. })),
-    );
-}
-
-#[test]
-fn transition_out_of_exit_is_rejected() {
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Exit,
-            },
-            Transition {
-                source: State::Exit,
-                target: State::Named(ident("a")),
-            },
-        ],
-    };
-    let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
-    let errors = validate(&schema_with(entity));
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::TransitionOutOfExit { .. })),
-    );
-}
-
-#[test]
-fn state_unreachable_from_entry_is_rejected() {
-    // b is named in transitions but only connects to itself and exit.
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Exit,
-            },
-            Transition {
-                source: State::Named(ident("b")),
-                target: State::Exit,
-            },
-        ],
-    };
+fn state_unreachable_from_initial_is_rejected() {
+    // b is listed as an exit state but nothing transitions into it
+    let fsm = fsm("a", &[], &["a", "b"]);
     let entity = entity_with(
         "E",
         vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
@@ -385,29 +207,14 @@ fn state_unreachable_from_entry_is_rejected() {
     assert!(
         errors
             .iter()
-            .any(|e| matches!(e, FsmError::UnreachableFromEntry { state, .. } if state == "b")),
+            .any(|e| matches!(e, FsmError::UnreachableFromInit { state, .. } if state == "b")),
     );
 }
 
 #[test]
 fn state_cannot_reach_exit_is_rejected() {
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Named(ident("b")),
-            },
-            // b never reaches exit
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Exit,
-            },
-        ],
-    };
+    // a may exit, but b has no path to an exit state
+    let fsm = fsm("a", &[("a", "b")], &["a"]);
     let entity = entity_with(
         "E",
         vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
@@ -423,26 +230,21 @@ fn state_cannot_reach_exit_is_rejected() {
 
 #[test]
 fn fsm_state_not_in_events_is_rejected() {
-    let fsm = Fsm {
-        transitions: linear_transitions(&["phantom"]),
-    };
+    let fsm = fsm("phantom", &[], &["phantom"]);
     let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
     let errors = validate(&schema_with(entity));
     assert!(
         errors
             .iter()
-            .any(|e| matches!(e, FsmError::UnknownState { state, .. } if
-            state == "phantom")),
+            .any(|e| matches!(e, FsmError::UnknownState { state, .. } if state == "phantom")),
     );
 }
 
 // TODO(johanpel): consider allowing FSMs to have freestanding events
 #[test]
 fn event_not_covered_by_fsm_is_rejected() {
-    let fsm = Fsm {
-        transitions: linear_transitions(&["a"]),
-    };
-    // dead is declared but never referenced by any transition.
+    // dead is declared but never appears as a state in the FSM.
+    let fsm = fsm("a", &[], &["a"]);
     let entity = entity_with(
         "E",
         vec![
@@ -458,22 +260,7 @@ fn event_not_covered_by_fsm_is_rejected() {
 
 #[test]
 fn cycle_requires_multi_cardinality() {
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Exit,
-            },
-        ],
-    };
+    let fsm = fsm("a", &[("a", "a")], &["a"]);
     let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
     let errors = validate(&schema_with(entity));
     assert!(errors.iter().any(|e| matches!(
@@ -488,9 +275,7 @@ fn cycle_requires_multi_cardinality() {
 
 #[test]
 fn acyclic_requires_once_cardinality() {
-    let fsm = Fsm {
-        transitions: linear_transitions(&["a"]),
-    };
+    let fsm = fsm("a", &[], &["a"]);
     let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
     let errors = validate(&schema_with(entity));
     assert!(errors.iter().any(|e| matches!(
@@ -505,26 +290,7 @@ fn acyclic_requires_once_cardinality() {
 
 #[test]
 fn scc_of_size_two_requires_multi_for_both_states() {
-    let fsm = Fsm {
-        transitions: vec![
-            Transition {
-                source: State::Entry,
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("a")),
-                target: State::Named(ident("b")),
-            },
-            Transition {
-                source: State::Named(ident("b")),
-                target: State::Named(ident("a")),
-            },
-            Transition {
-                source: State::Named(ident("b")),
-                target: State::Exit,
-            },
-        ],
-    };
+    let fsm = fsm("a", &[("a", "b"), ("b", "a")], &["b"]);
 
     // a and b should actually be multi, so this should not validate
     let entity = entity_with(
@@ -558,10 +324,86 @@ fn scc_of_size_two_requires_multi_for_both_states() {
 
 #[test]
 fn entity_without_fsm_constraint_is_ignored() {
-    let entity = Entity {
-        name: ident("E"),
-        events: vec![event("a", Cardinality::Once)],
-        annotations: Annotations::default(),
-    };
+    let entity = bare_entity("E", vec![event("a", Cardinality::Once)]);
     assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn builder_produces_valid_fsm_and_exposes_data() {
+    let entity = bare_entity(
+        "E",
+        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
+    );
+    let fsm = Fsm::builder(&entity, ident("a"))
+        .transition(ident("a"), ident("b"))
+        .exit_from(ident("b"))
+        .build()
+        .expect("valid fsm");
+
+    assert_eq!(fsm.initial_state(), &ident("a"));
+    assert_eq!(fsm.transitions().len(), 1);
+    assert_eq!(fsm.transitions()[0].source(), &ident("a"));
+    assert_eq!(fsm.transitions()[0].target(), &ident("b"));
+    assert_eq!(fsm.exit_from_states().len(), 1);
+    assert_eq!(fsm.exit_from_states()[0], ident("b"));
+}
+
+#[test]
+fn builder_rejects_unknown_event() {
+    // "b" is not an event the entity defines.
+    let entity = bare_entity("E", vec![event("a", Cardinality::Once)]);
+    let err = Fsm::builder(&entity, ident("b"))
+        .exit_from(ident("b"))
+        .build()
+        .expect_err("should reject unknown state");
+    let errors = match err {
+        FsmError::Multiple(errors) => errors,
+        single => vec![single],
+    };
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::UnknownState { state, .. } if state == "b")),
+    );
+}
+
+#[test]
+fn multiple_exit_states_pass() {
+    // Both b and c are valid exit states.
+    let fsm = fsm("a", &[("a", "b"), ("a", "c")], &["b", "c"]);
+    let entity = entity_with(
+        "E",
+        vec![
+            event("a", Cardinality::Once),
+            event("b", Cardinality::Once),
+            event("c", Cardinality::Once),
+        ],
+        &fsm,
+    );
+    assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn exit_state_may_have_outgoing_transition() {
+    // a is an exit state but may also continue to b.
+    let fsm = fsm("a", &[("a", "b")], &["a", "b"]);
+    let entity = entity_with(
+        "E",
+        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
+        &fsm,
+    );
+    assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn multiple_violations_are_aggregated() {
+    let fsm = fsm("a", &[("a", "a")], &[]);
+    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(errors.iter().any(|e| matches!(e, FsmError::NoExit { .. })));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::CardinalityMismatch { .. }))
+    );
 }

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -1,0 +1,567 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use quent_constraints::{Constraint as _, Error as ValidatorError, Validator};
+use quent_fsm::{Fsm, FsmConstraint, FsmError, State, Transition};
+use quent_schema::{
+    Schema,
+    annotations::Annotations,
+    constraint::Constraint,
+    entity::Entity,
+    event::{Cardinality, Event},
+    identifier::Identifier,
+};
+
+fn ident(s: &str) -> Identifier {
+    Identifier::try_new(s).unwrap()
+}
+
+fn event(name: &str, cardinality: Cardinality) -> Event {
+    Event {
+        name: ident(name),
+        cardinality,
+        payload: vec![],
+        annotations: Annotations::default(),
+    }
+}
+
+fn fsm_constraint(fsm: &Fsm) -> Constraint {
+    Constraint {
+        name: FsmConstraint::NAME.to_string(),
+        data: Some(serde_json::to_string(fsm).unwrap()),
+    }
+}
+
+fn entity_with(name: &str, events: Vec<Event>, fsm: &Fsm) -> Entity {
+    Entity {
+        name: ident(name),
+        events,
+        annotations: Annotations {
+            constraints: vec![fsm_constraint(fsm)],
+            ..Default::default()
+        },
+    }
+}
+
+fn schema_with(entity: Entity) -> Schema {
+    Schema {
+        name: ident("S"),
+        entities: vec![entity],
+        records: vec![],
+        annotations: Annotations::default(),
+    }
+}
+
+fn validate(schema: &Schema) -> Vec<FsmError> {
+    match Validator::default()
+        .try_with(FsmConstraint)
+        .unwrap()
+        .validate(schema)
+    {
+        Ok(()) => Vec::new(),
+        Err(ValidatorError::Invalid { failures, .. }) => {
+            let (_, source) = failures.into_iter().next().unwrap();
+            match *source.downcast::<FsmError>().unwrap() {
+                FsmError::Multiple(errors) => errors,
+                single => vec![single],
+            }
+        }
+        Err(_) => unreachable!(),
+    }
+}
+
+fn linear_transitions(named: &[&str]) -> Vec<Transition> {
+    let mut ts = Vec::new();
+    let mut prev = State::Entry;
+    for n in named {
+        let curr = State::Named(ident(n));
+        ts.push(Transition {
+            source: prev,
+            target: curr.clone(),
+        });
+        prev = curr;
+    }
+    ts.push(Transition {
+        source: prev,
+        target: State::Exit,
+    });
+    ts
+}
+
+#[test]
+fn well_formed_linear_fsm_passes() {
+    let fsm = Fsm {
+        transitions: linear_transitions(&["a", "b"]),
+    };
+    let entity = entity_with(
+        "E",
+        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
+        &fsm,
+    );
+    assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn well_formed_self_loop_fsm_passes() {
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Exit,
+            },
+        ],
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
+    assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn missing_data_is_rejected() {
+    let entity = Entity {
+        name: ident("E"),
+        events: vec![event("a", Cardinality::Once)],
+        annotations: Annotations {
+            constraints: vec![Constraint {
+                name: FsmConstraint::NAME.to_string(),
+                data: None,
+            }],
+            ..Default::default()
+        },
+    };
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::InvalidData { .. }))
+    );
+}
+
+#[test]
+fn invalid_json_is_rejected() {
+    let entity = Entity {
+        name: ident("E"),
+        events: vec![event("a", Cardinality::Once)],
+        annotations: Annotations {
+            constraints: vec![Constraint {
+                name: FsmConstraint::NAME.to_string(),
+                data: Some("{ trash".to_string()),
+            }],
+            ..Default::default()
+        },
+    };
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::InvalidData { .. })),
+    );
+}
+
+#[test]
+fn fsm_with_no_named_states_is_rejected() {
+    // this would appear in an event stream as some freak kind of stateless
+    // single-event FSM, so reject it.
+    let fsm = Fsm {
+        transitions: vec![Transition {
+            source: State::Entry,
+            target: State::Exit,
+        }],
+    };
+    let entity = entity_with("E", vec![], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::NoNamedStates { .. })),
+    );
+}
+
+#[test]
+fn reserved_name_entry_is_rejected() {
+    let fsm = Fsm {
+        transitions: linear_transitions(&["a"]),
+    };
+    let entity = entity_with(
+        "E",
+        vec![
+            event("Entry", Cardinality::Once),
+            event("a", Cardinality::Once),
+        ],
+        &fsm,
+    );
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::ReservedStateName { name: "entry", .. })),
+    );
+}
+
+#[test]
+fn reserved_name_exit_is_rejected() {
+    let fsm = Fsm {
+        transitions: linear_transitions(&["a"]),
+    };
+    let entity = entity_with(
+        "E",
+        vec![
+            event("EXIT", Cardinality::Once),
+            event("a", Cardinality::Once),
+        ],
+        &fsm,
+    );
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::ReservedStateName { name: "exit", .. })),
+    );
+}
+
+#[test]
+fn no_entry_transition_is_rejected() {
+    let fsm = Fsm {
+        transitions: vec![Transition {
+            source: State::Named(ident("a")),
+            target: State::Exit,
+        }],
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::WrongEntryCount { found: 0, .. })),
+    );
+    // The missing entry transition must not cascade into per-state unreachability.
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e, FsmError::UnreachableFromEntry { .. })),
+    );
+}
+
+#[test]
+fn two_entry_transitions_are_rejected() {
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("b")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Exit,
+            },
+            Transition {
+                source: State::Named(ident("b")),
+                target: State::Exit,
+            },
+        ],
+    };
+    let entity = entity_with(
+        "E",
+        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
+        &fsm,
+    );
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::WrongEntryCount { found: 2, .. })),
+    );
+}
+
+#[test]
+fn no_exit_transition_is_rejected() {
+    let fsm = Fsm {
+        transitions: vec![Transition {
+            source: State::Entry,
+            target: State::Named(ident("a")),
+        }],
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(errors.iter().any(|e| matches!(e, FsmError::NoExit { .. })),);
+    // if exit is missing just report that
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e, FsmError::CannotReachExit { .. })),
+    );
+}
+
+#[test]
+fn transition_into_entry_is_rejected() {
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Entry,
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Exit,
+            },
+        ],
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::TransitionIntoEntry { .. })),
+    );
+}
+
+#[test]
+fn transition_out_of_exit_is_rejected() {
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Exit,
+            },
+            Transition {
+                source: State::Exit,
+                target: State::Named(ident("a")),
+            },
+        ],
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::TransitionOutOfExit { .. })),
+    );
+}
+
+#[test]
+fn state_unreachable_from_entry_is_rejected() {
+    // b is named in transitions but only connects to itself and exit.
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Exit,
+            },
+            Transition {
+                source: State::Named(ident("b")),
+                target: State::Exit,
+            },
+        ],
+    };
+    let entity = entity_with(
+        "E",
+        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
+        &fsm,
+    );
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::UnreachableFromEntry { state, .. } if state == "b")),
+    );
+}
+
+#[test]
+fn state_cannot_reach_exit_is_rejected() {
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Named(ident("b")),
+            },
+            // b never reaches exit
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Exit,
+            },
+        ],
+    };
+    let entity = entity_with(
+        "E",
+        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
+        &fsm,
+    );
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::CannotReachExit { state, .. } if state == "b")),
+    );
+}
+
+#[test]
+fn fsm_state_not_in_events_is_rejected() {
+    let fsm = Fsm {
+        transitions: linear_transitions(&["phantom"]),
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::UnknownState { state, .. } if
+            state == "phantom")),
+    );
+}
+
+// TODO(johanpel): consider allowing FSMs to have freestanding events
+#[test]
+fn event_not_covered_by_fsm_is_rejected() {
+    let fsm = Fsm {
+        transitions: linear_transitions(&["a"]),
+    };
+    // dead is declared but never referenced by any transition.
+    let entity = entity_with(
+        "E",
+        vec![
+            event("a", Cardinality::Once),
+            event("dead", Cardinality::Once),
+        ],
+        &fsm,
+    );
+    let errors = validate(&schema_with(entity));
+    assert!(errors.iter().any(|e| matches!(e,
+    FsmError::UncoveredEvent { event, .. } if event == "dead")),);
+}
+
+#[test]
+fn cycle_requires_multi_cardinality() {
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Exit,
+            },
+        ],
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(errors.iter().any(|e| matches!(
+        e,
+        FsmError::CardinalityMismatch {
+            expected: Cardinality::Multi,
+            found: Cardinality::Once,
+            ..
+        }
+    )),);
+}
+
+#[test]
+fn acyclic_requires_once_cardinality() {
+    let fsm = Fsm {
+        transitions: linear_transitions(&["a"]),
+    };
+    let entity = entity_with("E", vec![event("a", Cardinality::Multi)], &fsm);
+    let errors = validate(&schema_with(entity));
+    assert!(errors.iter().any(|e| matches!(
+        e,
+        FsmError::CardinalityMismatch {
+            expected: Cardinality::Once,
+            found: Cardinality::Multi,
+            ..
+        }
+    )),);
+}
+
+#[test]
+fn scc_of_size_two_requires_multi_for_both_states() {
+    let fsm = Fsm {
+        transitions: vec![
+            Transition {
+                source: State::Entry,
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("a")),
+                target: State::Named(ident("b")),
+            },
+            Transition {
+                source: State::Named(ident("b")),
+                target: State::Named(ident("a")),
+            },
+            Transition {
+                source: State::Named(ident("b")),
+                target: State::Exit,
+            },
+        ],
+    };
+
+    // a and b should actually be multi, so this should not validate
+    let entity = entity_with(
+        "E",
+        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
+        &fsm,
+    );
+    let errors = validate(&schema_with(entity));
+    assert!(errors.iter().any(|e| matches!(
+        e,
+        FsmError::CardinalityMismatch { state, expected: Cardinality::Multi, .. }
+            if state == "a"
+    )),);
+    assert!(errors.iter().any(|e| matches!(
+        e,
+        FsmError::CardinalityMismatch { state, expected: Cardinality::Multi, .. }
+            if state == "b"
+    )),);
+
+    // make them multi to make it pass
+    let entity = entity_with(
+        "E",
+        vec![
+            event("a", Cardinality::Multi),
+            event("b", Cardinality::Multi),
+        ],
+        &fsm,
+    );
+    assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn entity_without_fsm_constraint_is_ignored() {
+    let entity = Entity {
+        name: ident("E"),
+        events: vec![event("a", Cardinality::Once)],
+        annotations: Annotations::default(),
+    };
+    assert!(validate(&schema_with(entity)).is_empty());
+}

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -39,10 +39,11 @@ fn fsm(initial: &str, transitions: &[(&str, &str)], exit: &[&str]) -> String {
         .iter()
         .map(|&(source, target)| serde_json::json!({ "source": source, "target": target }))
         .collect();
+    let (first_exit, other_exit) = exit.split_first().unwrap();
     serde_json::json!({
         "initial_state": initial,
         "transitions": transitions,
-        "exit_from_states": exit,
+        "exit_from_states": { "state": first_exit, "others": other_exit },
     })
     .to_string()
 }
@@ -180,17 +181,19 @@ fn reserved_name_exit_is_rejected() {
 }
 
 #[test]
-fn no_exit_state_is_rejected() {
-    let fsm = fsm("a", &[], &[]);
-    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
+fn empty_exit_is_rejected() {
+    let data = serde_json::json!({
+        "initial_state": "a",
+        "transitions": [],
+        "exit_from_states": [],
+    })
+    .to_string();
+    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &data);
     let errors = validate(&schema_with(entity));
-    assert!(errors.iter().any(|e| matches!(e, FsmError::NoExit { .. })),);
-    // a missing exit must not cascade into every state being flagged as unable
-    // to reach exit.
     assert!(
-        !errors
+        errors
             .iter()
-            .any(|e| matches!(e, FsmError::CannotReachExit { .. })),
+            .any(|e| matches!(e, FsmError::InvalidData { .. }))
     );
 }
 
@@ -334,28 +337,29 @@ fn builder_produces_valid_fsm_and_exposes_data() {
         "E",
         vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
     );
-    let fsm = Fsm::builder(&entity, ident("a"))
+    let fsm = Fsm::builder(&entity, ident("a"), ident("b"))
         .transition(ident("a"), ident("b"))
-        .exit_from(ident("b"))
         .build()
-        .expect("valid fsm");
+        .unwrap();
 
     assert_eq!(fsm.initial_state(), &ident("a"));
     assert_eq!(fsm.transitions().len(), 1);
     assert_eq!(fsm.transitions()[0].source(), &ident("a"));
     assert_eq!(fsm.transitions()[0].target(), &ident("b"));
-    assert_eq!(fsm.exit_from_states().len(), 1);
-    assert_eq!(fsm.exit_from_states()[0], ident("b"));
+    assert_eq!(
+        fsm.exit_from_states().collect::<Vec<_>>(),
+        vec![&ident("b")],
+    );
 }
 
 #[test]
 fn builder_rejects_unknown_event() {
-    // "b" is not an event the entity defines.
+    // b is not an event
     let entity = bare_entity("E", vec![event("a", Cardinality::Once)]);
-    let err = Fsm::builder(&entity, ident("b"))
-        .exit_from(ident("b"))
+    let err = Fsm::builder(&entity, ident("b"), ident("b"))
         .build()
-        .expect_err("should reject unknown state");
+        .err()
+        .unwrap();
     let errors = match err {
         FsmError::Multiple(errors) => errors,
         single => vec![single],
@@ -397,10 +401,23 @@ fn exit_state_may_have_outgoing_transition() {
 
 #[test]
 fn multiple_violations_are_aggregated() {
-    let fsm = fsm("a", &[("a", "a")], &[]);
-    let entity = entity_with("E", vec![event("a", Cardinality::Once)], &fsm);
+    // b is unreachable from the initial state
+    // b is declared Multi though it is acyclic
+    let fsm = fsm("a", &[], &["a", "b"]);
+    let entity = entity_with(
+        "E",
+        vec![
+            event("a", Cardinality::Once),
+            event("b", Cardinality::Multi),
+        ],
+        &fsm,
+    );
     let errors = validate(&schema_with(entity));
-    assert!(errors.iter().any(|e| matches!(e, FsmError::NoExit { .. })));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, FsmError::UnreachableFromInit { .. }))
+    );
     assert!(
         errors
             .iter()

--- a/crates/schema/src/identifier.rs
+++ b/crates/schema/src/identifier.rs
@@ -74,6 +74,18 @@ impl std::fmt::Display for Identifier {
     }
 }
 
+impl PartialEq<str> for Identifier {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<&str> for Identifier {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == **other
+    }
+}
+
 impl<T> AsRef<T> for Identifier
 where
     T: ?Sized,
@@ -128,6 +140,14 @@ mod tests {
     #[test]
     fn rejects_empty() {
         assert_eq!(Identifier::try_new(""), Err(IdentifierError::Empty));
+    }
+
+    #[test]
+    fn compares_to_str() {
+        let id = Identifier::try_new("foo").unwrap();
+        assert_eq!(id, "foo");
+        assert_ne!(id, "bar");
+        assert!(&id == "foo");
     }
 
     #[test]

--- a/examples/simulator/application/Cargo.toml
+++ b/examples/simulator/application/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace =  true
 publish.workspace = true
 [dependencies]
 clap = {version = "4.5.57", features = ["derive", "env"] }
-petgraph = "0.8.3"
+petgraph.workspace = true
 quent-attributes = { path = "../../../crates/attributes" }
 quent-exporter = { path = "../../../crates/exporter" }
 quent-query-engine-model = { path = "../../../domains/query_engine/model" }


### PR DESCRIPTION
This PR adds the `quent-fsm` crate. This is a built-in constraint (also see #192) ("quent.fsm.v1") that restricts the order of an entity's events according to some FSM topology that an entity can be annotated with in a schema. 

This can in turn be leveraged by code generation steps to produce a more specific instrumentation API for this entity. For example e.g. in Rust following the typestate pattern, the Rust compiler will prevent you from emitting events that make an illegal transition.

This is widely applicable wherever clients want to trace any type of lifecycle of entities in their code. 
It can even be used to form more traditional traces, e.g. of trees of "spans" (a span could have one "started/open" state like in OTel tracing, or go through cycles of "enter, exit, ..." , like in the case of the Rust `tracing` crate where this helps trace the execution of async tasks.

The reference instrumentation library generator and modeling APIs will support this constraint.

Integration with codegen was explored in #128. This is part of the larger effort described in #191.