### PR TITLE
fix(ui): Bundle optimization pass

### DIFF
--- a/ui/packages/@quent/components/package.json
+++ b/ui/packages/@quent/components/package.json
@@ -19,8 +19,7 @@
     "@quent/client": "workspace:*",
     "@quent/hooks": "workspace:*",
     "@quent/utils": "workspace:*",
-    "d3-dag": "^1.2.1",
-    "elkjs": "^0.11.1"
+    "d3-dag": "^1.2.1"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",

--- a/ui/packages/@quent/components/package.json
+++ b/ui/packages/@quent/components/package.json
@@ -7,7 +7,10 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "sideEffects": ["**/echarts.ts", "**/*.css"],
+  "sideEffects": [
+    "**/echarts.ts",
+    "**/*.css"
+  ],
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit"
@@ -16,18 +19,19 @@
     "@quent/client": "workspace:*",
     "@quent/hooks": "workspace:*",
     "@quent/utils": "workspace:*",
+    "d3-dag": "^1.2.1",
     "elkjs": "^0.11.1"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "@tanstack/react-query": "^5.0.0",
+    "@tanstack/react-table": "^8.0.0",
+    "@tanstack/react-virtual": "^3.0.0",
     "@xyflow/react": "^12.10.1",
     "echarts": "^5.6.0",
     "echarts-for-react": "^3.0.6",
     "jotai": "^2.0.0",
