### PR TITLE
ci: use official setup-pixi action

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -38,13 +38,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: curl -fsSL https://pixi.sh/install.sh | bash && echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          path: .pixi/
-          key: ${{ runner.os }}-pixi-${{ hashFiles('pixi.lock') }}
-          restore-keys: ${{ runner.os }}-pixi-
-      - run: pixi install
+          cache: true
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,13 +40,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: curl -fsSL https://pixi.sh/install.sh | bash && echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          path: .pixi/
-          key: ${{ runner.os }}-pixi-${{ hashFiles('pixi.lock') }}
-          restore-keys: ${{ runner.os }}-pixi-
-      - run: pixi install
+          cache: true
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,13 +37,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - run: curl -fsSL https://pixi.sh/install.sh | bash && echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          path: .pixi/
-          key: ${{ runner.os }}-pixi-${{ hashFiles('pixi.lock') }}
-          restore-keys: ${{ runner.os }}-pixi-
-      - run: pixi install
+          cache: true
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |


### PR DESCRIPTION
## Summary

Switch the Rust, Python, and C++ workflows from the manual pixi setup
(`curl … pixi.sh/install.sh | bash` + `actions/cache` + `pixi install`) to the
official [`prefix-dev/setup-pixi`](https://github.com/prefix-dev/setup-pixi)
action.

The single action step replaces the previous three steps, relying on the
action's defaults:

- `cache: true` — caches the environment keyed on `pixi.lock` (replaces the manual `.pixi/` `actions/cache` step)
- `run-install: true` (default) — runs `pixi install`
- `locked: true` (default, since `pixi.lock` is present) — runs `pixi install --locked`, consistent with the repo's `cargo --locked` / `pnpm --frozen-lockfile` conventions

The separate cargo registry/git caches (and the `cargo-deny` cache) are left
untouched. All commands continue to invoke `pixi run …` explicitly, so no
environment activation is required.

## Notes

- SHA-pinned to `v0.9.6` to satisfy the `zizmor` `unpinned-uses: hash-pin` policy.
- `pixi-version` is intentionally left unpinned to preserve the prior behavior (the install script installed the latest pixi). It can be pinned later for fully reproducible pixi installs.
- **Behavior change worth flagging:** the action defaults to `--locked`, whereas the old `pixi install` did not. If `pixi.lock` ever drifts from `pixi.toml`, these jobs now fail fast instead of silently updating the lockfile (the desirable CI behavior).

---

🤖 This PR was authored by an AI agent (Claude Code) on behalf of @mbrobbel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
