### PR TITLE
feat: add ref-target constraint crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-ref-target"
+version = "0.1.0"
+dependencies = [
+ "quent-constraints",
+ "quent-schema",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "quent-schema"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     # Unused preliminary crates of https://github.com/rapidsai/quent/issues/191
     "crates/constraints",
     "crates/schema",
+    "crates/ref-target"
 ]
 
 # default-members excludes any crate that activates `quent-time/__test-clock-override`.

--- a/crates/constraints/src/lib.rs
+++ b/crates/constraints/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeSet, HashMap, hash_map::Entry};
 
-use quent_schema::{Schema, constraint::Constraint as SchemaConstraint};
+use quent_schema::{Schema, constraint::Constraint as SchemaConstraint, data_type::DataType};
 
 /// A trait for types that implement a "constraint" of an application event
 /// model.
@@ -130,6 +130,7 @@ impl Validator {
                 check(&event.annotations.constraints);
                 for field in &event.payload {
                     check(&field.annotations.constraints);
+                    check_entity_refs(&field.ty, &mut check);
                 }
             }
         }
@@ -137,6 +138,7 @@ impl Validator {
             check(&record.annotations.constraints);
             for field in &record.fields {
                 check(&field.annotations.constraints);
+                check_entity_refs(&field.ty, &mut check);
             }
         }
 
@@ -156,5 +158,19 @@ impl Validator {
                 failures,
             })
         }
+    }
+}
+
+fn check_entity_refs(ty: &DataType, check: &mut impl FnMut(&[SchemaConstraint])) {
+    match ty {
+        DataType::Option(inner) | DataType::List(inner) => check_entity_refs(inner, check),
+        DataType::EntityRef { data, annotations } => {
+            check(&annotations.constraints);
+            if let Some(inner) = data {
+                check_entity_refs(inner, check);
+            }
+        }
+        // this doesn't need to go into records as this is walked from the top-level
+        _ => {}
     }
 }