-    "@tanstack/react-query": "^5.0.0",
-    "@tanstack/react-table": "^8.0.0",
-    "@tanstack/react-virtual": "^3.0.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import ELK from 'elkjs';
 import {
   useCallback,
   useEffect,
@@ -40,14 +39,13 @@ import {
   useSetSelectedNodeData,
   useSetDagDisplayedNodeIds,
 } from '@quent/hooks';
+import { calculateLayout, NODE_LAYOUT_WIDTH } from './layout';
 import type { DAGData } from '../services/query-plan/types';
 import { QueryPlanNode, type QueryPlanNodeData } from '../query-plan/QueryPlanNode';
 import { DAGLegend } from './DAGLegend';
 import { parseCustomStatistics } from '../lib/queryBundle.utils';
 import { continuousColor, getOperationTypeColor, buildOperatorColorMap } from '@quent/utils';
 import { inferFieldFormatter } from '@quent/utils';
-
-const elk = new ELK();
 
 // Edge geometry constants
 const EDGE_STROKE_WIDTH_DEFAULT = 1.5;
@@ -61,8 +59,6 @@ const ARROW_DEPTH_RATIO = 0.6;
 const FALLBACK_NORMALIZED_T = 0.5; // used when min === max
 
 // Layout constants
-const NODE_LAYOUT_WIDTH = 200;
-const NODE_LAYOUT_HEIGHT = 60;
 const FIT_VIEW_PADDING = 0.1;
 const FLOW_MIN_ZOOM = 0.1;
 const FLOW_MAX_ZOOM = 2;
@@ -221,16 +217,6 @@ const VariableWidthEdge = ({
   );
 };
 
-const ELK_LAYER_SPACING = '100';
-const ELK_NODE_SPACING = '50';
-
-const elkOptions = {
-  'elk.algorithm': 'layered',
-  'elk.direction': 'DOWN',
-  'elk.layered.spacing.nodeNodeBetweenLayers': ELK_LAYER_SPACING,
-  'elk.spacing.nodeNode': ELK_NODE_SPACING,
-};
-
 const edgeTypes = {
   smoothstep: VariableWidthEdge,
   default: VariableWidthEdge,
@@ -267,37 +253,6 @@ interface DAGProps {
   selectedNodeIds?: string[];
   /** Called when node selection changes. */
   onSelectionChange?: (nodeIds: string[]) => void;
-}
-
-async function calculateLayout(
-  nodes: Node<QueryPlanNodeData>[],
-  edges: Edge[]
-): Promise<{ nodes: Node<QueryPlanNodeData>[]; edges: Edge[] }> {
-  const graph = {
-    id: 'root',
-    layoutOptions: elkOptions,
-    children: nodes.map(node => ({
-      id: node.id,
-      width: NODE_LAYOUT_WIDTH,
-      height: NODE_LAYOUT_HEIGHT,
-    })),
-    edges: edges.map(edge => ({
-      id: edge.id,
-      sources: [edge.source],
-      targets: [edge.target],
-    })),
-  };
-
-  const layout = await elk.layout(graph);
-
-  return {
-    nodes:
-      layout.children?.map((child, i) => ({
-        ...nodes[i],
-        position: { x: child.x ?? 0, y: child.y ?? 0 },
-      })) ?? [],
-    edges: edges,
-  };
 }
 
 const FlowLayout = ({
@@ -372,8 +327,7 @@ const FlowLayout = ({
           baseColor: operatorColorMap.get(node.type.toLowerCase()),
         },
         style: {
-          width: 'auto',
-          minWidth: NODE_LAYOUT_WIDTH,
+          width: NODE_LAYOUT_WIDTH,
           background: 'transparent',
           boxShadow: 'none',
           border: 0,

--- a/ui/packages/@quent/components/src/dag/layout.ts
+++ b/ui/packages/@quent/components/src/dag/layout.ts
@@ -2,22 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { graph, sugiyama } from 'd3-dag';
-import ELK from 'elkjs';
 import type { Node, Edge } from '@xyflow/react';
 
 export const NODE_LAYOUT_WIDTH = 200;
 const NODE_LAYOUT_HEIGHT = 60;
+// Spacing between adjacent nodes in the same layer (horizontal gap)
 const NODE_SPACING = 50;
+// Spacing between layers (vertical gap)
 const LAYER_SPACING = 100;
 
-export type LayoutEngine = 'd3-dag' | 'elk';
+// nodeSize encodes center-to-center distance per axis:
+//   x (within a layer): node width + gap between siblings
+//   y (between layers): node height + gap between layers
+const NODE_SIZE = [NODE_LAYOUT_WIDTH + NODE_SPACING, NODE_LAYOUT_HEIGHT + LAYER_SPACING] as const;
 
-const D3_NODE_SIZE = [
-  NODE_LAYOUT_WIDTH + NODE_SPACING,
-  NODE_LAYOUT_HEIGHT + LAYER_SPACING,
-] as const;
-
-async function layoutWithD3Dag<TData extends Record<string, unknown>>(
+export async function calculateLayout<TData extends Record<string, unknown>>(
   nodes: Node<TData>[],
   edges: Edge[]
 ): Promise<{ nodes: Node<TData>[]; edges: Edge[] }> {
@@ -30,8 +29,8 @@ async function layoutWithD3Dag<TData extends Record<string, unknown>>(
     if (src && tgt) grf.link(src, tgt, undefined);
   }
 
-  // sugiyama is synchronous and top-to-bottom by default (matches ELK DOWN)
-  sugiyama().nodeSize(D3_NODE_SIZE)(grf);
+  // sugiyama is synchronous and top-to-bottom by default
+  sugiyama().nodeSize(NODE_SIZE)(grf);
 
   // d3-dag reports node centers; ReactFlow expects top-left
   const posMap = new Map<string, { x: number; y: number }>();
@@ -46,56 +45,4 @@ async function layoutWithD3Dag<TData extends Record<string, unknown>>(
     nodes: nodes.map(n => ({ ...n, position: posMap.get(n.id) ?? { x: 0, y: 0 } })),
     edges,
   };
-}
-
-// ---- ELK -------------------------------------------------------------------
-
-const elk = new ELK();
-
-const elkOptions = {
-  'elk.algorithm': 'layered',
-  'elk.direction': 'DOWN',
-  'elk.layered.spacing.nodeNodeBetweenLayers': `${LAYER_SPACING}`,
-  'elk.spacing.nodeNode': `${NODE_SPACING}`,
-};
-
-async function layoutWithElk<TData extends Record<string, unknown>>(
-  nodes: Node<TData>[],
-  edges: Edge[]
-): Promise<{ nodes: Node<TData>[]; edges: Edge[] }> {
-  const elkGraph = {
-    id: 'root',
-    layoutOptions: elkOptions,
-    children: nodes.map(n => ({
-      id: n.id,
-      width: NODE_LAYOUT_WIDTH,
-      height: NODE_LAYOUT_HEIGHT,
-    })),
-    edges: edges.map(e => ({
-      id: e.id,
-      sources: [e.source],
-      targets: [e.target],
-    })),
-  };
-
-  const layout = await elk.layout(elkGraph);
-
-  return {
-    nodes:
-      layout.children?.map((child, i) => ({
-        ...nodes[i]!,
-        position: { x: child.x ?? 0, y: child.y ?? 0 },
-      })) ?? [],
-    edges,
-  };
-}
-
-// ---- Public API ------------------------------------------------------------
-
-export async function calculateLayout<TData extends Record<string, unknown>>(
-  nodes: Node<TData>[],
-  edges: Edge[],
-  engine: LayoutEngine = 'd3-dag'
-): Promise<{ nodes: Node<TData>[]; edges: Edge[] }> {
-  return engine === 'elk' ? layoutWithElk(nodes, edges) : layoutWithD3Dag(nodes, edges);
 }

--- a/ui/packages/@quent/components/src/dag/layout.ts
+++ b/ui/packages/@quent/components/src/dag/layout.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { graph, sugiyama } from 'd3-dag';
+import ELK from 'elkjs';
+import type { Node, Edge } from '@xyflow/react';
+
+export const NODE_LAYOUT_WIDTH = 200;
+const NODE_LAYOUT_HEIGHT = 60;
+const NODE_SPACING = 50;
+const LAYER_SPACING = 100;
+
+export type LayoutEngine = 'd3-dag' | 'elk';
+
+const D3_NODE_SIZE = [
+  NODE_LAYOUT_WIDTH + NODE_SPACING,
+  NODE_LAYOUT_HEIGHT + LAYER_SPACING,
+] as const;
+
+async function layoutWithD3Dag<TData extends Record<string, unknown>>(
+  nodes: Node<TData>[],
+  edges: Edge[]
+): Promise<{ nodes: Node<TData>[]; edges: Edge[] }> {
+  const grf = graph<string, undefined>();
+  const nodeById = new Map<string, ReturnType<typeof grf.node>>();
+  for (const n of nodes) nodeById.set(n.id, grf.node(n.id));
+  for (const e of edges) {
+    const src = nodeById.get(e.source);
+    const tgt = nodeById.get(e.target);
+    if (src && tgt) grf.link(src, tgt, undefined);
+  }
+
+  // sugiyama is synchronous and top-to-bottom by default (matches ELK DOWN)
+  sugiyama().nodeSize(D3_NODE_SIZE)(grf);
+
+  // d3-dag reports node centers; ReactFlow expects top-left
+  const posMap = new Map<string, { x: number; y: number }>();
+  for (const node of grf.nodes()) {
+    posMap.set(node.data, {
+      x: (node.x ?? 0) - NODE_LAYOUT_WIDTH / 2,
+      y: (node.y ?? 0) - NODE_LAYOUT_HEIGHT / 2,
+    });
+  }
+
+  return {
+    nodes: nodes.map(n => ({ ...n, position: posMap.get(n.id) ?? { x: 0, y: 0 } })),
+    edges,
+  };
+}
+
+// ---- ELK -------------------------------------------------------------------
+
+const elk = new ELK();
+
+const elkOptions = {
+  'elk.algorithm': 'layered',
+  'elk.direction': 'DOWN',
+  'elk.layered.spacing.nodeNodeBetweenLayers': `${LAYER_SPACING}`,
+  'elk.spacing.nodeNode': `${NODE_SPACING}`,
+};
+
+async function layoutWithElk<TData extends Record<string, unknown>>(
+  nodes: Node<TData>[],
+  edges: Edge[]
+): Promise<{ nodes: Node<TData>[]; edges: Edge[] }> {
+  const elkGraph = {
+    id: 'root',
+    layoutOptions: elkOptions,
+    children: nodes.map(n => ({
+      id: n.id,
+      width: NODE_LAYOUT_WIDTH,
+      height: NODE_LAYOUT_HEIGHT,
+    })),
+    edges: edges.map(e => ({
+      id: e.id,
+      sources: [e.source],
+      targets: [e.target],
+    })),
+  };
+
+  const layout = await elk.layout(elkGraph);
+
+  return {
+    nodes:
+      layout.children?.map((child, i) => ({
+        ...nodes[i]!,
+        position: { x: child.x ?? 0, y: child.y ?? 0 },
+      })) ?? [],
+    edges,
+  };
+}
+
+// ---- Public API ------------------------------------------------------------
+
+export async function calculateLayout<TData extends Record<string, unknown>>(
+  nodes: Node<TData>[],
+  edges: Edge[],
+  engine: LayoutEngine = 'd3-dag'
+): Promise<{ nodes: Node<TData>[]; edges: Edge[] }> {
+  return engine === 'elk' ? layoutWithElk(nodes, edges) : layoutWithD3Dag(nodes, edges);
+}

--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -164,6 +164,7 @@ export { ResourceTimeline } from './timeline/ResourceTimeline';
 
 // ─── DAG components ───────────────────────────────────────────────────────────
 export { DAGChart } from './dag/DAGChart';
+export type { LayoutEngine } from './dag/layout';
 export { DAGControls } from './dag/DAGControls';
 export { DAGLegend } from './dag/DAGLegend';
 export { DAGNodeInfoPanel } from './dag/DAGNodeInfoPanel';

--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -164,7 +164,6 @@ export { ResourceTimeline } from './timeline/ResourceTimeline';
 
 // ─── DAG components ───────────────────────────────────────────────────────────
 export { DAGChart } from './dag/DAGChart';
-export type { LayoutEngine } from './dag/layout';
 export { DAGControls } from './dag/DAGControls';
 export { DAGLegend } from './dag/DAGLegend';
 export { DAGNodeInfoPanel } from './dag/DAGNodeInfoPanel';

--- a/ui/packages/@quent/components/src/lib/echarts.ts
+++ b/ui/packages/@quent/components/src/lib/echarts.ts
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Custom ECharts build with only the modules we need.
- * This significantly reduces bundle size (~1MB → ~300KB).
- *
- * To add new chart types or features, import and register them here.
+ * Custom ECharts build — only SVGRenderer + LineChart + CustomChart + the components we actually use.
+ * To add chart types or features, import and register them here.
  * See: https://echarts.apache.org/handbook/en/basics/import
  */
 
@@ -18,60 +16,41 @@ import type { LineSeriesOption, CustomSeriesOption } from 'echarts/charts';
 
 // Components - only import what you use
 import {
-  TitleComponent,
   TooltipComponent,
   GridComponent,
   DataZoomComponent,
   DataZoomInsideComponent,
   DataZoomSliderComponent,
-  ToolboxComponent,
   MarkAreaComponent,
-  VisualMapComponent,
 } from 'echarts/components';
 import type {
-  TitleComponentOption,
   TooltipComponentOption,
   GridComponentOption,
   DataZoomComponentOption,
-  ToolboxComponentOption,
   MarkAreaComponentOption,
-  VisualMapComponentOption,
 } from 'echarts/components';
 
-// Renderers - timeline charts opt into SVG, while canvas remains available for heavier charts.
-import { CanvasRenderer, SVGRenderer } from 'echarts/renderers';
+import { SVGRenderer } from 'echarts/renderers';
 
-// Register the required components
 echarts.use([
-  // Charts
   LineChart,
   CustomChart,
-  // Components
-  TitleComponent,
   TooltipComponent,
   GridComponent,
   DataZoomComponent,
   DataZoomInsideComponent,
   DataZoomSliderComponent,
-  ToolboxComponent,
   MarkAreaComponent,
-  VisualMapComponent,
-  // Renderer
-  CanvasRenderer,
   SVGRenderer,
 ]);
 
-// Compose the option type from the components we use
 export type EChartsOption = ComposeOption<
   | LineSeriesOption
   | CustomSeriesOption
-  | TitleComponentOption
   | TooltipComponentOption
   | GridComponentOption
   | DataZoomComponentOption
-  | ToolboxComponentOption
   | MarkAreaComponentOption
-  | VisualMapComponentOption
 >;
 
 // Re-export echarts instance and types

--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import ReactEChartsComponent from 'echarts-for-react';
+import EChartsReactCore from 'echarts-for-react/lib/core';
 
 import type { EChartsOption } from '../lib/echarts';
 import type { EChartsInstance } from 'echarts-for-react';
@@ -373,7 +373,7 @@ export function OperatorGanttChart({
 
   return (
     <HiddenScroll ref={wrapperRef} style={{ height: wrapperHeight }}>
-      <ReactEChartsComponent
+      <EChartsReactCore
         echarts={echarts}
         theme={themeName}
         option={option}

--- a/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
+++ b/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
@@ -45,7 +45,7 @@ export interface QueryPlanNodeData extends Record<string, unknown> {
 }
 
 const nodeVariants = cva(
-  'px-4 py-2 rounded-md border-1 min-w-[180px] max-w-[250px] transition cursor-pointer text-foreground z-10 nodrag nopan',
+  'w-full px-4 py-2 rounded-md border-1 transition cursor-pointer text-foreground z-10 nodrag nopan',
   {
     variants: {
       selected: {

--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import ReactEChartsComponent from 'echarts-for-react';
+import EChartsReactCore from 'echarts-for-react/lib/core';
 import { echarts } from '../lib/echarts';
 import type { EChartsOption } from '../lib/echarts';
 import type { LineSeriesOption } from 'echarts/charts';
@@ -247,9 +247,6 @@ export function Timeline({
         trigger: 'axis',
         transitionDuration: 0,
       },
-      title: {
-        left: 'center',
-      },
       axisPointer: {
         link: [{ xAxisIndex: 'all' }],
       },
@@ -434,7 +431,7 @@ export function Timeline({
           {formatAxisValue(maxValue)}
         </span>
       )}
-      <ReactEChartsComponent
+      <EChartsReactCore
         echarts={echarts}
         theme={themeName}
         opts={opts}

--- a/ui/packages/@quent/components/src/timeline/TimelineController.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineController.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ReactEChartsComponent from 'echarts-for-react';
+import EChartsReactCore from 'echarts-for-react/lib/core';
 import { echarts } from '../lib/echarts';
 import type { EChartsOption } from '../lib/echarts';
 import type { EChartsInstance } from 'echarts-for-react';
@@ -357,7 +357,7 @@ export function TimelineController({
   const opts = useMemo(() => ({ renderer: 'svg' }) as Opts, []);
 
   return (
-    <ReactEChartsComponent
+    <EChartsReactCore
       echarts={echarts}
       theme={themeName}
       option={eChartOptions}

--- a/ui/packages/@quent/components/src/timeline/TimelineRuler.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineRuler.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useMemo } from 'react';
-import ReactEChartsComponent from 'echarts-for-react';
+import EChartsReactCore from 'echarts-for-react/lib/core';
 import { echarts } from '../lib/echarts';
 import type { EChartsOption } from '../lib/echarts';
 import { useZoomRange } from '@quent/hooks';
@@ -143,7 +143,7 @@ export function TimelineRuler({ startTime, isDark, mode = 'relative' }: Timeline
   ]);
 
   return (
-    <ReactEChartsComponent
+    <EChartsReactCore
       echarts={echarts}
       theme={themeName}
       option={option}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -247,9 +247,6 @@ importers:
       echarts-for-react:
         specifier: ^3.0.6
         version: 3.0.6(echarts@5.6.0)(react@19.2.4)
-      elkjs:
-        specifier: ^0.11.1
-        version: 0.11.1
       jotai:
         specifier: ^2.0.0
         version: 2.18.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4)

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      d3-dag:
+        specifier: ^1.2.1
+        version: 1.2.1
       echarts:
         specifier: ^5.6.0
         version: 5.6.0
@@ -1920,6 +1923,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  convert-hrtime@5.0.0:
+    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
+    engines: {node: '>=12'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1951,9 +1958,16 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
+
+  d3-dag@1.2.1:
+    resolution: {integrity: sha512-EMctxrHEOccjqrSRwQcjj3VKBEOtwoN0xCA8XtOYKKJii2B8XZqi9Yp2iVRcm6J/jZBzX+6fnihWGk+YuERDjA==}
 
   d3-dispatch@3.0.1:
     resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
@@ -2207,6 +2221,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-timeout@1.0.2:
+    resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
+    engines: {node: '>=18'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2218,6 +2236,10 @@ packages:
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-own-enumerable-keys@1.0.0:
+    resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
+    engines: {node: '>=14.16'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2269,6 +2291,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  identifier-regex@1.0.1:
+    resolution: {integrity: sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==}
+    engines: {node: '>=18'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2288,6 +2314,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -2310,6 +2340,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-identifier@1.0.1:
+    resolution: {integrity: sha512-HQ5v4rEJ7REUV54bCd2l5FaD299SGDEn2UPoVXaTHAyGviLq2menVUD2udi3trQ32uvB6LdAh/0ck2EuizrtpA==}
+    engines: {node: '>=18'}
+
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -2317,8 +2351,16 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -2342,6 +2384,9 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  javascript-lp-solver@1.0.3:
+    resolution: {integrity: sha512-+qUYrubmn227YTz25uf9wOTlgB3wFKGtutECxL1shjOkgi/Tcn3SpnC7+T9rxhv/JNOxLIfZ3O6wEx0FwLlXbw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2541,6 +2586,10 @@ packages:
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
+  make-asynchronous@1.1.0:
+    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
+    engines: {node: '>=18'}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -2615,6 +2664,10 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  p-event@6.0.1:
+    resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
+    engines: {node: '>=16.17'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2622,6 +2675,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -2705,6 +2762,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  quadprog@1.6.1:
+    resolution: {integrity: sha512-fN5Jkcjlln/b3pJkseDKREf89JkKIyu6cKIVXisgL6ocKPQ0yTp9n6NZUAq3otEPPw78WZMG9K0o9WsfKyMWJw==}
+    engines: {node: '>=8.x'}
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -2776,6 +2837,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2885,6 +2950,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  stringify-object@6.0.0:
+    resolution: {integrity: sha512-6f94vIED6vmJJfh3lyVsVWxCYSfI5uM+16ntED/Ql37XIyV6kj0mRAAiTeMMc/QLYIaizC3bUprQ8pQnDDrKfA==}
+    engines: {node: '>=20'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2901,6 +2970,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  super-regex@1.1.0:
+    resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2938,6 +3011,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  time-span@5.1.0:
+    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
+    engines: {node: '>=12'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3023,6 +3100,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   type-fest@5.4.4:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
@@ -3164,6 +3245,9 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -4835,6 +4919,8 @@ snapshots:
 
   consola@3.4.2: {}
 
+  convert-hrtime@5.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@2.0.0: {}
@@ -4865,7 +4951,18 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
   d3-color@3.1.0: {}
+
+  d3-dag@1.2.1:
+    dependencies:
+      d3-array: 3.2.4
+      javascript-lp-solver: 1.0.3
+      quadprog: 1.6.1
+      stringify-object: 6.0.0
 
   d3-dispatch@3.0.1: {}
 
@@ -5126,11 +5223,15 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-timeout@1.0.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
   get-nonce@1.0.1: {}
+
+  get-own-enumerable-keys@1.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -5178,6 +5279,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  identifier-regex@1.0.1:
+    dependencies:
+      reserved-identifiers: 1.2.0
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5190,6 +5295,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  internmap@2.0.3: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -5205,11 +5312,20 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-identifier@1.0.1:
+    dependencies:
+      identifier-regex: 1.0.1
+      super-regex: 1.1.0
+
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
+  is-obj@3.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-regexp@3.1.0: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -5231,6 +5347,8 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  javascript-lp-solver@1.0.3: {}
 
   jiti@2.6.1: {}
 
@@ -5389,6 +5507,12 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
+  make-asynchronous@1.1.0:
+    dependencies:
+      p-event: 6.0.1
+      type-fest: 4.41.0
+      web-worker: 1.5.0
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
@@ -5476,6 +5600,10 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  p-event@6.0.1:
+    dependencies:
+      p-timeout: 6.1.4
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -5483,6 +5611,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-timeout@6.1.4: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -5543,6 +5673,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  quadprog@1.6.1: {}
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -5600,6 +5732,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reserved-identifiers@1.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -5699,6 +5833,13 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  stringify-object@6.0.0:
+    dependencies:
+      get-own-enumerable-keys: 1.0.0
+      is-identifier: 1.0.1
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5718,6 +5859,12 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  super-regex@1.1.0:
+    dependencies:
+      function-timeout: 1.0.2
+      make-asynchronous: 1.1.0
+      time-span: 5.1.0
 
   supports-color@7.2.0:
     dependencies:
@@ -5748,6 +5895,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  time-span@5.1.0:
+    dependencies:
+      convert-hrtime: 5.0.0
 
   tiny-invariant@1.3.3: {}
 
@@ -5827,6 +5978,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   type-fest@5.4.4:
     dependencies:
@@ -5941,6 +6094,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-worker@1.5.0: {}
 
   webidl-conversions@8.0.1: {}
 


### PR DESCRIPTION
* Shaving echarts down, remove unused stuff
* Replace elkjs (one giant transpiled from java bundle) with [d3-dag](https://github.com/erikbrinkman/d3-dag) which is tree-shakeable, can do much the same layout algorithms

📓 Can use `pnpm stats` to see the grid tree diagram

Old:
```
dist/index.html                           0.68 kB │ gzip:   0.36 kB
dist/assets/index-BZV40eAE.css           15.85 kB │ gzip:   2.66 kB
dist/assets/index-9HxSGAUS.css           51.68 kB │ gzip:   9.18 kB
dist/assets/react-vendor-l0sNRNKZ.js      0.00 kB │ gzip:   0.02 kB
dist/assets/tanstack-BqyRUkjq.js        129.40 kB │ gzip:  41.23 kB
dist/assets/xyflow-BxH6U5Q4.js          174.62 kB │ gzip:  57.11 kB
dist/assets/index-C1GOA13Q.js           640.68 kB │ gzip: 203.97 kB
dist/assets/echarts-9vs-I123.js       1,026.20 kB │ gzip: 339.02 kB
dist/assets/index-Bdtl4WFg.js         1,463.97 kB │ gzip: 448.07 kB
```

New:
```
dist/index.html                         0.68 kB │ gzip:   0.36 kB
dist/assets/index-BZV40eAE.css         15.85 kB │ gzip:   2.66 kB
dist/assets/index-Da0mS7Fh.css         51.62 kB │ gzip:   9.16 kB
dist/assets/react-vendor-l0sNRNKZ.js    0.00 kB │ gzip:   0.02 kB
dist/assets/index-3PlP4Ya-.js         113.46 kB │ gzip:  38.84 kB
dist/assets/tanstack-BBqlz-CG.js      129.80 kB │ gzip:  41.32 kB
dist/assets/xyflow-CwW_-K14.js        174.62 kB │ gzip:  57.11 kB
dist/assets/echarts-6P77CYjS.js       555.96 kB │ gzip: 188.63 kB
dist/assets/index-CSZrf8mO.js         619.86 kB │ gzip: 194.87 kB
```




Chunk | Old | New | Saved (raw) | Saved (gzip)
-- | -- | -- | -- | --
echarts | 1,026 kB (339 kB gz) | 556 kB (189 kB gz) | -470 kB (-46%) | -150 kB gz (-44%)
main index | 1,464 kB + 641 kB (652 kB gz) | 620 kB + 113 kB (234 kB gz) | -1,371 kB (-65%) | -418 kB gz (-64%)



