### PR TITLE
refactor(ui): Align neutral colors with tailwind palette

### DIFF
--- a/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
+++ b/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
@@ -49,8 +49,8 @@ const nodeVariants = cva(
   {
     variants: {
       selected: {
-        true: 'shadow-glow border-2 scale-110',
-        false: 'shadow-md',
+        true: 'border-2 scale-110',
+        false: '',
       },
     },
     defaultVariants: {
@@ -162,14 +162,17 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
 
   const nodeContent = (
     <div
-      className={nodeVariants({ selected: isSelected })}
+      className={cn(nodeVariants({ selected: isSelected }), {
+        'shadow-glow': isSelected || isActiveHighlight,
+        'shadow-node': !isSelected && !isActiveHighlight,
+      })}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       style={
         {
           borderColor: heatmapColor ?? activeColor,
           backgroundColor: heatmapColor ?? bgColor,
-          '--glow-color': activeColor,
+          '--glow-color': 'hsl(var(--primary))',
           ...(fieldColor && isLightColor(fieldColor) ? { color: '#111827' } : {}),
         } as React.CSSProperties
       }
@@ -209,9 +212,7 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
 
   return (
     <div
-      className={cn(opacityClass, 'z-10', {
-        'ring-2 ring-primary/50 rounded-md': isActiveHighlight,
-      })}
+      className={cn(opacityClass, 'z-10')}
     >
       {nodeContent}
     </div>

--- a/ui/packages/@quent/utils/src/colors.ts
+++ b/ui/packages/@quent/utils/src/colors.ts
@@ -337,8 +337,8 @@ const VIRIDIS_STOPS: [number, number, number][] = [
   [253, 231, 37],
 ];
 
-const NEUTRAL: [number, number, number] = [229, 231, 235];
-const NEUTRAL_DARK: [number, number, number] = [55, 65, 81];
+const NEUTRAL: [number, number, number] = [255, 255, 255];
+const NEUTRAL_DARK: [number, number, number] = [14, 22, 33];
 
 function blendToColor(
   r: number,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -138,7 +138,11 @@
 }
 
 @utility shadow-glow {
-  box-shadow: 0 0 14px 2px color-mix(in srgb, var(--glow-color, transparent) 55%, transparent);
+  box-shadow: 0 0 14px 2px color-mix(in srgb, var(--glow-color, transparent) 34%, transparent);
+}
+
+@utility shadow-node {
+  box-shadow: 0 0 8px 1px color-mix(in srgb, hsl(var(--foreground)) 16%, transparent);
 }
 
 @utility bg-diagonal-stripe {


### PR DESCRIPTION
Use the `.bg-background` colors for the neutral light/dark colors when creating continuous scales. I think this looks better than the gray as a neutral, and keeps everything within the palette, lemme know what you think.


Adjusted some drop shadows to make these stand out against the background a little better + the selected nodes more visible:

https://github.com/user-attachments/assets/1a819796-c515-4b93-afc8-f9ecf834c5c2


Light
<img width="1691" height="929" alt="Screenshot 2026-06-03 at 3 11 22 PM" src="https://github.com/user-attachments/assets/fdd10ded-ce45-40ce-9916-5a01f1b2a4b1" />
<img width="1722" height="944" alt="Screenshot 2026-06-03 at 3 09 16 PM" src="https://github.com/user-attachments/assets/28c760ed-f949-4dee-898c-0799d4cb0129" />

Dark
<img width="1664" height="867" alt="Screenshot 2026-06-03 at 3 08 14 PM" src="https://github.com/user-attachments/assets/68d9a66e-f540-4007-b517-c8ab8306a849" />
<img width="1705" height="937" alt="Screenshot 2026-06-03 at 3 08 58 PM" src="https://github.com/user-attachments/assets/5580f8a7-b044-44e1-8ad0-ea21cdc996a6" />