--- a/crates/ref-target/Cargo.toml
+++ b/crates/ref-target/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "quent-ref-target"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+quent-schema = { path = "../schema", features = ["serde"] }
+quent-constraints = { path = "../constraints" }
+serde = { workspace = true }
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/ref-target/src/lib.rs
+++ b/crates/ref-target/src/lib.rs
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Constraint for entity reference restricting the type of entity it can point to.
+
+use quent_constraints::Constraint;
+use quent_schema::{Schema, data_type::DataType, entity::Entity, identifier::Identifier};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// The entity type an entity reference is restricted to point at.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefTarget {
+    /// Name of the entity type this reference must point at.
+    pub target: Identifier,
+}
+
+/// Restricts the type of entities
+/// [`quent_schema::data_type::DataType::EntityRef`] can point to.
+///
+/// ## Requirements
+///
+/// 1. The named target is an entity declared in the schema.
+pub struct RefTargetConstraint;
+
+impl Constraint for RefTargetConstraint {
+    const NAME: &'static str = "quent.ref-target.v1";
+
+    fn validate(&self, schema: &Schema) -> Result<(), Box<dyn std::error::Error>> {
+        let mut errors = Vec::new();
+
+        for entity in &schema.entities {
+            for event in &entity.events {
+                for field in &event.payload {
+                    check_targets(
+                        &field.ty,
+                        &|| {
+                            format!(
+                                "entity \"{}\" event \"{}\" field \"{}\"",
+                                entity.name, event.name, field.name
+                            )
+                        },
+                        &schema.entities,
+                        &mut errors,
+                    );
+                }
+            }
+        }
+        for record in &schema.records {
+            for field in &record.fields {
+                check_targets(
+                    &field.ty,
+                    &|| format!("record \"{}\" field \"{}\"", record.name, field.name),
+                    &schema.entities,
+                    &mut errors,
+                );
+            }
+        }
+
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors.pop().unwrap().into()),
+            _ => Err(RefTargetError::Multiple(errors).into()),
+        }
+    }
+}
+
+fn check_targets<F: Fn() -> String>(
+    ty: &DataType,
+    location: &F,
+    entities: &[Entity],
+    errors: &mut Vec<RefTargetError>,
+) {
+    match ty {
+        DataType::Option(inner) | DataType::List(inner) => {
+            check_targets(inner, location, entities, errors);
+        }
+        DataType::EntityRef { data, annotations } => {
+            if let Some(constraint) = annotations
+                .constraints
+                .iter()
+                .find(|c| c.name == RefTargetConstraint::NAME)
+            {
+                match constraint.data.as_deref() {
+                    None => errors.push(RefTargetError::InvalidData {
+                        location: location(),
+                        message: "constraint data is missing".to_string(),
+                    }),
+                    Some(raw) => match serde_json::from_str::<RefTarget>(raw) {
+                        Ok(ref_target) => {
+                            if !entities.iter().any(|e| e.name == ref_target.target) {
+                                errors.push(RefTargetError::UnknownTarget {
+                                    location: location(),
+                                    target: ref_target.target,
+                                });
+                            }
+                        }
+                        Err(e) => errors.push(RefTargetError::InvalidData {
+                            location: location(),
+                            message: format!("failed to decode ref-target: {e}"),
+                        }),
+                    },
+                }
+            }
+            if let Some(inner) = data {
+                check_targets(inner, location, entities, errors);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RefTargetError {
+    #[error("{location}: invalid ref-target data: {message}")]
+    InvalidData { location: String, message: String },
+    #[error("{location}: ref-target points at unknown entity \"{target}\"")]
+    UnknownTarget {
+        location: String,
+        target: Identifier,
+    },
+    #[error("multiple ref-target violations:\n{}", join_errors(.0))]
+    Multiple(Vec<RefTargetError>),
+}
+
+fn join_errors(errors: &[RefTargetError]) -> String {
+    errors
+        .iter()
+        .map(|e| format!("  - {e}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/ref-target/tests/ref-target-constraint.rs
+++ b/crates/ref-target/tests/ref-target-constraint.rs
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use quent_constraints::{Constraint as _, Error as ValidatorError, Validator};
+use quent_ref_target::{RefTarget, RefTargetConstraint, RefTargetError};
+use quent_schema::{
+    Schema,
+    annotations::Annotations,
+    constraint::Constraint,
+    data_type::DataType,
+    entity::Entity,
+    event::{Cardinality, Event, EventField},
+    identifier::Identifier,
+};
+
+fn ident(s: &str) -> Identifier {
+    Identifier::try_new(s).unwrap()
+}
+
+fn target_constraint(target: &str) -> Constraint {
+    Constraint {
+        name: RefTargetConstraint::NAME.to_string(),
+        data: Some(
+            serde_json::to_string(&RefTarget {
+                target: ident(target),
+            })
+            .unwrap(),
+        ),
+    }
+}
+
+fn ref_with(constraint: Constraint) -> DataType {
+    DataType::EntityRef {
+        data: None,
+        annotations: Annotations {
+            constraints: vec![constraint],
+            ..Default::default()
+        },
+    }
+}
+
+fn field(name: &str, ty: DataType) -> EventField {
+    EventField {
+        name: ident(name),
+        ty,
+        annotations: Annotations::default(),
+    }
+}
+
+fn event(name: &str, payload: Vec<EventField>) -> Event {
+    Event {
+        name: ident(name),
+        cardinality: Cardinality::Once,
+        payload,
+        annotations: Annotations::default(),
+    }
+}
+
+fn entity(name: &str, events: Vec<Event>) -> Entity {
+    Entity {
+        name: ident(name),
+        events,
+        annotations: Annotations::default(),
+    }
+}
+
+fn schema_with(entities: Vec<Entity>) -> Schema {
+    Schema {
+        name: ident("S"),
+        entities,
+        records: vec![],
+        annotations: Annotations::default(),
+    }
+}
+
+fn validate(schema: &Schema) -> Vec<RefTargetError> {
+    match Validator::default()
+        .try_with(RefTargetConstraint)
+        .unwrap()
+        .validate(schema)
+    {
+        Ok(()) => Vec::new(),
+        Err(ValidatorError::Invalid { failures, .. }) => {
+            let (_, source) = failures.into_iter().next().unwrap();
+            match *source.downcast::<RefTargetError>().unwrap() {
+                RefTargetError::Multiple(errors) => errors,
+                single => vec![single],
+            }
+        }
+        Err(_) => unreachable!(),
+    }
+}
+
+#[test]
+fn ref_to_existing_entity_passes() {
+    let worker = entity("Worker", vec![]);
+    let task = entity(
+        "Task",
+        vec![event(
+            "created",
+            vec![field("on", ref_with(target_constraint("Worker")))],
+        )],
+    );
+    assert!(validate(&schema_with(vec![worker, task])).is_empty());
+}
+
+#[test]
+fn ref_to_unknown_entity_is_rejected() {
+    let task = entity(
+        "Task",
+        vec![event(
+            "created",
+            vec![field("on", ref_with(target_constraint("ghost")))],
+        )],
+    );
+    let errors = validate(&schema_with(vec![task]));
+    assert!(
+        errors.iter().any(
+            |e| matches!(e, RefTargetError::UnknownTarget { target, .. } if target == "ghost")
+        ),
+    );
+}
+
+#[test]
+fn missing_data_is_rejected() {
+    let bad = ref_with(Constraint {
+        name: RefTargetConstraint::NAME.to_string(),
+        data: None,
+    });
+    let task = entity("Task", vec![event("created", vec![field("on", bad)])]);
+    let errors = validate(&schema_with(vec![task]));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, RefTargetError::InvalidData { .. })),
+    );
+}
+
+#[test]
+fn invalid_json_is_rejected() {
+    let bad = ref_with(Constraint {
+        name: RefTargetConstraint::NAME.to_string(),
+        data: Some("{ trash".to_string()),
+    });
+    let task = entity("Task", vec![event("created", vec![field("on", bad)])]);
+    let errors = validate(&schema_with(vec![task]));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, RefTargetError::InvalidData { .. })),
+    );
+}

--- a/crates/schema/src/data_type.rs
+++ b/crates/schema/src/data_type.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::identifier::Identifier;
+use crate::{annotations::Annotations, identifier::Identifier};
 
 /// Types of data values in [`crate::event::Event`]s and [`crate::record::Record`]s.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DataType {
     Bool,
@@ -31,6 +31,11 @@ pub enum DataType {
     /// A record whose fields are determined by the instrumentation client at
     /// run-time.
     DynamicRecord,
-    /// A reference to an entity optionally carrying data.
-    EntityRef(Option<Box<DataType>>),
+    /// A reference to an entity, optionally carrying data and annotations.
+    EntityRef {
+        /// Optional payload data carried by the reference.
+        data: Option<Box<DataType>>,
+        /// Annotations of this entity reference.
+        annotations: Annotations,
+    },
 }

--- a/crates/schema/src/identifier.rs
+++ b/crates/schema/src/identifier.rs
@@ -74,6 +74,18 @@ impl std::fmt::Display for Identifier {
     }
 }
 
+impl PartialEq<str> for Identifier {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<&str> for Identifier {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == **other
+    }
+}
+
 impl<T> AsRef<T> for Identifier
 where
     T: ?Sized,
@@ -128,6 +140,14 @@ mod tests {
     #[test]
     fn rejects_empty() {
         assert_eq!(Identifier::try_new(""), Err(IdentifierError::Empty));
+    }
+
+    #[test]
+    fn compares_to_str() {
+        let id = Identifier::try_new("foo").unwrap();
+        assert_eq!(id, "foo");
+        assert_ne!(id, "bar");
+        assert!(&id == "foo");
     }
 
     #[test]


### PR DESCRIPTION
Adds `quent-ref-target` crate with the `quent.ref-target.v1` constraint, which restricts an `EntityRef` to a named target entity and validates that the target is a declared entity in the schema.

One part of https://github.com/rapidsai/quent/issues/195