### PR TITLE
feat: add ref-tree constraint crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-ref-tree"
+version = "0.1.0"
+dependencies = [
+ "quent-constraints",
+ "quent-ref-target",
+ "quent-schema",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "quent-schema"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,9 +2209,11 @@ dependencies = [
 name = "quent-ref-tree"
 version = "0.1.0"
 dependencies = [
+ "petgraph",
  "quent-constraints",
  "quent-ref-target",
  "quent-schema",
+ "rustc-hash",
  "serde_json",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "crates/constraints",
     "crates/schema",
     "crates/ref-target",
+    "crates/ref-tree",
     "crates/fsm",
 ]
 

--- a/crates/ref-target/src/lib.rs
+++ b/crates/ref-target/src/lib.rs
@@ -5,7 +5,7 @@
 
 use quent_constraints::{Constraint, utils::bullet_list};
 use quent_schema::{
-    DataType, Identifier,
+    Annotations, DataType, Identifier,
     visitor::{Cursor, Element, Visitor},
 };
 use serde::{Deserialize, Serialize};
@@ -13,9 +13,26 @@ use thiserror::Error;
 
 /// The entity type an entity reference is restricted to point at.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RefTarget {
-    /// Name of the entity type this reference must point at.
-    pub target: Identifier,
+pub struct RefTarget(Identifier);
+
+impl From<RefTarget> for Identifier {
+    fn from(ref_target: RefTarget) -> Self {
+        ref_target.0
+    }
+}
+
+impl AsRef<Identifier> for RefTarget {
+    fn as_ref(&self) -> &Identifier {
+        &self.0
+    }
+}
+
+impl RefTarget {
+    /// Return the reference target entity type declared on `annotations`, if any.
+    pub fn from_annotations(annotations: &Annotations) -> Option<Self> {
+        let raw = annotations.constraint(RefTargetConstraint::NAME)?.data()?;
+        serde_json::from_str(raw).ok()
+    }
 }
 
 /// Restricts the type of entities
@@ -33,30 +50,32 @@ impl Visitor for RefTargetConstraint {
     type Output = Result<(), RefTargetError>;
 
     fn visit(&mut self, cursor: &Cursor) {
-        if let Element::DataType(DataType::EntityRef { annotations, .. }) = cursor.current()
-            && let Some(constraint) = annotations.constraint(RefTargetConstraint::NAME)
-        {
-            let location = cursor.to_string();
-            match constraint.data() {
-                None => self.errors.push(RefTargetError::InvalidData {
-                    location,
-                    message: "constraint data is missing".to_string(),
-                }),
-                Some(raw) => match serde_json::from_str::<RefTarget>(raw) {
-                    Ok(ref_target) => {
-                        if cursor.root().entity(&ref_target.target).is_none() {
-                            self.errors.push(RefTargetError::UnknownTarget {
-                                location,
-                                target: ref_target.target,
-                            });
-                        }
+        let Element::DataType(DataType::EntityRef { annotations, .. }) = cursor.current() else {
+            return;
+        };
+        let Some(constraint) = annotations.constraint(RefTargetConstraint::NAME) else {
+            return;
+        };
+        let location = cursor.to_string();
+        match constraint.data() {
+            None => self.errors.push(RefTargetError::InvalidData {
+                location,
+                message: "constraint data is missing".to_string(),
+            }),
+            Some(raw) => match serde_json::from_str::<RefTarget>(raw) {
+                Ok(ref_target) => {
+                    if cursor.root().entity(ref_target.as_ref()).is_none() {
+                        self.errors.push(RefTargetError::UnknownTarget {
+                            location,
+                            target: ref_target.as_ref().clone(),
+                        });
                     }
-                    Err(e) => self.errors.push(RefTargetError::InvalidData {
-                        location,
-                        message: format!("failed to decode ref-target: {e}"),
-                    }),
-                },
-            }
+                }
+                Err(e) => self.errors.push(RefTargetError::InvalidData {
+                    location,
+                    message: format!("failed to decode ref-target: {e}"),
+                }),
+            },
         }
     }
 

--- a/crates/ref-target/tests/ref-target-constraint.rs
+++ b/crates/ref-target/tests/ref-target-constraint.rs
@@ -2,18 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use quent_constraints::Constraint as _;
-use quent_ref_target::{RefTarget, RefTargetConstraint, RefTargetError};
+use quent_ref_target::{RefTargetConstraint, RefTargetError};
 use quent_schema::{
     DataType, Entity, Schema,
     builder::AnnotationsBuilder,
     test_utils::{entity, event, field, ident, schema},
 };
 
+// RefTarget is a transparent newtype over Identifier, so the wire format is just
+// the bare entity name.
 fn target_data(target: &str) -> String {
-    serde_json::to_string(&RefTarget {
-        target: ident(target),
-    })
-    .unwrap()
+    serde_json::to_string(&ident(target)).unwrap()
 }
 
 fn ref_with(data: Option<String>) -> DataType {

--- a/crates/ref-tree/Cargo.toml
+++ b/crates/ref-tree/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "quent-ref-tree"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+quent-schema = { path = "../schema", features = ["serde"] }
+quent-constraints = { path = "../constraints" }
+quent-ref-target = { path = "../ref-target" }
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/ref-tree/Cargo.toml
+++ b/crates/ref-tree/Cargo.toml
@@ -8,8 +8,10 @@ publish.workspace = true
 quent-schema = { path = "../schema", features = ["serde"] }
 quent-constraints = { path = "../constraints" }
 quent-ref-target = { path = "../ref-target" }
+petgraph = { workspace = true }
 serde_json.workspace = true
 thiserror.workspace = true
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 quent-schema = { path = "../schema", features = ["test-utils"] }

--- a/crates/ref-tree/Cargo.toml
+++ b/crates/ref-tree/Cargo.toml
@@ -10,3 +10,6 @@ quent-constraints = { path = "../constraints" }
 quent-ref-target = { path = "../ref-target" }
 serde_json.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+quent-schema = { path = "../schema", features = ["test-utils"] }

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -60,8 +60,9 @@ use quent_schema::{
 ///    which its events do not carry an entity reference annotated with this
 ///    constraint.
 /// 2. Every non-root entity must have _at least one_ event carrying _at most
-///    one_ entity reference annotated with this constraint. Consequently, a
-///    record carries _at most one_ such reference across its (nested) fields.
+///    one_ entity reference annotated with this constraint, counting references
+///    reached through record-typed fields. Correspondingly, a record carries
+///    _at most one_ such reference across its (nested) fields.
 /// 3. Every entity reference annotated with this constraint must be annotated
 ///    with a reference target constraint (defined by the `quent-ref-target`
 ///    crate).
@@ -101,8 +102,6 @@ pub struct RefTreeConstraint {
     index: FxHashMap<Node, NodeIndex>,
     // Name of every entity, in schema order, to figure out which one is root.
     entities: Vec<Identifier>,
-    // Quick lookup for entity events that have already declared a parent.
-    events_seen: FxHashSet<(Identifier, Identifier)>,
     // Quick lookup for records that have already declared a parent.
     records_seen: FxHashSet<Identifier>,
     // Set once a tree-forming reference declares a parent. The tree shape is
@@ -132,7 +131,8 @@ impl Visitor for RefTreeConstraint {
                     self.node_or_insert(Node::Entity(entity.name().clone()));
                 }
             }
-            // If we encounter an event, add it as a node and connect it to its entity.
+            // If we encounter an event, add it as a node and connect it to its
+            // entity.
             Element::Event(event) => {
                 if let [_, Element::Entity(entity), ..] = cursor.elements() {
                     let from = self.node_or_insert(Node::Entity(entity.name().clone()));
@@ -162,26 +162,22 @@ impl Visitor for RefTreeConstraint {
                     Some(target) => {
                         let target = self.node_or_insert(Node::Entity(target.as_ref().clone()));
 
-                        // Now check whether it is referencing from an event or a record.
+                        // The max per-event tree-forming ref count (req 2) is
+                        // enforced after the walk, since refs reached through
+                        // records are only known then.
                         if let Some((entity, event)) = event_at_cursor(cursor) {
-                            if self.events_seen.insert((entity.clone(), event.clone())) {
-                                let from =
-                                    self.node_or_insert(Node::Event(entity.clone(), event.clone()));
-                                self.graph.add_edge(from, target, ());
-                                self.used = true;
-                            } else {
-                                // A second parent ref in this event, violates req 2.
-                                self.errors.push(RefTreeError::MultiplePerEvent {
-                                    location: cursor.to_string(),
-                                });
-                            }
+                            let from =
+                                self.node_or_insert(Node::Event(entity.clone(), event.clone()));
+                            self.graph.add_edge(from, target, ());
+                            self.used = true;
                         } else if let Some(record) = record_at_cursor(cursor) {
                             if self.records_seen.insert(record.clone()) {
                                 let from = self.node_or_insert(Node::Record(record.clone()));
                                 self.graph.add_edge(from, target, ());
                                 self.used = true;
                             } else {
-                                // A second parent ref in this record, also violates req 2.
+                                // A second parent ref in this record violates
+                                // req 2 already:
                                 self.errors.push(RefTreeError::MultipleRefsInRecord {
                                     location: cursor.to_string(),
                                 });
@@ -191,7 +187,8 @@ impl Visitor for RefTreeConstraint {
                 }
             }
             // If we encounter a datatype with a record, add it to the graph and
-            // connect to either the event or the other record using this record.
+            // connect to either the event or the other record using this
+            // record.
             Element::DataType(DataType::Record(name)) => {
                 if let Some((entity, event)) = event_at_cursor(cursor) {
                     let from = self.node_or_insert(Node::Event(entity.clone(), event.clone()));
@@ -228,6 +225,7 @@ impl Visitor for RefTreeConstraint {
                 )
             })
         {
+            check_events(&graph, &mut errors);
             check_tree(&graph, &index, &entities, &mut errors);
         }
         match errors.len() {
@@ -325,6 +323,48 @@ fn check_tree(
             });
         }
     }
+}
+
+// Report all events that exceed one tree-forming refs in their direct or nested
+// record fields.
+fn check_events(graph: &Graph<Node, ()>, errors: &mut Vec<RefTreeError>) {
+    for node in graph.node_indices() {
+        if let Node::Event(entity, event) = &graph[node]
+            && event_ref_count(graph, node) > 1
+        {
+            errors.push(RefTreeError::MultiplePerEvent {
+                location: format!("{entity}.{event}"),
+            });
+        }
+    }
+}
+
+// Check the graph to discover the number of tree-forming refs an event carries,
+// including in its nested records.
+fn event_ref_count(graph: &Graph<Node, ()>, event: NodeIndex) -> usize {
+    let mut count = 0;
+    let mut seen_records: FxHashSet<NodeIndex> = FxHashSet::default();
+    let mut records: Vec<NodeIndex> = Vec::new();
+    for neighbor in graph.neighbors(event) {
+        match &graph[neighbor] {
+            Node::Entity(_) => count += 1,
+            Node::Record(_) => records.push(neighbor),
+            Node::Event(..) => {}
+        }
+    }
+    while let Some(record) = records.pop() {
+        if !seen_records.insert(record) {
+            continue;
+        }
+        for neighbor in graph.neighbors(record) {
+            match &graph[neighbor] {
+                Node::Entity(_) => count += 1,
+                Node::Record(_) => records.push(neighbor),
+                Node::Event(..) => {}
+            }
+        }
+    }
+    count
 }
 
 // List all unique parent entities reachable from the supplied entity

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -5,10 +5,11 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use quent_constraints::Constraint;
+use quent_constraints::{Constraint, utils::join_errors};
 use quent_ref_target::{RefTarget, RefTargetConstraint};
 use quent_schema::{
-    Schema, annotations::Annotations, data_type::DataType, identifier::Identifier, record::Record,
+    Annotations, DataType, Entity, Identifier, Record,
+    visitor::{Cursor, Element, Visitor},
 };
 use thiserror::Error;
 
@@ -83,20 +84,39 @@ use thiserror::Error;
 /// _could_ error on emitting a second parent-declaring event if it changes the
 /// reference value. An analysis library _could_ produce an error when an event
 /// stream is ingested exhibiting this ambiguity.
-pub struct RefTreeConstraint;
+#[derive(Default)]
+pub struct RefTreeConstraint {
+    entities: Vec<Entity>,
+    records: Vec<Record>,
+}
+
+impl Visitor for RefTreeConstraint {
+    type Output = Result<(), RefTreeError>;
+
+    fn visit(&mut self, cursor: &Cursor) {
+        // The tree is a global property of the schema, and the walk treats a
+        // record reference as a leaf. Harvest the entities and records and form
+        // the tree in `finish`, descending records there.
+        match cursor.current() {
+            Element::Entity(entity) => self.entities.push(entity.clone()),
+            Element::Record(record) => self.records.push(record.clone()),
+            _ => {}
+        }
+    }
+
+    fn finish(self) -> Self::Output {
+        let mut errors = Vec::new();
+        check_tree(&self.entities, &self.records, &mut errors);
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors.pop().unwrap()),
+            _ => Err(RefTreeError::Multiple(errors)),
+        }
+    }
+}
 
 impl Constraint for RefTreeConstraint {
     const NAME: &'static str = "quent.ref-tree.v1";
-
-    fn validate(&self, schema: &Schema) -> Result<(), Box<dyn std::error::Error>> {
-        let mut errors = Vec::new();
-        check_tree(schema, &mut errors);
-        match errors.len() {
-            0 => Ok(()),
-            1 => Err(errors.pop().unwrap().into()),
-            _ => Err(RefTreeError::Multiple(errors).into()),
-        }
-    }
 }
 
 /// A tree-forming reference gathered from an entity's events.
@@ -109,7 +129,7 @@ enum TreeRef {
     TypeErased { location: String },
 }
 
-/// Index into [`Schema::entities`]; never interchanged with a name or a count.
+/// Index into the harvested entities; never interchanged with a name or a count.
 #[derive(Clone, Copy)]
 struct EntityIdx(usize);
 
@@ -120,28 +140,28 @@ struct NonRoot {
     parent: EntityIdx,
 }
 
-fn check_tree(schema: &Schema, errors: &mut Vec<RefTreeError>) {
-    let n = schema.entities.len();
+fn check_tree(entities: &[Entity], records: &[Record], errors: &mut Vec<RefTreeError>) {
+    let n = entities.len();
 
     // Gather, per entity, the tree-forming references its events declare,
     // descending through Option/List, reference payloads and record fields. At
     // most one is allowed per event (req. 2's parenthetical).
     let mut refs_by_entity: Vec<Vec<TreeRef>> = (0..n).map(|_| Vec::new()).collect();
-    for (i, entity) in schema.entities.iter().enumerate() {
-        for event in &entity.events {
+    for (i, entity) in entities.iter().enumerate() {
+        for event in entity.events() {
             let mut in_event = Vec::new();
-            for field in &event.payload {
+            for field in event.fields() {
                 let loc = Loc::Field {
-                    entity: &entity.name,
-                    event: &event.name,
-                    field: &field.name,
+                    entity: entity.name(),
+                    event: event.name(),
+                    field: field.name(),
                 };
-                collect_refs(&field.ty, &loc, &schema.records, &mut in_event);
+                collect_refs(field.ty(), &loc, records, &mut in_event);
             }
             if in_event.len() > 1 {
                 errors.push(RefTreeError::MultiplePerEvent {
-                    entity: entity.name.clone(),
-                    event: event.name.clone(),
+                    entity: entity.name().clone(),
+                    event: event.name().clone(),
                     count: in_event.len(),
                 });
             }
@@ -181,7 +201,7 @@ fn check_tree(schema: &Schema, errors: &mut Vec<RefTreeError>) {
         _ => {
             let mut names: Vec<Identifier> = roots
                 .iter()
-                .map(|idx| schema.entities[idx.0].name.clone())
+                .map(|idx| entities[idx.0].name().clone())
                 .collect();
             names.sort();
             errors.push(RefTreeError::MultipleRoots { roots: names });
@@ -189,11 +209,10 @@ fn check_tree(schema: &Schema, errors: &mut Vec<RefTreeError>) {
         }
     };
 
-    let index: HashMap<&Identifier, EntityIdx> = schema
-        .entities
+    let index: HashMap<&Identifier, EntityIdx> = entities
         .iter()
         .enumerate()
-        .map(|(i, e)| (&e.name, EntityIdx(i)))
+        .map(|(i, e)| (e.name(), EntityIdx(i)))
         .collect();
 
     // Req. 2: each non-root must declare exactly one parent type. A non-root
@@ -221,11 +240,11 @@ fn check_tree(schema: &Schema, errors: &mut Vec<RefTreeError>) {
                     parent,
                 }),
                 None => errors.push(RefTreeError::Unreachable {
-                    entity: schema.entities[i].name.clone(),
+                    entity: entities[i].name().clone(),
                 }),
             },
             _ => errors.push(RefTreeError::ConflictingParents {
-                entity: schema.entities[i].name.clone(),
+                entity: entities[i].name().clone(),
                 parents: parents.into_iter().cloned().collect(),
             }),
         }
@@ -251,7 +270,7 @@ fn check_tree(schema: &Schema, errors: &mut Vec<RefTreeError>) {
     for node in &graph {
         if !visited[node.entity.0] {
             errors.push(RefTreeError::Unreachable {
-                entity: schema.entities[node.entity.0].name.clone(),
+                entity: entities[node.entity.0].name().clone(),
             });
         }
     }
@@ -287,19 +306,32 @@ fn collect_refs<'a>(
             if loc.descends_record(name) {
                 return;
             }
-            if let Some(record) = records.iter().find(|r| &r.name == name) {
-                for field in &record.fields {
+            if let Some(record) = records.iter().find(|r| r.name() == name) {
+                for field in record.fields() {
                     let nested = Loc::Nested {
                         outer: loc,
                         record: name,
-                        field: &field.name,
+                        field: field.name(),
                     };
-                    collect_refs(&field.ty, &nested, records, out);
+                    collect_refs(field.ty(), &nested, records, out);
                 }
             }
         }
         _ => {}
     }
+}
+
+/// The target entity type of a co-located `quent.ref-target.v1`, if present and
+/// decodable.
+fn tree_ref_target(annotations: &Annotations) -> Option<Identifier> {
+    let raw = annotations.constraint(RefTargetConstraint::NAME)?.data()?;
+    serde_json::from_str::<RefTarget>(raw)
+        .ok()
+        .map(|rt| rt.target)
+}
+
+fn has_tree(annotations: &Annotations) -> bool {
+    annotations.constraint(RefTreeConstraint::NAME).is_some()
 }
 
 /// Borrowed path to a tree-forming reference, rendered to a string only when a
@@ -345,26 +377,6 @@ impl Loc<'_> {
     }
 }
 
-/// The target entity type of a co-located `quent.ref-target.v1`, if present and
-/// decodable.
-fn tree_ref_target(annotations: &Annotations) -> Option<Identifier> {
-    let constraint = annotations
-        .constraints
-        .iter()
-        .find(|c| c.name == RefTargetConstraint::NAME)?;
-    let raw = constraint.data.as_deref()?;
-    serde_json::from_str::<RefTarget>(raw)
-        .ok()
-        .map(|rt| rt.target)
-}
-
-fn has_tree(annotations: &Annotations) -> bool {
-    annotations
-        .constraints
-        .iter()
-        .any(|c| c.name == RefTreeConstraint::NAME)
-}
-
 #[derive(Debug, Error)]
 pub enum RefTreeError {
     #[error(
@@ -401,12 +413,4 @@ fn join_idents(ids: &[Identifier]) -> String {
         .map(|i| format!("\"{i}\""))
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-fn join_errors(errors: &[RefTreeError]) -> String {
-    errors
-        .iter()
-        .map(|e| format!("  - {e}"))
-        .collect::<Vec<_>>()
-        .join("\n")
 }

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Constraint marking an entity reference as tree-forming.
+
+/// Constraint to express a tree connecting all entities within a graph where
+/// vertice represent entities and entity references representing edges.
+///
+/// This constraint can be used for arbitrary purposes. Its canonical purpose
+/// is to provide some "preferred" way of traversing entities and their events
+/// from a single starting point (the root entity), e.g. such that some user
+/// interface can help a human traverse the trace in this preferred way.
+///
+/// References annotated with this constraint are typically used (but not
+/// limited) to express:
+/// - Causal relations (e.g. entity Y was produced by entity X)
+/// - Scopes (e.g. entity Y is part of X)
+/// - Ownership relations (e.g. entity Y is owned by entity X)
+///
+/// In order for instrumentation libraries to provide strong guarantees
+/// (typically compile-time) that this constraint is met, the tree must be fully
+/// defined at "schema-time". Therefore, type-erased entity references cannot
+/// carry an annotation with this constraint, as this would allow forming entity
+/// graphs that are not trees (i.e. multiple instances of an entity of type A
+/// would be able to emit events that refer to both an entity of type B and of
+/// type C). For this reason, this constraint depends on the constraint provided
+/// by the [`quent_ref_target`] crate.
+///
+/// ## Requirements
+///
+/// 1. The schema has exactly one entity (a.k.a. the root entity) that does not
+///    carry an entity reference annotated with this constraint in any of its
+///    events.
+/// 2. Every non-root entity has at least one event carrying an entity
+///    reference annotated with this constraint to declare it refers to exactly
+///    one type of parent entity in the tree (a.k.a. a parent entity reference).
+/// 3. Every parent entity reference must be target-constrained (carry a
+///    [`quent_ref_target`] annotation). A type-erased reference may not carry
+///    this constraint (implied by requirement 2).
+/// 4. There is exactly one path from every non-root entity type to the root
+///    entity type through parent entity references.
+///
+/// ## Note on possible parent ambiguity (req. 2)
+///
+/// Parent ambiguity at run-time can exist through multiple parent-declaring
+/// events, which is allowed by requirement 2.
+///
+/// Since client code can have branching behavior where certain events are
+/// conditionally emitted, this constraint permits the parent reference to be
+/// placed (once) on any number of events, even though logically speaking, it
+/// can only have one parent, and it would ideally emit its parent reference
+/// exactly once. It is the responsibility of the client code to ensure it
+/// produces an unambiguous event stream with regards to this tree-forming
+/// constraint.
+///
+/// This constraint intentionally defers any potential resolution to the problem
+/// of clients producing ambiguous event streams to schema producer / consumer
+/// implementations.
+///
+/// For example, a modeling API or DSL _could_ decide to enforce FSM entities to
+/// always declare their parent in the initial state. An instrumentation library
+/// _could_ error on emitting a second parent-declaring event if it changes the
+/// reference value. An analysis library _could_ produce an error when an event
+/// stream is ingested exhibiting this ambiguity.
+pub struct RefTreeConstraint;

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -12,18 +12,31 @@ use quent_schema::{
 };
 use thiserror::Error;
 
-/// Constraint to express a tree connecting all entities within a graph where
-/// vertices represent entities and edges represent entity references.
+/// Constrains the graph of entities (as vertices) and entity references (as
+/// edges) to contain a subgraph that is a tree connecting all entities.
 ///
 /// This constraint can be used for arbitrary purposes. Its canonical purpose
 /// is to provide some "preferred" way of traversing entities and their events
-/// from a single starting point (the root entity), e.g. such that some user
-/// interface can help a human traverse the trace in this preferred way.
+/// from a single starting point (the root entity).
 ///
 /// References annotated with this constraint are typically used (but not
 /// limited) to express:
-/// - Causal relations (e.g. entity Y was produced by entity X)
-/// - Hierarchical relations (e.g. entity Y is part of / owned by / scoped by X)
+///
+/// - **Hierarchical relations**, for example: "entity X ... entity Y"
+///     - is part of
+///     - is owned by
+///     - is scoped by
+///     - is parented by
+///     - sits under
+/// - **Causal relations**, for example: "entity X ...entity Y"
+///     - is spawned by
+///     - is produced by
+///     - exists because of
+///
+/// These types of references are typically not used to express:
+/// - **Structural references** at the same hierarchical level, for example:
+///   entity X is attached to Y (often causes loops)
+/// - Dataflow directionality (E.g. entity X is moved into Y)
 ///
 /// In order for instrumentation libraries to provide strong guarantees
 /// (typically compile-time) that this constraint is met, the tree must be fully
@@ -39,7 +52,7 @@ use thiserror::Error;
 /// 1. The schema has exactly one entity (a.k.a. the root entity) that does not
 ///    carry an entity reference annotated with this constraint in any of its
 ///    events.
-/// 2. Every non-root entity has at least one event carrying an entity
+/// 2. Every non-root entity has _at least one event_ carrying an entity
 ///    reference annotated with this constraint to declare it refers to exactly
 ///    one type of parent entity in the tree (a.k.a. a parent entity reference).
 /// 3. Every parent entity reference must be target-constrained (carry a
@@ -61,8 +74,8 @@ use thiserror::Error;
 /// produces an unambiguous event stream with regards to this tree-forming
 /// constraint.
 ///
-/// This constraint intentionally defers any potential resolution to the problem
-/// of clients producing ambiguous event streams to schema producer / consumer
+/// This constraint intentionally defers any potential solution for clients
+/// producing ambiguous event streams to schema producer / consumer
 /// implementations.
 ///
 /// For example, a modeling API or DSL _could_ decide to enforce FSM entities to

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -3,8 +3,17 @@
 
 //! Constraint marking an entity reference as tree-forming.
 
+use std::collections::{HashMap, VecDeque};
+
+use quent_constraints::Constraint;
+use quent_ref_target::{RefTarget, RefTargetConstraint};
+use quent_schema::{
+    Schema, annotations::Annotations, data_type::DataType, identifier::Identifier, record::Record,
+};
+use thiserror::Error;
+
 /// Constraint to express a tree connecting all entities within a graph where
-/// vertice represent entities and entity references representing edges.
+/// vertices represent entities and edges represent entity references.
 ///
 /// This constraint can be used for arbitrary purposes. Its canonical purpose
 /// is to provide some "preferred" way of traversing entities and their events
@@ -14,8 +23,7 @@
 /// References annotated with this constraint are typically used (but not
 /// limited) to express:
 /// - Causal relations (e.g. entity Y was produced by entity X)
-/// - Scopes (e.g. entity Y is part of X)
-/// - Ownership relations (e.g. entity Y is owned by entity X)
+/// - Hierarchical relations (e.g. entity Y is part of / owned by / scoped by X)
 ///
 /// In order for instrumentation libraries to provide strong guarantees
 /// (typically compile-time) that this constraint is met, the tree must be fully
@@ -63,3 +71,329 @@
 /// reference value. An analysis library _could_ produce an error when an event
 /// stream is ingested exhibiting this ambiguity.
 pub struct RefTreeConstraint;
+
+impl Constraint for RefTreeConstraint {
+    const NAME: &'static str = "quent.ref-tree.v1";
+
+    fn validate(&self, schema: &Schema) -> Result<(), Box<dyn std::error::Error>> {
+        let mut errors = Vec::new();
+        check_tree(schema, &mut errors);
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors.pop().unwrap().into()),
+            _ => Err(RefTreeError::Multiple(errors).into()),
+        }
+    }
+}
+
+/// A tree-forming reference gathered from an entity's events.
+enum TreeRef {
+    /// Target-constrained: the parent type from the co-located
+    /// `quent.ref-target.v1`.
+    Targeted { target: Identifier },
+    /// Type-erased: no decodable target (a req. 3 violation). The location is
+    /// rendered here because this is the only path that consumes it.
+    TypeErased { location: String },
+}
+
+/// Index into [`Schema::entities`]; never interchanged with a name or a count.
+#[derive(Clone, Copy)]
+struct EntityIdx(usize);
+
+/// A non-root entity paired with the single parent entity its references
+/// resolve to. There is no representable non-root without a parent edge.
+struct NonRoot {
+    entity: EntityIdx,
+    parent: EntityIdx,
+}
+
+fn check_tree(schema: &Schema, errors: &mut Vec<RefTreeError>) {
+    let n = schema.entities.len();
+
+    // Gather, per entity, the tree-forming references its events declare,
+    // descending through Option/List, reference payloads and record fields. At
+    // most one is allowed per event (req. 2's parenthetical).
+    let mut refs_by_entity: Vec<Vec<TreeRef>> = (0..n).map(|_| Vec::new()).collect();
+    for (i, entity) in schema.entities.iter().enumerate() {
+        for event in &entity.events {
+            let mut in_event = Vec::new();
+            for field in &event.payload {
+                let loc = Loc::Field {
+                    entity: &entity.name,
+                    event: &event.name,
+                    field: &field.name,
+                };
+                collect_refs(&field.ty, &loc, &schema.records, &mut in_event);
+            }
+            if in_event.len() > 1 {
+                errors.push(RefTreeError::MultiplePerEvent {
+                    entity: entity.name.clone(),
+                    event: event.name.clone(),
+                    count: in_event.len(),
+                });
+            }
+            refs_by_entity[i].append(&mut in_event);
+        }
+    }
+
+    // The constraint only forms a tree when at least one reference uses it.
+    if refs_by_entity.iter().all(|r| r.is_empty()) {
+        return;
+    }
+
+    // Req. 3: every parent reference must be target-constrained.
+    for refs in &refs_by_entity {
+        for r in refs {
+            if let TreeRef::TypeErased { location } = r {
+                errors.push(RefTreeError::NotTargetConstrained {
+                    location: location.clone(),
+                });
+            }
+        }
+    }
+
+    // Req. 1: exactly one root (an entity carrying no tree-forming reference).
+    let roots: Vec<EntityIdx> = refs_by_entity
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.is_empty())
+        .map(|(i, _)| EntityIdx(i))
+        .collect();
+    let root = match roots.as_slice() {
+        [] => {
+            errors.push(RefTreeError::NoRoot);
+            return;
+        }
+        [root] => *root,
+        _ => {
+            let mut names: Vec<Identifier> = roots
+                .iter()
+                .map(|idx| schema.entities[idx.0].name.clone())
+                .collect();
+            names.sort();
+            errors.push(RefTreeError::MultipleRoots { roots: names });
+            return;
+        }
+    };
+
+    let index: HashMap<&Identifier, EntityIdx> = schema
+        .entities
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (&e.name, EntityIdx(i)))
+        .collect();
+
+    // Req. 2: each non-root must declare exactly one parent type. A non-root
+    // carrying a type-erased reference is already reported (req. 3) and dropped.
+    // A resolved non-root carries its parent edge by construction; a target
+    // naming no entity has no path to the root (req. 4), reported directly.
+    let mut graph: Vec<NonRoot> = Vec::new();
+    for (i, refs) in refs_by_entity.iter().enumerate() {
+        if refs.is_empty() || refs.iter().any(|r| matches!(r, TreeRef::TypeErased { .. })) {
+            continue;
+        }
+        let mut parents: Vec<&Identifier> = refs
+            .iter()
+            .filter_map(|r| match r {
+                TreeRef::Targeted { target } => Some(target),
+                TreeRef::TypeErased { .. } => None,
+            })
+            .collect();
+        parents.sort();
+        parents.dedup();
+        match parents.as_slice() {
+            [parent] => match index.get(*parent) {
+                Some(&parent) => graph.push(NonRoot {
+                    entity: EntityIdx(i),
+                    parent,
+                }),
+                None => errors.push(RefTreeError::Unreachable {
+                    entity: schema.entities[i].name.clone(),
+                }),
+            },
+            _ => errors.push(RefTreeError::ConflictingParents {
+                entity: schema.entities[i].name.clone(),
+                parents: parents.into_iter().cloned().collect(),
+            }),
+        }
+    }
+
+    // Req. 4: a walk from the unique root over parent -> child edges reaches
+    // every non-root on a path to it. Any left unvisited sits on a cycle.
+    let mut children: Vec<Vec<EntityIdx>> = (0..n).map(|_| Vec::new()).collect();
+    for node in &graph {
+        children[node.parent.0].push(node.entity);
+    }
+    let mut visited = vec![false; n];
+    visited[root.0] = true;
+    let mut queue = VecDeque::from([root]);
+    while let Some(parent) = queue.pop_front() {
+        for &child in &children[parent.0] {
+            if !visited[child.0] {
+                visited[child.0] = true;
+                queue.push_back(child);
+            }
+        }
+    }
+    for node in &graph {
+        if !visited[node.entity.0] {
+            errors.push(RefTreeError::Unreachable {
+                entity: schema.entities[node.entity.0].name.clone(),
+            });
+        }
+    }
+}
+
+/// Gather every tree-forming reference reachable in `ty`, classifying each as
+/// targeted or type-erased. Descends `Option`/`List`, reference payloads and —
+/// resolving names against `records` — record fields. `loc` tracks the path so
+/// a violation can name its site without allocating on the valid path.
+fn collect_refs<'a>(
+    ty: &'a DataType,
+    loc: &'a Loc<'a>,
+    records: &'a [Record],
+    out: &mut Vec<TreeRef>,
+) {
+    match ty {
+        DataType::Option(inner) | DataType::List(inner) => collect_refs(inner, loc, records, out),
+        DataType::EntityRef { data, annotations } => {
+            if has_tree(annotations) {
+                out.push(match tree_ref_target(annotations) {
+                    Some(target) => TreeRef::Targeted { target },
+                    None => TreeRef::TypeErased {
+                        location: loc.render(),
+                    },
+                });
+            }
+            if let Some(inner) = data {
+                collect_refs(inner, loc, records, out);
+            }
+        }
+        DataType::Record(name) => {
+            // Guard against record definitions that nest cyclically.
+            if loc.descends_record(name) {
+                return;
+            }
+            if let Some(record) = records.iter().find(|r| &r.name == name) {
+                for field in &record.fields {
+                    let nested = Loc::Nested {
+                        outer: loc,
+                        record: name,
+                        field: &field.name,
+                    };
+                    collect_refs(&field.ty, &nested, records, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Borrowed path to a tree-forming reference, rendered to a string only when a
+/// violation is reported.
+enum Loc<'a> {
+    Field {
+        entity: &'a Identifier,
+        event: &'a Identifier,
+        field: &'a Identifier,
+    },
+    Nested {
+        outer: &'a Loc<'a>,
+        record: &'a Identifier,
+        field: &'a Identifier,
+    },
+}
+
+impl Loc<'_> {
+    fn render(&self) -> String {
+        match self {
+            Loc::Field {
+                entity,
+                event,
+                field,
+            } => format!("entity \"{entity}\" event \"{event}\" field \"{field}\""),
+            Loc::Nested {
+                outer,
+                record,
+                field,
+            } => format!(
+                "{} -> record \"{record}\" field \"{field}\"",
+                outer.render()
+            ),
+        }
+    }
+
+    /// Whether the path already descends through record `name` (a nesting cycle).
+    fn descends_record(&self, name: &Identifier) -> bool {
+        match self {
+            Loc::Field { .. } => false,
+            Loc::Nested { outer, record, .. } => *record == name || outer.descends_record(name),
+        }
+    }
+}
+
+/// The target entity type of a co-located `quent.ref-target.v1`, if present and
+/// decodable.
+fn tree_ref_target(annotations: &Annotations) -> Option<Identifier> {
+    let constraint = annotations
+        .constraints
+        .iter()
+        .find(|c| c.name == RefTargetConstraint::NAME)?;
+    let raw = constraint.data.as_deref()?;
+    serde_json::from_str::<RefTarget>(raw)
+        .ok()
+        .map(|rt| rt.target)
+}
+
+fn has_tree(annotations: &Annotations) -> bool {
+    annotations
+        .constraints
+        .iter()
+        .any(|c| c.name == RefTreeConstraint::NAME)
+}
+
+#[derive(Debug, Error)]
+pub enum RefTreeError {
+    #[error(
+        "{location}: a tree-forming reference must be target-constrained (carry a quent.ref-target.v1 annotation)"
+    )]
+    NotTargetConstrained { location: String },
+    #[error(
+        "entity \"{entity}\" event \"{event}\": {count} tree-forming references, at most one is allowed"
+    )]
+    MultiplePerEvent {
+        entity: Identifier,
+        event: Identifier,
+        count: usize,
+    },
+    #[error(
+        "tree-forming references are used but no entity is a root (every entity has a parent); a tree needs exactly one root"
+    )]
+    NoRoot,
+    #[error("more than one root entity (no tree-forming reference): {}", join_idents(.roots))]
+    MultipleRoots { roots: Vec<Identifier> },
+    #[error("entity \"{entity}\" declares more than one parent type: {}", join_idents(.parents))]
+    ConflictingParents {
+        entity: Identifier,
+        parents: Vec<Identifier>,
+    },
+    #[error("entity \"{entity}\" has no path to the root through tree-forming references")]
+    Unreachable { entity: Identifier },
+    #[error("multiple ref-tree violations:\n{}", join_errors(.0))]
+    Multiple(Vec<RefTreeError>),
+}
+
+fn join_idents(ids: &[Identifier]) -> String {
+    ids.iter()
+        .map(|i| format!("\"{i}\""))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn join_errors(errors: &[RefTreeError]) -> String {
+    errors
+        .iter()
+        .map(|e| format!("  - {e}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 /// is to provide some "preferred" way of traversing entities and their events
 /// from a single starting point (the root entity).
 ///
-/// References annotated with this constraint are typically used (but not
+/// References annotated with this constraint are _typically_ used (but not
 /// limited) to express:
 ///
 /// - **Hierarchical relations**, for example: "entity X ... entity Y"
@@ -34,10 +34,10 @@ use thiserror::Error;
 ///     - is produced by
 ///     - exists because of
 ///
-/// These types of references are typically not used to express:
+/// These types of references are _typically_ not used to express:
 /// - **Structural references** at the same hierarchical level, for example:
 ///   entity X is attached to Y (often causes loops)
-/// - Dataflow directionality (E.g. entity X is moved into Y)
+/// - **Flow directionality**, for example: entity X is moved to Y
 ///
 /// In order for instrumentation libraries to provide strong guarantees
 /// (typically compile-time) that this constraint is met, the tree must be fully
@@ -45,22 +45,25 @@ use thiserror::Error;
 /// carry an annotation with this constraint, as this would allow forming entity
 /// graphs that are not trees (i.e. multiple instances of an entity of type A
 /// would be able to emit events that refer to both an entity of type B and of
-/// type C). For this reason, this constraint depends on the constraint provided
-/// by the [`quent_ref_target`] crate.
+/// type C as its parent). For this reason, this constraint depends on the
+/// constraint provided by the [`quent_ref_target`] crate.
 ///
 /// ## Requirements
 ///
-/// 1. The schema has exactly one entity (a.k.a. the root entity) that does not
-///    carry an entity reference annotated with this constraint in any of its
-///    events.
-/// 2. Every non-root entity has _at least one event_ carrying an entity
-///    reference annotated with this constraint to declare it refers to exactly
-///    one type of parent entity in the tree (a.k.a. a parent entity reference).
-/// 3. Every parent entity reference must be target-constrained (carry a
-///    [`quent_ref_target`] annotation). A type-erased reference may not carry
-///    this constraint (implied by requirement 2).
-/// 4. There is exactly one path from every non-root entity type to the root
-///    entity type through parent entity references.
+/// 1. The schema must have exactly one entity (a.k.a. the root entity) of
+///    which its events do not carry an entity reference annotated with this
+///    constraint.
+/// 2. Every non-root entity must have _at least one_ event carrying _at most
+///    one_ entity reference annotated with this constraint. Consequently, a
+///    record carries _at most one_ such reference across its (nested) fields.
+/// 3. Every entity reference annotated with this constraint must be annotated
+///    with a reference target constraint (defined by the `quent-ref-target`
+///    crate).
+/// 4. All events of one entity carrying an entity reference with this
+///    constraint (req 2) target (req 3) to _exactly one_ type of parent
+///    entity.
+/// 5. From every non-root entity, entity references with this constraint can be
+///    followed such that the root is reached.
 ///
 /// ## Note on possible parent ambiguity (req. 2)
 ///
@@ -82,7 +85,7 @@ use thiserror::Error;
 /// For example, a modeling API or DSL _could_ decide to enforce FSM entities to
 /// always declare their parent in the initial state. An instrumentation library
 /// _could_ error on emitting a second parent-declaring event if it changes the
-/// reference value. An analysis library _could_ produce an error when an event
+/// referenced parent. An analysis library _could_ produce an error when an event
 /// stream is ingested exhibiting this ambiguity.
 #[derive(Default)]
 pub struct RefTreeConstraint {

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -3,15 +3,24 @@
 
 //! Constraint marking an entity reference as tree-forming.
 
-use std::collections::{HashMap, VecDeque};
+use petgraph::{
+    Graph,
+    graph::NodeIndex,
+    graphmap::DiGraphMap,
+    visit::{Bfs, Walker},
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+use thiserror::Error;
 
-use quent_constraints::{Constraint, utils::join_errors};
-use quent_ref_target::{RefTarget, RefTargetConstraint};
+use quent_constraints::{
+    Constraint,
+    utils::{join_errors, join_idents},
+};
+use quent_ref_target::RefTarget;
 use quent_schema::{
-    Annotations, DataType, Entity, Identifier, Record,
+    DataType, Identifier,
     visitor::{Cursor, Element, Visitor},
 };
-use thiserror::Error;
 
 /// Constrains the graph of entities (as vertices) and entity references (as
 /// edges) to contain a subgraph that is a tree connecting all entities.
@@ -89,27 +98,141 @@ use thiserror::Error;
 /// stream is ingested exhibiting this ambiguity.
 #[derive(Default)]
 pub struct RefTreeConstraint {
-    entities: Vec<Entity>,
-    records: Vec<Record>,
+    // Graph of entities, events with entity refs, and records with entity refs.
+    graph: Graph<Node, ()>,
+    // Map of a node to its petgraph index.
+    index: FxHashMap<Node, NodeIndex>,
+    // Name of every entity, in schema order, to figure out which one is root.
+    entities: Vec<Identifier>,
+    // Quick lookup for entity events that have already declared a parent.
+    events_seen: FxHashSet<(Identifier, Identifier)>,
+    // Quick lookup for records that have already declared a parent.
+    records_seen: FxHashSet<Identifier>,
+    // Set once a tree-forming reference declares a parent. The tree shape is
+    // only validated when at least one reference uses the constraint.
+    used: bool,
+    // Errors gathered during the walk.
+    errors: Vec<RefTreeError>,
+}
+
+/// A vertex in the entity/event/record graph.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum Node {
+    Entity(Identifier),
+    Event(Identifier, Identifier),
+    Record(Identifier),
 }
 
 impl Visitor for RefTreeConstraint {
     type Output = Result<(), RefTreeError>;
 
     fn visit(&mut self, cursor: &Cursor) {
-        // The tree is a global property of the schema, and the walk treats a
-        // record reference as a leaf. Harvest the entities and records and form
-        // the tree in `finish`, descending records there.
         match cursor.current() {
-            Element::Entity(entity) => self.entities.push(entity.clone()),
-            Element::Record(record) => self.records.push(record.clone()),
+            // Add every entity as a node.
+            Element::Schema(schema) => {
+                for entity in schema.entities() {
+                    self.entities.push(entity.name().clone());
+                    self.node_or_insert(Node::Entity(entity.name().clone()));
+                }
+            }
+            // If we encounter an event, add it as a node and connect it to its entity.
+            Element::Event(event) => {
+                if let [_, Element::Entity(entity), ..] = cursor.elements() {
+                    let from = self.node_or_insert(Node::Entity(entity.name().clone()));
+                    let to = self
+                        .node_or_insert(Node::Event(entity.name().clone(), event.name().clone()));
+                    self.graph.add_edge(from, to, ());
+                }
+            }
+            // If we encounter an entity ref with this constraint, first ensure
+            // it has a constrained target entity.
+            Element::DataType(DataType::EntityRef { annotations, .. })
+                if annotations.has_constraint(RefTreeConstraint::NAME) =>
+            {
+                match RefTarget::from_annotations(annotations) {
+                    // Req 3 is not met:
+                    None => self.errors.push(RefTreeError::NotTargetConstrained {
+                        location: cursor.to_string(),
+                    }),
+                    // The reference must target a declared entity, else the
+                    // constraint data is ill-formed
+                    Some(target) if cursor.root().entity(target.as_ref()).is_none() => {
+                        self.errors.push(RefTreeError::UnknownTarget {
+                            location: cursor.to_string(),
+                            target: target.as_ref().clone(),
+                        });
+                    }
+                    Some(target) => {
+                        let target = self.node_or_insert(Node::Entity(target.as_ref().clone()));
+
+                        // Now check whether it is referencing from an event or a record.
+                        if let Some((entity, event)) = event_at_cursor(cursor) {
+                            if self.events_seen.insert((entity.clone(), event.clone())) {
+                                let from =
+                                    self.node_or_insert(Node::Event(entity.clone(), event.clone()));
+                                self.graph.add_edge(from, target, ());
+                                self.used = true;
+                            } else {
+                                // A second parent ref in this event, violates req 2.
+                                self.errors.push(RefTreeError::MultiplePerEvent {
+                                    location: cursor.to_string(),
+                                });
+                            }
+                        } else if let Some(record) = record_at_cursor(cursor) {
+                            if self.records_seen.insert(record.clone()) {
+                                let from = self.node_or_insert(Node::Record(record.clone()));
+                                self.graph.add_edge(from, target, ());
+                                self.used = true;
+                            } else {
+                                // A second parent ref in this record, also violates req 2.
+                                self.errors.push(RefTreeError::MultipleRefsInRecord {
+                                    location: cursor.to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            // If we encounter a datatype with a record, add it to the graph and
+            // connect to either the event or the other record using this record.
+            Element::DataType(DataType::Record(name)) => {
+                if let Some((entity, event)) = event_at_cursor(cursor) {
+                    let from = self.node_or_insert(Node::Event(entity.clone(), event.clone()));
+                    let to = self.node_or_insert(Node::Record(name.clone()));
+                    self.graph.add_edge(from, to, ());
+                } else if let Some(record) = record_at_cursor(cursor) {
+                    let from = self.node_or_insert(Node::Record(record.clone()));
+                    let to = self.node_or_insert(Node::Record(name.clone()));
+                    self.graph.add_edge(from, to, ());
+                }
+            }
             _ => {}
         }
     }
 
     fn finish(self) -> Self::Output {
-        let mut errors = Vec::new();
-        check_tree(&self.entities, &self.records, &mut errors);
+        let RefTreeConstraint {
+            graph,
+            index,
+            entities,
+            used,
+            mut errors,
+            ..
+        } = self;
+        // The tree is only validated when at least one reference uses the
+        // constraint. Type-erased references and references to unknown entities
+        // are reported during the walk and make the tree undefined, so exit
+        // early if this happened.
+        if used
+            && !errors.iter().any(|e| {
+                matches!(
+                    e,
+                    RefTreeError::NotTargetConstrained { .. } | RefTreeError::UnknownTarget { .. }
+                )
+            })
+        {
+            check_tree(&graph, &index, &entities, &mut errors);
+        }
         match errors.len() {
             0 => Ok(()),
             1 => Err(errors.pop().unwrap()),
@@ -122,283 +245,139 @@ impl Constraint for RefTreeConstraint {
     const NAME: &'static str = "quent.ref-tree.v1";
 }
 
-/// A tree-forming reference gathered from an entity's events.
-enum TreeRef {
-    /// Target-constrained: the parent type from the co-located
-    /// `quent.ref-target.v1`.
-    Targeted { target: Identifier },
-    /// Type-erased: no decodable target (a req. 3 violation). The location is
-    /// rendered here because this is the only path that consumes it.
-    TypeErased { location: String },
-}
-
-/// Index into the harvested entities; never interchanged with a name or a count.
-#[derive(Clone, Copy)]
-struct EntityIdx(usize);
-
-/// A non-root entity paired with the single parent entity its references
-/// resolve to. There is no representable non-root without a parent edge.
-struct NonRoot {
-    entity: EntityIdx,
-    parent: EntityIdx,
-}
-
-fn check_tree(entities: &[Entity], records: &[Record], errors: &mut Vec<RefTreeError>) {
-    let n = entities.len();
-
-    // Gather, per entity, the tree-forming references its events declare,
-    // descending through Option/List, reference payloads and record fields. At
-    // most one is allowed per event (req. 2's parenthetical).
-    let mut refs_by_entity: Vec<Vec<TreeRef>> = (0..n).map(|_| Vec::new()).collect();
-    for (i, entity) in entities.iter().enumerate() {
-        for event in entity.events() {
-            let mut in_event = Vec::new();
-            for field in event.fields() {
-                let loc = Loc::Field {
-                    entity: entity.name(),
-                    event: event.name(),
-                    field: field.name(),
-                };
-                collect_refs(field.ty(), &loc, records, &mut in_event);
-            }
-            if in_event.len() > 1 {
-                errors.push(RefTreeError::MultiplePerEvent {
-                    entity: entity.name().clone(),
-                    event: event.name().clone(),
-                    count: in_event.len(),
-                });
-            }
-            refs_by_entity[i].append(&mut in_event);
+impl RefTreeConstraint {
+    fn node_or_insert(&mut self, node: Node) -> NodeIndex {
+        if let Some(&index) = self.index.get(&node) {
+            return index;
         }
+        let index = self.graph.add_node(node.clone());
+        self.index.insert(node, index);
+        index
     }
+}
 
-    // The constraint only forms a tree when at least one reference uses it.
-    if refs_by_entity.iter().all(|r| r.is_empty()) {
-        return;
-    }
+fn check_tree(
+    graph: &Graph<Node, ()>,
+    index: &FxHashMap<Node, NodeIndex>,
+    entities: &[Identifier],
+    errors: &mut Vec<RefTreeError>,
+) {
+    let mut roots: Vec<&Identifier> = Vec::new();
+    let mut non_roots: Vec<&Identifier> = Vec::new();
 
-    // Req. 3: every parent reference must be target-constrained.
-    for refs in &refs_by_entity {
-        for r in refs {
-            if let TreeRef::TypeErased { location } = r {
-                errors.push(RefTreeError::NotTargetConstrained {
-                    location: location.clone(),
+    // For each entity, we figure out whether we can collapse its parent edges
+    // (through multiple events) into one edge. If not, this violates the
+    // requirements.
+    let mut entity_edges: Vec<(&Identifier, &Identifier)> = Vec::new();
+
+    for entity in entities {
+        // Unwrap should be safe here since we added entities to the set and
+        // graph in lockstep.
+        let node = *index.get(&Node::Entity(entity.clone())).unwrap();
+
+        let unique_parents = entity_unique_parents(graph, node);
+        match unique_parents.as_slice() {
+            // No parents, it is a (the?) root entity
+            [] => roots.push(entity),
+            // One parent type, non-root.
+            [parent] => {
+                non_roots.push(entity);
+                entity_edges.push((*parent, entity));
+            }
+            // Multiple parent types, this violates req 4:
+            _ => {
+                errors.push(RefTreeError::ConflictingParents {
+                    entity: entity.clone(),
+                    parents: unique_parents.into_iter().cloned().collect(),
                 });
             }
         }
     }
 
-    // Req. 1: exactly one root (an entity carrying no tree-forming reference).
-    let roots: Vec<EntityIdx> = refs_by_entity
-        .iter()
-        .enumerate()
-        .filter(|(_, r)| r.is_empty())
-        .map(|(i, _)| EntityIdx(i))
-        .collect();
-    let root = match roots.as_slice() {
-        [] => {
+    // Check req 1, one root
+    let root = match roots.len() {
+        0 => {
             errors.push(RefTreeError::NoRoot);
             return;
         }
-        [root] => *root,
+        1 => roots[0],
         _ => {
-            let mut names: Vec<Identifier> = roots
-                .iter()
-                .map(|idx| entities[idx.0].name().clone())
-                .collect();
-            names.sort();
-            errors.push(RefTreeError::MultipleRoots { roots: names });
+            errors.push(RefTreeError::MultipleRoots {
+                roots: roots.iter().map(|r| (*r).clone()).collect(),
+            });
             return;
         }
     };
 
-    let index: HashMap<&Identifier, EntityIdx> = entities
-        .iter()
-        .enumerate()
-        .map(|(i, e)| (e.name(), EntityIdx(i)))
-        .collect();
-
-    // Req. 2: each non-root must declare exactly one parent type. A non-root
-    // carrying a type-erased reference is already reported (req. 3) and dropped.
-    // A resolved non-root carries its parent edge by construction; a target
-    // naming no entity has no path to the root (req. 4), reported directly.
-    let mut graph: Vec<NonRoot> = Vec::new();
-    for (i, refs) in refs_by_entity.iter().enumerate() {
-        if refs.is_empty() || refs.iter().any(|r| matches!(r, TreeRef::TypeErased { .. })) {
-            continue;
-        }
-        let mut parents: Vec<&Identifier> = refs
-            .iter()
-            .filter_map(|r| match r {
-                TreeRef::Targeted { target } => Some(target),
-                TreeRef::TypeErased { .. } => None,
-            })
-            .collect();
-        parents.sort();
-        parents.dedup();
-        match parents.as_slice() {
-            [parent] => match index.get(*parent) {
-                Some(&parent) => graph.push(NonRoot {
-                    entity: EntityIdx(i),
-                    parent,
-                }),
-                None => errors.push(RefTreeError::Unreachable {
-                    entity: entities[i].name().clone(),
-                }),
-            },
-            _ => errors.push(RefTreeError::ConflictingParents {
-                entity: entities[i].name().clone(),
-                parents: parents.into_iter().cloned().collect(),
-            }),
-        }
+    // We know:
+    // - there is one root
+    // - each non-root entity refers to exactly one parent type
+    // Now check:
+    // - every entity reaches root (req 5)
+    // If there are no errors afterwards the whole constraint is validated.
+    let mut maybe_tree: DiGraphMap<&Identifier, ()> = DiGraphMap::new();
+    maybe_tree.add_node(root);
+    for (parent, child) in entity_edges {
+        maybe_tree.add_edge(parent, child, ());
     }
-
-    // Req. 4: a walk from the unique root over parent -> child edges reaches
-    // every non-root on a path to it. Any left unvisited sits on a cycle.
-    let mut children: Vec<Vec<EntityIdx>> = (0..n).map(|_| Vec::new()).collect();
-    for node in &graph {
-        children[node.parent.0].push(node.entity);
-    }
-    let mut visited = vec![false; n];
-    visited[root.0] = true;
-    let mut queue = VecDeque::from([root]);
-    while let Some(parent) = queue.pop_front() {
-        for &child in &children[parent.0] {
-            if !visited[child.0] {
-                visited[child.0] = true;
-                queue.push_back(child);
-            }
-        }
-    }
-    for node in &graph {
-        if !visited[node.entity.0] {
+    let reachable: FxHashSet<&Identifier> = Bfs::new(&maybe_tree, root).iter(&maybe_tree).collect();
+    for entity in non_roots {
+        if !reachable.contains(entity) {
             errors.push(RefTreeError::Unreachable {
-                entity: entities[node.entity.0].name().clone(),
+                entity: entity.clone(),
             });
         }
     }
 }
 
-/// Gather every tree-forming reference reachable in `ty`, classifying each as
-/// targeted or type-erased. Descends `Option`/`List`, reference payloads and —
-/// resolving names against `records` — record fields. `loc` tracks the path so
-/// a violation can name its site without allocating on the valid path.
-fn collect_refs<'a>(
-    ty: &'a DataType,
-    loc: &'a Loc<'a>,
-    records: &'a [Record],
-    out: &mut Vec<TreeRef>,
-) {
-    match ty {
-        DataType::Option(inner) | DataType::List(inner) => collect_refs(inner, loc, records, out),
-        DataType::EntityRef { data, annotations } => {
-            if has_tree(annotations) {
-                out.push(match tree_ref_target(annotations) {
-                    Some(target) => TreeRef::Targeted { target },
-                    None => TreeRef::TypeErased {
-                        location: loc.render(),
-                    },
-                });
-            }
-            if let Some(inner) = data {
-                collect_refs(inner, loc, records, out);
-            }
+// List all unique parent entities reachable from the supplied entity
+fn entity_unique_parents(graph: &Graph<Node, ()>, entity: NodeIndex) -> Vec<&Identifier> {
+    let mut parents = Vec::new();
+    let mut seen: FxHashSet<NodeIndex> = FxHashSet::default();
+    let mut stack: Vec<NodeIndex> = graph.neighbors(entity).collect();
+    while let Some(node) = stack.pop() {
+        if !seen.insert(node) {
+            continue;
         }
-        DataType::Record(name) => {
-            // Guard against record definitions that nest cyclically.
-            if loc.descends_record(name) {
-                return;
-            }
-            if let Some(record) = records.iter().find(|r| r.name() == name) {
-                for field in record.fields() {
-                    let nested = Loc::Nested {
-                        outer: loc,
-                        record: name,
-                        field: field.name(),
-                    };
-                    collect_refs(field.ty(), &nested, records, out);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-/// The target entity type of a co-located `quent.ref-target.v1`, if present and
-/// decodable.
-fn tree_ref_target(annotations: &Annotations) -> Option<Identifier> {
-    let raw = annotations.constraint(RefTargetConstraint::NAME)?.data()?;
-    serde_json::from_str::<RefTarget>(raw)
-        .ok()
-        .map(|rt| rt.target)
-}
-
-fn has_tree(annotations: &Annotations) -> bool {
-    annotations.constraint(RefTreeConstraint::NAME).is_some()
-}
-
-/// Borrowed path to a tree-forming reference, rendered to a string only when a
-/// violation is reported.
-enum Loc<'a> {
-    Field {
-        entity: &'a Identifier,
-        event: &'a Identifier,
-        field: &'a Identifier,
-    },
-    Nested {
-        outer: &'a Loc<'a>,
-        record: &'a Identifier,
-        field: &'a Identifier,
-    },
-}
-
-impl Loc<'_> {
-    fn render(&self) -> String {
-        match self {
-            Loc::Field {
-                entity,
-                event,
-                field,
-            } => format!("entity \"{entity}\" event \"{event}\" field \"{field}\""),
-            Loc::Nested {
-                outer,
-                record,
-                field,
-            } => format!(
-                "{} -> record \"{record}\" field \"{field}\"",
-                outer.render()
-            ),
+        match &graph[node] {
+            Node::Entity(parent) => parents.push(parent),
+            Node::Event(..) | Node::Record(_) => stack.extend(graph.neighbors(node)),
         }
     }
+    parents
+}
 
-    /// Whether the path already descends through record `name` (a nesting cycle).
-    fn descends_record(&self, name: &Identifier) -> bool {
-        match self {
-            Loc::Field { .. } => false,
-            Loc::Nested { outer, record, .. } => *record == name || outer.descends_record(name),
+fn event_at_cursor<'s>(cursor: &'s Cursor) -> Option<(&'s Identifier, &'s Identifier)> {
+    match cursor.elements() {
+        [_schema, Element::Entity(entity), Element::Event(event), ..] => {
+            Some((entity.name(), event.name()))
         }
+        _ => None,
+    }
+}
+fn record_at_cursor<'s>(cursor: &'s Cursor) -> Option<&'s Identifier> {
+    match cursor.elements() {
+        [_schema, Element::Record(record), ..] => Some(record.name()),
+        _ => None,
     }
 }
 
 #[derive(Debug, Error)]
 pub enum RefTreeError {
-    #[error(
-        "{location}: a tree-forming reference must be target-constrained (carry a quent.ref-target.v1 annotation)"
-    )]
+    #[error("{location}: a tree-forming reference must be target-constrained")]
     NotTargetConstrained { location: String },
-    #[error(
-        "entity \"{entity}\" event \"{event}\": {count} tree-forming references, at most one is allowed"
-    )]
-    MultiplePerEvent {
-        entity: Identifier,
-        event: Identifier,
-        count: usize,
+    #[error("{location}: tree-forming reference targets unknown entity \"{target}\"")]
+    UnknownTarget {
+        location: String,
+        target: Identifier,
     },
-    #[error(
-        "tree-forming references are used but no entity is a root (every entity has a parent); a tree needs exactly one root"
-    )]
+    #[error("{location}: an event carries more than one tree-forming reference")]
+    MultiplePerEvent { location: String },
+    #[error("{location}: a record carries more than one tree-forming reference")]
+    MultipleRefsInRecord { location: String },
+    #[error("tree-forming references are used, but there is no root entity")]
     NoRoot,
-    #[error("more than one root entity (no tree-forming reference): {}", join_idents(.roots))]
+    #[error("more than one root entity: {}", join_idents(.roots))]
     MultipleRoots { roots: Vec<Identifier> },
     #[error("entity \"{entity}\" declares more than one parent type: {}", join_idents(.parents))]
     ConflictingParents {
@@ -409,11 +388,4 @@ pub enum RefTreeError {
     Unreachable { entity: Identifier },
     #[error("multiple ref-tree violations:\n{}", join_errors(.0))]
     Multiple(Vec<RefTreeError>),
-}
-
-fn join_idents(ids: &[Identifier]) -> String {
-    ids.iter()
-        .map(|i| format!("\"{i}\""))
-        .collect::<Vec<_>>()
-        .join(", ")
 }

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -12,10 +12,7 @@ use petgraph::{
 use rustc_hash::{FxHashMap, FxHashSet};
 use thiserror::Error;
 
-use quent_constraints::{
-    Constraint,
-    utils::{join_errors, join_idents},
-};
+use quent_constraints::{Constraint, utils::bullet_list};
 use quent_ref_target::RefTarget;
 use quent_schema::{
     DataType, Identifier,
@@ -386,6 +383,10 @@ pub enum RefTreeError {
     },
     #[error("entity \"{entity}\" has no path to the root through tree-forming references")]
     Unreachable { entity: Identifier },
-    #[error("multiple ref-tree violations:\n{}", join_errors(.0))]
+    #[error("multiple ref-tree violations:\n{}", bullet_list(.0))]
     Multiple(Vec<RefTreeError>),
+}
+
+fn join_idents(ids: &[Identifier]) -> String {
+    ids.iter().map(AsRef::as_ref).collect::<Vec<_>>().join(", ")
 }

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -10,9 +10,10 @@ use quent_schema::{
     constraint::Constraint,
     data_type::DataType,
     entity::Entity,
-    event::{Cardinality, Event, EventField},
+    event::{Cardinality, Event},
+    field::Field,
     identifier::Identifier,
-    record::{Record, RecordField},
+    record::Record,
 };
 
 fn ident(s: &str) -> Identifier {
@@ -68,15 +69,15 @@ fn ref_carrying(data: DataType) -> DataType {
     }
 }
 
-fn field(name: &str, ty: DataType) -> EventField {
-    EventField {
+fn field(name: &str, ty: DataType) -> Field {
+    Field {
         name: ident(name),
         ty,
         annotations: Annotations::default(),
     }
 }
 
-fn event(name: &str, payload: Vec<EventField>) -> Event {
+fn event(name: &str, payload: Vec<Field>) -> Event {
     Event {
         name: ident(name),
         cardinality: Cardinality::Once,
@@ -103,18 +104,10 @@ fn child(name: &str, ty: DataType) -> Entity {
     entity(name, vec![event("created", vec![field("parent", ty)])])
 }
 
-fn record(name: &str, fields: Vec<RecordField>) -> Record {
+fn record(name: &str, fields: Vec<Field>) -> Record {
     Record {
         name: ident(name),
         fields,
-        annotations: Annotations::default(),
-    }
-}
-
-fn record_field(name: &str, ty: DataType) -> RecordField {
-    RecordField {
-        name: ident(name),
-        ty,
         annotations: Annotations::default(),
     }
 }
@@ -205,7 +198,7 @@ fn tree_ref_in_reference_payload_is_found() {
 #[test]
 fn tree_ref_via_record_field_resolves_parent() {
     // A parent reference reached through a record-typed event field counts.
-    let meta = record("Meta", vec![record_field("owner", tree_ref_to("Cluster"))]);
+    let meta = record("Meta", vec![field("owner", tree_ref_to("Cluster"))]);
     let worker = child("Worker", DataType::Record(ident("Meta")));
     let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
     assert!(validate(&schema).is_empty());
@@ -218,8 +211,8 @@ fn recursive_record_does_not_loop() {
     let meta = record(
         "Meta",
         vec![
-            record_field("owner", tree_ref_to("Cluster")),
-            record_field(
+            field("owner", tree_ref_to("Cluster")),
+            field(
                 "nested",
                 DataType::Option(Box::new(DataType::Record(ident("Meta")))),
             ),
@@ -259,7 +252,7 @@ fn type_erased_tree_ref_is_rejected() {
 #[test]
 fn type_erased_tree_ref_via_record_is_rejected() {
     // Req. 3 also reaches references hidden behind a record-typed field.
-    let meta = record("Meta", vec![record_field("owner", tree_ref())]);
+    let meta = record("Meta", vec![field("owner", tree_ref())]);
     let worker = child("Worker", DataType::Record(ident("Meta")));
     let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
     let errors = validate(&schema);

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use quent_constraints::{Constraint, validate as run_constraints};
-use quent_ref_target::{RefTarget, RefTargetConstraint};
+use quent_ref_target::RefTargetConstraint;
 use quent_ref_tree::{RefTreeConstraint, RefTreeError};
 use quent_schema::{
     Annotations, DataType, Entity, Record, Schema,
@@ -23,10 +23,7 @@ fn tree_ref() -> DataType {
 
 /// A tree-forming reference restricted to a specific parent entity type.
 fn tree_ref_to(target: &str) -> DataType {
-    let data = serde_json::to_string(&RefTarget {
-        target: ident(target),
-    })
-    .unwrap();
+    let data = serde_json::to_string(&ident(target)).unwrap();
     DataType::EntityRef {
         data: None,
         annotations: AnnotationsBuilder::new()
@@ -46,9 +43,9 @@ fn ref_carrying(data: DataType) -> DataType {
     }
 }
 
-/// An entity with no events — carries no tree-forming reference, so it is a root.
+/// An entity whose event carries no tree-forming reference, so it is a root.
 fn root(name: &str) -> Entity {
-    entity(name, vec![])
+    entity(name, vec![event("created", vec![field("x", DataType::U64)])])
 }
 
 /// An entity whose single event carries one tree-forming reference `ty`.
@@ -142,6 +139,24 @@ fn tree_ref_via_record_field_resolves_parent() {
 }
 
 #[test]
+fn multiple_refs_in_record_is_rejected() {
+    // Req. 2: a record declares the parent at most once across its fields.
+    let meta = record(
+        "Meta",
+        vec![
+            field("a", tree_ref_to("Cluster")),
+            field("b", tree_ref_to("Cluster")),
+        ],
+    );
+    let worker = child("Worker", DataType::Record(ident("Meta")));
+    let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
+    assert!(matches!(
+        single_error(&schema),
+        RefTreeError::MultipleRefsInRecord { .. }
+    ));
+}
+
+#[test]
 fn recursive_record_does_not_loop() {
     // A record that nests itself (via Option) must not send the walker into an
     // infinite descent.
@@ -232,7 +247,7 @@ fn two_tree_refs_in_one_event_is_rejected() {
     let schema = schema_with(vec![root("Cluster"), task]);
     assert!(matches!(
         single_error(&schema),
-        RefTreeError::MultiplePerEvent { count: 2, .. }
+        RefTreeError::MultiplePerEvent { .. }
     ));
 }
 
@@ -261,12 +276,13 @@ fn multiple_roots_is_rejected() {
 }
 
 #[test]
-fn unknown_target_is_unreachable() {
-    // Req. 4: a parent type naming no entity has no path to the root.
+fn unknown_target_is_rejected() {
+    // Req. 5: a reference targeting a non-existent entity is rejected at the
+    // reference site.
     let schema = schema_with(vec![root("Cluster"), child("A", tree_ref_to("Ghost"))]);
     assert!(matches!(
         single_error(&schema),
-        RefTreeError::Unreachable { entity } if entity == "A"
+        RefTreeError::UnknownTarget { target, .. } if target == "Ghost"
     ));
 }
 

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -1,63 +1,40 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use quent_constraints::{Constraint as _, Error as ValidatorError, Validator};
+use quent_constraints::{Constraint, validate as run_constraints};
 use quent_ref_target::{RefTarget, RefTargetConstraint};
 use quent_ref_tree::{RefTreeConstraint, RefTreeError};
 use quent_schema::{
-    Schema,
-    annotations::Annotations,
-    constraint::Constraint,
-    data_type::DataType,
-    entity::Entity,
-    event::{Cardinality, Event},
-    field::Field,
-    identifier::Identifier,
-    record::Record,
+    Annotations, DataType, Entity, Record, Schema,
+    builder::AnnotationsBuilder,
+    test_utils::{constraint, entity, event, field, ident, record, schema},
 };
-
-fn ident(s: &str) -> Identifier {
-    Identifier::try_new(s).unwrap()
-}
-
-fn tree_constraint() -> Constraint {
-    Constraint {
-        name: RefTreeConstraint::NAME.to_string(),
-        data: None,
-    }
-}
-
-fn target_constraint(target: &str) -> Constraint {
-    Constraint {
-        name: RefTargetConstraint::NAME.to_string(),
-        data: Some(
-            serde_json::to_string(&RefTarget {
-                target: ident(target),
-            })
-            .unwrap(),
-        ),
-    }
-}
 
 /// A type-erased tree-forming reference (no target).
 fn tree_ref() -> DataType {
     DataType::EntityRef {
         data: None,
-        annotations: Annotations {
-            constraints: vec![tree_constraint()],
-            ..Default::default()
-        },
+        annotations: AnnotationsBuilder::new()
+            .constraint(constraint(RefTreeConstraint::NAME, None))
+            .unwrap()
+            .build(),
     }
 }
 
 /// A tree-forming reference restricted to a specific parent entity type.
 fn tree_ref_to(target: &str) -> DataType {
+    let data = serde_json::to_string(&RefTarget {
+        target: ident(target),
+    })
+    .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: Annotations {
-            constraints: vec![tree_constraint(), target_constraint(target)],
-            ..Default::default()
-        },
+        annotations: AnnotationsBuilder::new()
+            .constraint(constraint(RefTreeConstraint::NAME, None))
+            .unwrap()
+            .constraint(constraint(RefTargetConstraint::NAME, Some(data.as_str())))
+            .unwrap()
+            .build(),
     }
 }
 
@@ -65,31 +42,6 @@ fn tree_ref_to(target: &str) -> DataType {
 fn ref_carrying(data: DataType) -> DataType {
     DataType::EntityRef {
         data: Some(Box::new(data)),
-        annotations: Annotations::default(),
-    }
-}
-
-fn field(name: &str, ty: DataType) -> Field {
-    Field {
-        name: ident(name),
-        ty,
-        annotations: Annotations::default(),
-    }
-}
-
-fn event(name: &str, payload: Vec<Field>) -> Event {
-    Event {
-        name: ident(name),
-        cardinality: Cardinality::Once,
-        payload,
-        annotations: Annotations::default(),
-    }
-}
-
-fn entity(name: &str, events: Vec<Event>) -> Entity {
-    Entity {
-        name: ident(name),
-        events,
         annotations: Annotations::default(),
     }
 }
@@ -104,48 +56,33 @@ fn child(name: &str, ty: DataType) -> Entity {
     entity(name, vec![event("created", vec![field("parent", ty)])])
 }
 
-fn record(name: &str, fields: Vec<Field>) -> Record {
-    Record {
-        name: ident(name),
-        fields,
-        annotations: Annotations::default(),
-    }
-}
-
 fn schema_with(entities: Vec<Entity>) -> Schema {
-    schema_with_records(entities, vec![])
+    schema("S", entities, vec![])
 }
 
 fn schema_with_records(entities: Vec<Entity>, records: Vec<Record>) -> Schema {
-    Schema {
-        name: ident("S"),
-        entities,
-        records,
-        annotations: Annotations::default(),
-    }
+    schema("S", entities, records)
 }
 
 fn validate(schema: &Schema) -> Vec<RefTreeError> {
-    let validator = Validator::default()
-        .try_with(RefTreeConstraint)
-        .unwrap()
-        .try_with(RefTargetConstraint)
-        .unwrap();
-    match validator.validate(schema) {
+    let report = run_constraints::<(RefTreeConstraint, RefTargetConstraint)>(schema);
+    match report.results.0 {
         Ok(()) => Vec::new(),
-        Err(ValidatorError::Invalid { failures, .. }) => {
-            for (name, source) in failures {
-                if name == RefTreeConstraint::NAME {
-                    return match *source.downcast::<RefTreeError>().unwrap() {
-                        RefTreeError::Multiple(errors) => errors,
-                        single => vec![single],
-                    };
-                }
-            }
-            Vec::new()
-        }
-        Err(_) => unreachable!(),
+        Err(RefTreeError::Multiple(errors)) => errors,
+        Err(single) => vec![single],
     }
+}
+
+/// Assert the schema satisfies the constraint.
+fn assert_valid(schema: &Schema) {
+    assert!(validate(schema).is_empty());
+}
+
+/// Assert the schema produces exactly one violation, and return it.
+fn single_error(schema: &Schema) -> RefTreeError {
+    let mut errors = validate(schema);
+    assert_eq!(errors.len(), 1);
+    errors.pop().unwrap()
 }
 
 #[test]
@@ -155,7 +92,7 @@ fn target_chain_to_root_passes() {
         child("Worker", tree_ref_to("Cluster")),
         child("Task", tree_ref_to("Worker")),
     ]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -164,35 +101,35 @@ fn single_child_under_root_passes() {
         root("Cluster"),
         child("Worker", tree_ref_to("Cluster")),
     ]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
 fn no_tree_ref_anywhere_passes() {
     // The constraint only forms a tree when at least one reference uses it.
     let schema = schema_with(vec![child("Solo", DataType::U64)]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
 fn option_nested_tree_ref_is_found() {
     let nested = DataType::Option(Box::new(tree_ref_to("Cluster")));
     let schema = schema_with(vec![root("Cluster"), child("Worker", nested)]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
 fn list_nested_tree_ref_is_found() {
     let nested = DataType::List(Box::new(tree_ref_to("Cluster")));
     let schema = schema_with(vec![root("Cluster"), child("Worker", nested)]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
 fn tree_ref_in_reference_payload_is_found() {
     let nested = ref_carrying(tree_ref_to("Cluster"));
     let schema = schema_with(vec![root("Cluster"), child("Worker", nested)]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -201,7 +138,7 @@ fn tree_ref_via_record_field_resolves_parent() {
     let meta = record("Meta", vec![field("owner", tree_ref_to("Cluster"))]);
     let worker = child("Worker", DataType::Record(ident("Meta")));
     let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -220,7 +157,7 @@ fn recursive_record_does_not_loop() {
     );
     let worker = child("Worker", DataType::Record(ident("Meta")));
     let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -234,17 +171,15 @@ fn same_parent_across_events_passes() {
         ],
     );
     let schema = schema_with(vec![root("Cluster"), task]);
-    assert!(validate(&schema).is_empty());
+    assert_valid(&schema);
 }
 
 #[test]
 fn type_erased_tree_ref_is_rejected() {
     // Req. 3: a tree-forming reference must be target-constrained.
     let schema = schema_with(vec![root("Cluster"), child("Worker", tree_ref())]);
-    let errors = validate(&schema);
-    assert_eq!(errors.len(), 1);
     assert!(matches!(
-        errors[0],
+        single_error(&schema),
         RefTreeError::NotTargetConstrained { .. }
     ));
 }
@@ -255,10 +190,8 @@ fn type_erased_tree_ref_via_record_is_rejected() {
     let meta = record("Meta", vec![field("owner", tree_ref())]);
     let worker = child("Worker", DataType::Record(ident("Meta")));
     let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
-    let errors = validate(&schema);
-    assert_eq!(errors.len(), 1);
     assert!(matches!(
-        errors[0],
+        single_error(&schema),
         RefTreeError::NotTargetConstrained { .. }
     ));
 }
@@ -278,11 +211,10 @@ fn conflicting_parents_is_rejected() {
         child("Worker", tree_ref_to("Cluster")),
         task,
     ]);
-    let errors = validate(&schema);
-    assert_eq!(errors.len(), 1);
-    assert!(
-        matches!(&errors[0], RefTreeError::ConflictingParents { entity, .. } if entity == "Task"),
-    );
+    assert!(matches!(
+        single_error(&schema),
+        RefTreeError::ConflictingParents { entity, .. } if entity == "Task"
+    ));
 }
 
 #[test]
@@ -298,10 +230,8 @@ fn two_tree_refs_in_one_event_is_rejected() {
         )],
     );
     let schema = schema_with(vec![root("Cluster"), task]);
-    let errors = validate(&schema);
-    assert_eq!(errors.len(), 1);
     assert!(matches!(
-        errors[0],
+        single_error(&schema),
         RefTreeError::MultiplePerEvent { count: 2, .. }
     ));
 }
@@ -313,9 +243,7 @@ fn no_root_is_rejected() {
         child("A", tree_ref_to("B")),
         child("B", tree_ref_to("A")),
     ]);
-    let errors = validate(&schema);
-    assert_eq!(errors.len(), 1);
-    assert!(matches!(errors[0], RefTreeError::NoRoot));
+    assert!(matches!(single_error(&schema), RefTreeError::NoRoot));
 }
 
 #[test]
@@ -326,18 +254,20 @@ fn multiple_roots_is_rejected() {
         root("Other"),
         child("Worker", tree_ref_to("Cluster")),
     ]);
-    let errors = validate(&schema);
-    assert_eq!(errors.len(), 1);
-    assert!(matches!(errors[0], RefTreeError::MultipleRoots { .. }));
+    assert!(matches!(
+        single_error(&schema),
+        RefTreeError::MultipleRoots { .. }
+    ));
 }
 
 #[test]
 fn unknown_target_is_unreachable() {
     // Req. 4: a parent type naming no entity has no path to the root.
     let schema = schema_with(vec![root("Cluster"), child("A", tree_ref_to("Ghost"))]);
-    let errors = validate(&schema);
-    assert_eq!(errors.len(), 1);
-    assert!(matches!(&errors[0], RefTreeError::Unreachable { entity } if entity == "A"));
+    assert!(matches!(
+        single_error(&schema),
+        RefTreeError::Unreachable { entity } if entity == "A"
+    ));
 }
 
 #[test]

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -1,0 +1,370 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use quent_constraints::{Constraint as _, Error as ValidatorError, Validator};
+use quent_ref_target::{RefTarget, RefTargetConstraint};
+use quent_ref_tree::{RefTreeConstraint, RefTreeError};
+use quent_schema::{
+    Schema,
+    annotations::Annotations,
+    constraint::Constraint,
+    data_type::DataType,
+    entity::Entity,
+    event::{Cardinality, Event, EventField},
+    identifier::Identifier,
+    record::{Record, RecordField},
+};
+
+fn ident(s: &str) -> Identifier {
+    Identifier::try_new(s).unwrap()
+}
+
+fn tree_constraint() -> Constraint {
+    Constraint {
+        name: RefTreeConstraint::NAME.to_string(),
+        data: None,
+    }
+}
+
+fn target_constraint(target: &str) -> Constraint {
+    Constraint {
+        name: RefTargetConstraint::NAME.to_string(),
+        data: Some(
+            serde_json::to_string(&RefTarget {
+                target: ident(target),
+            })
+            .unwrap(),
+        ),
+    }
+}
+
+/// A type-erased tree-forming reference (no target).
+fn tree_ref() -> DataType {
+    DataType::EntityRef {
+        data: None,
+        annotations: Annotations {
+            constraints: vec![tree_constraint()],
+            ..Default::default()
+        },
+    }
+}
+
+/// A tree-forming reference restricted to a specific parent entity type.
+fn tree_ref_to(target: &str) -> DataType {
+    DataType::EntityRef {
+        data: None,
+        annotations: Annotations {
+            constraints: vec![tree_constraint(), target_constraint(target)],
+            ..Default::default()
+        },
+    }
+}
+
+/// A plain (non-tree) entity reference carrying `data` as its payload.
+fn ref_carrying(data: DataType) -> DataType {
+    DataType::EntityRef {
+        data: Some(Box::new(data)),
+        annotations: Annotations::default(),
+    }
+}
+
+fn field(name: &str, ty: DataType) -> EventField {
+    EventField {
+        name: ident(name),
+        ty,
+        annotations: Annotations::default(),
+    }
+}
+
+fn event(name: &str, payload: Vec<EventField>) -> Event {
+    Event {
+        name: ident(name),
+        cardinality: Cardinality::Once,
+        payload,
+        annotations: Annotations::default(),
+    }
+}
+
+fn entity(name: &str, events: Vec<Event>) -> Entity {
+    Entity {
+        name: ident(name),
+        events,
+        annotations: Annotations::default(),
+    }
+}
+
+/// An entity with no events — carries no tree-forming reference, so it is a root.
+fn root(name: &str) -> Entity {
+    entity(name, vec![])
+}
+
+/// An entity whose single event carries one tree-forming reference `ty`.
+fn child(name: &str, ty: DataType) -> Entity {
+    entity(name, vec![event("created", vec![field("parent", ty)])])
+}
+
+fn record(name: &str, fields: Vec<RecordField>) -> Record {
+    Record {
+        name: ident(name),
+        fields,
+        annotations: Annotations::default(),
+    }
+}
+
+fn record_field(name: &str, ty: DataType) -> RecordField {
+    RecordField {
+        name: ident(name),
+        ty,
+        annotations: Annotations::default(),
+    }
+}
+
+fn schema_with(entities: Vec<Entity>) -> Schema {
+    schema_with_records(entities, vec![])
+}
+
+fn schema_with_records(entities: Vec<Entity>, records: Vec<Record>) -> Schema {
+    Schema {
+        name: ident("S"),
+        entities,
+        records,
+        annotations: Annotations::default(),
+    }
+}
+
+fn validate(schema: &Schema) -> Vec<RefTreeError> {
+    let validator = Validator::default()
+        .try_with(RefTreeConstraint)
+        .unwrap()
+        .try_with(RefTargetConstraint)
+        .unwrap();
+    match validator.validate(schema) {
+        Ok(()) => Vec::new(),
+        Err(ValidatorError::Invalid { failures, .. }) => {
+            for (name, source) in failures {
+                if name == RefTreeConstraint::NAME {
+                    return match *source.downcast::<RefTreeError>().unwrap() {
+                        RefTreeError::Multiple(errors) => errors,
+                        single => vec![single],
+                    };
+                }
+            }
+            Vec::new()
+        }
+        Err(_) => unreachable!(),
+    }
+}
+
+#[test]
+fn target_chain_to_root_passes() {
+    let schema = schema_with(vec![
+        root("Cluster"),
+        child("Worker", tree_ref_to("Cluster")),
+        child("Task", tree_ref_to("Worker")),
+    ]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn single_child_under_root_passes() {
+    let schema = schema_with(vec![
+        root("Cluster"),
+        child("Worker", tree_ref_to("Cluster")),
+    ]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn no_tree_ref_anywhere_passes() {
+    // The constraint only forms a tree when at least one reference uses it.
+    let schema = schema_with(vec![child("Solo", DataType::U64)]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn option_nested_tree_ref_is_found() {
+    let nested = DataType::Option(Box::new(tree_ref_to("Cluster")));
+    let schema = schema_with(vec![root("Cluster"), child("Worker", nested)]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn list_nested_tree_ref_is_found() {
+    let nested = DataType::List(Box::new(tree_ref_to("Cluster")));
+    let schema = schema_with(vec![root("Cluster"), child("Worker", nested)]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn tree_ref_in_reference_payload_is_found() {
+    let nested = ref_carrying(tree_ref_to("Cluster"));
+    let schema = schema_with(vec![root("Cluster"), child("Worker", nested)]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn tree_ref_via_record_field_resolves_parent() {
+    // A parent reference reached through a record-typed event field counts.
+    let meta = record("Meta", vec![record_field("owner", tree_ref_to("Cluster"))]);
+    let worker = child("Worker", DataType::Record(ident("Meta")));
+    let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn recursive_record_does_not_loop() {
+    // A record that nests itself (via Option) must not send the walker into an
+    // infinite descent.
+    let meta = record(
+        "Meta",
+        vec![
+            record_field("owner", tree_ref_to("Cluster")),
+            record_field(
+                "nested",
+                DataType::Option(Box::new(DataType::Record(ident("Meta")))),
+            ),
+        ],
+    );
+    let worker = child("Worker", DataType::Record(ident("Meta")));
+    let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn same_parent_across_events_passes() {
+    // Req. 2 permits the parent reference on any number of events.
+    let task = entity(
+        "Task",
+        vec![
+            event("created", vec![field("a", tree_ref_to("Cluster"))]),
+            event("moved", vec![field("b", tree_ref_to("Cluster"))]),
+        ],
+    );
+    let schema = schema_with(vec![root("Cluster"), task]);
+    assert!(validate(&schema).is_empty());
+}
+
+#[test]
+fn type_erased_tree_ref_is_rejected() {
+    // Req. 3: a tree-forming reference must be target-constrained.
+    let schema = schema_with(vec![root("Cluster"), child("Worker", tree_ref())]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        errors[0],
+        RefTreeError::NotTargetConstrained { .. }
+    ));
+}
+
+#[test]
+fn type_erased_tree_ref_via_record_is_rejected() {
+    // Req. 3 also reaches references hidden behind a record-typed field.
+    let meta = record("Meta", vec![record_field("owner", tree_ref())]);
+    let worker = child("Worker", DataType::Record(ident("Meta")));
+    let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        errors[0],
+        RefTreeError::NotTargetConstrained { .. }
+    ));
+}
+
+#[test]
+fn conflicting_parents_is_rejected() {
+    // Req. 2: a non-root declaring two distinct parent types across events.
+    let task = entity(
+        "Task",
+        vec![
+            event("created", vec![field("a", tree_ref_to("Worker"))]),
+            event("moved", vec![field("b", tree_ref_to("Cluster"))]),
+        ],
+    );
+    let schema = schema_with(vec![
+        root("Cluster"),
+        child("Worker", tree_ref_to("Cluster")),
+        task,
+    ]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 1);
+    assert!(
+        matches!(&errors[0], RefTreeError::ConflictingParents { entity, .. } if entity == "Task"),
+    );
+}
+
+#[test]
+fn two_tree_refs_in_one_event_is_rejected() {
+    let task = entity(
+        "Task",
+        vec![event(
+            "created",
+            vec![
+                field("a", tree_ref_to("Cluster")),
+                field("b", tree_ref_to("Cluster")),
+            ],
+        )],
+    );
+    let schema = schema_with(vec![root("Cluster"), task]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        errors[0],
+        RefTreeError::MultiplePerEvent { count: 2, .. }
+    ));
+}
+
+#[test]
+fn no_root_is_rejected() {
+    // Req. 1: every entity has a parent, so none is a root.
+    let schema = schema_with(vec![
+        child("A", tree_ref_to("B")),
+        child("B", tree_ref_to("A")),
+    ]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(errors[0], RefTreeError::NoRoot));
+}
+
+#[test]
+fn multiple_roots_is_rejected() {
+    // Req. 1: two entities carry no tree-forming reference.
+    let schema = schema_with(vec![
+        root("Cluster"),
+        root("Other"),
+        child("Worker", tree_ref_to("Cluster")),
+    ]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(errors[0], RefTreeError::MultipleRoots { .. }));
+}
+
+#[test]
+fn unknown_target_is_unreachable() {
+    // Req. 4: a parent type naming no entity has no path to the root.
+    let schema = schema_with(vec![root("Cluster"), child("A", tree_ref_to("Ghost"))]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(&errors[0], RefTreeError::Unreachable { entity } if entity == "A"));
+}
+
+#[test]
+fn target_cycle_is_unreachable() {
+    // Req. 4: A and B form a cycle with no path to the root.
+    let schema = schema_with(vec![
+        root("Cluster"),
+        child("A", tree_ref_to("B")),
+        child("B", tree_ref_to("A")),
+    ]);
+    let errors = validate(&schema);
+    assert_eq!(errors.len(), 2);
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, RefTreeError::Unreachable { entity } if entity == "A")),
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e, RefTreeError::Unreachable { entity } if entity == "B")),
+    );
+}

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -255,6 +255,26 @@ fn two_tree_refs_in_one_event_is_rejected() {
 }
 
 #[test]
+fn direct_and_record_refs_in_one_event_is_rejected() {
+    let meta = record("Meta", vec![field("owner", tree_ref_to("Cluster"))]);
+    let worker = entity(
+        "Worker",
+        vec![event(
+            "created",
+            vec![
+                field("direct", tree_ref_to("Cluster")),
+                field("meta", DataType::Record(ident("Meta"))),
+            ],
+        )],
+    );
+    let schema = schema_with_records(vec![root("Cluster"), worker], vec![meta]);
+    assert!(matches!(
+        single_error(&schema),
+        RefTreeError::MultiplePerEvent { .. }
+    ));
+}
+
+#[test]
 fn no_root_is_rejected() {
     // Req. 1: every entity has a parent, so none is a root.
     let schema = schema_with(vec![

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -7,7 +7,7 @@ use quent_ref_tree::{RefTreeConstraint, RefTreeError};
 use quent_schema::{
     Annotations, DataType, Entity, Record, Schema,
     builder::AnnotationsBuilder,
-    test_utils::{constraint, entity, event, field, ident, record, schema},
+    test_utils::{entity, event, field, ident, record, schema},
 };
 
 /// A type-erased tree-forming reference (no target).
@@ -15,7 +15,7 @@ fn tree_ref() -> DataType {
     DataType::EntityRef {
         data: None,
         annotations: AnnotationsBuilder::new()
-            .constraint(constraint(RefTreeConstraint::NAME, None))
+            .constraint(RefTreeConstraint::NAME, None)
             .unwrap()
             .build(),
     }
@@ -27,9 +27,9 @@ fn tree_ref_to(target: &str) -> DataType {
     DataType::EntityRef {
         data: None,
         annotations: AnnotationsBuilder::new()
-            .constraint(constraint(RefTreeConstraint::NAME, None))
+            .constraint(RefTreeConstraint::NAME, None)
             .unwrap()
-            .constraint(constraint(RefTargetConstraint::NAME, Some(data.as_str())))
+            .constraint(RefTargetConstraint::NAME, Some(data))
             .unwrap()
             .build(),
     }

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -45,7 +45,10 @@ fn ref_carrying(data: DataType) -> DataType {
 
 /// An entity whose event carries no tree-forming reference, so it is a root.
 fn root(name: &str) -> Entity {
-    entity(name, vec![event("created", vec![field("x", DataType::U64)])])
+    entity(
+        name,
+        vec![event("created", vec![field("x", DataType::U64)])],
+    )
 }
 
 /// An entity whose single event carries one tree-forming reference `ty`.

--- a/crates/schema/src/schema/annotations.rs
+++ b/crates/schema/src/schema/annotations.rs
@@ -43,6 +43,11 @@ impl Annotations {
         self.constraints.get(name)
     }
 
+    /// Return true if the constraint declared under `name` is set.
+    pub fn has_constraint(&self, name: &str) -> bool {
+        self.constraint(name).is_some()
+    }
+
     /// The declared constraints, in declaration order.
     pub fn constraints(&self) -> impl Iterator<Item = &Constraint> + '_ {
         self.constraints.values()


### PR DESCRIPTION
Adds the `quent-ref-tree` crate which implements an opt-in schema constraint that requires the definition of a tree of entities in a graph of entities referring to each other.

Part of #191 and closes #195 to feature parity with pre-schema-based arch