### PR TITLE
docs(new-arch): Draft version of the evolving arch of current crates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,22 @@ See the [FAQ](./faq.md) for detailed comparisons.
 The current focus is on query engines, but the modeling
 concepts are domain-agnostic and may be applied to other domains.
 
+## Schema crate internals
+
+The five foundational schema crates (`quent-schema`, `quent-constraints`,
+`quent-fsm`, `quent-ref-target`, `quent-ref-tree`) form the layer on which
+all modeling and instrumentation is built. Two documents cover them in depth:
+
+- [**Crate Architecture**](./crate-architecture.md) — the complete picture:
+  how the five crates fit together, the two-layer design, constraint
+  composition, single-pass validation, and a full Kubernetes platform example
+  showing FSM order, ref-target, and ref-tree working together in one
+  `validate()` call.
+- [**`quent-ref-tree` explained**](./ref-tree-explained.md) — a focused
+  deep-dive into `quent-ref-tree`: its five requirements, the internal
+  entity/event/record graph it builds, the `finish()` collapse algorithm, and
+  the full error taxonomy.
+
 For development instructions and repository overview, see the
 [root README](../README.md).
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,6 +4,9 @@
 
 - [Event Model](./event_model.md)
 - [FAQ](./faq.md)
+- [Schema Crate Internals](./crate-architecture.md)
+  - [Crate Architecture](./crate-architecture.md)
+  - [quent-ref-tree explained](./ref-tree-explained.md)
 - [Modeling Concepts](./modeling/README.md)
   - [Attributes](./modeling/attributes.md)
   - [Time-related concepts](./modeling/time.md)

--- a/docs/crate-architecture.md
+++ b/docs/crate-architecture.md
@@ -1,0 +1,892 @@
+# Quent Schema Crate Architecture
+
+A guided tour of the five foundational crates — `quent-schema`,
+`quent-constraints`, `quent-fsm`, `quent-ref-target`, and `quent-ref-tree` —
+covering their design, how they interplay at runtime, and how to wire them
+together using a real-world Kubernetes platform example.
+
+> **Companion reading.** This document explains the full five-crate system.
+> For a deep-dive into `quent-ref-tree` specifically — its algorithm, internal
+> graph, and error taxonomy — see
+> [`ref-tree-explained.md`](./ref-tree-explained.md).
+
+---
+
+## 1. The five crates at a glance
+
+```mermaid
+graph TD
+    schema["quent-schema\n─────────────\nData model: Schema, Entity,\nEvent, Record, Field, DataType\nVisitor walk + Cursor"]
+    constraints["quent-constraints\n─────────────\nConstraint trait (named Visitor)\nvalidate() orchestrator\nReport"]
+    fsm["quent-fsm\n─────────────\nFSM topology constraint\nEvent-order rules per entity"]
+    reftarget["quent-ref-target\n─────────────\nEntityRef target constraint\nReference points at real entity"]
+    reftree["quent-ref-tree\n─────────────\nTree-structure constraint\nReferences form one rooted tree"]
+
+    constraints --> schema
+    fsm --> schema
+    fsm --> constraints
+    reftarget --> schema
+    reftarget --> constraints
+    reftree --> schema
+    reftree --> constraints
+    reftree -. "requires (tree-ref\nmust be target-constrained)" .-> reftarget
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class schema,constraints core;
+    class fsm,reftarget,reftree cons;
+```
+
+| Crate | Role | Depends on |
+| --- | --- | --- |
+| `quent-schema` | Dumb data model + Visitor walk | — |
+| `quent-constraints` | Constraint trait + `validate()` orchestrator | `quent-schema` |
+| `quent-fsm` | Enforces valid event ordering per entity | `quent-schema`, `quent-constraints` |
+| `quent-ref-target` | Validates that an `EntityRef` names a real entity | `quent-schema`, `quent-constraints` |
+| `quent-ref-tree` | Validates that tree-forming refs form one rooted tree | `quent-schema`, `quent-constraints`, *(reads)* `quent-ref-target` |
+
+---
+
+## 2. The two-layer design
+
+```mermaid
+graph LR
+    subgraph layer1["Layer 1 · Foundation (stable, dumb)"]
+        direction TB
+        schema_data["Schema\nEntity · Event · Record\nField · DataType · Annotations"]
+        visitor["Visitor trait\nCursor walk\nSchema::walk()"]
+        schema_data ~~~ visitor
+    end
+
+    subgraph layer2["Layer 2 · Rules (pluggable, independent)"]
+        direction TB
+        c_trait["Constraint trait\n= Visitor + NAME"]
+        validate["validate::<(A,B,C)>()\nOne walk · one Report"]
+        fsm2["FsmConstraint"]
+        rt2["RefTargetConstraint"]
+        rtr2["RefTreeConstraint"]
+        c_trait ~~~ validate ~~~ fsm2 ~~~ rt2 ~~~ rtr2
+    end
+
+    layer1 -->|"provides the walk"| layer2
+
+    classDef found fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef rule fill:#2da44e,stroke:#136229,color:#fff;
+    class layer1 found;
+    class layer2 rule;
+```
+
+**Key insight.** The schema data model never learns domain rules. All domain
+knowledge — "events must follow this order", "this reference must point at a
+real entity", "these references must form a tree" — lives exclusively in
+`Layer 2` crates. You add new rules by adding new crates; `quent-schema` never
+changes.
+
+---
+
+## 3. `quent-schema` — the data model
+
+### 3.1 Structure
+
+```mermaid
+classDiagram
+    class Schema {
+        name: Identifier
+        entities: Map
+        records: Map
+        annotations: Annotations
+    }
+    class Entity {
+        name: Identifier
+        events: Map
+        annotations: Annotations
+    }
+    class Event {
+        name: Identifier
+        cardinality: Once | Multi
+        payload: Map~Field~
+        annotations: Annotations
+    }
+    class Record {
+        name: Identifier
+        fields: Map
+        annotations: Annotations
+    }
+    class Field {
+        name: Identifier
+        ty: DataType
+        annotations: Annotations
+    }
+    class DataType {
+        Bool · U8‥U64 · I8‥I64
+        F32 · F64 · String · Uuid
+        Option(DataType)
+        List(DataType)
+        Record(Identifier)
+        DynamicRecord
+        EntityRef
+    }
+    class Annotations {
+        docs: Option~String~
+        constraints: Map~name → Constraint~
+        metadata: Map
+    }
+
+    Schema "1" o-- "*" Entity
+    Schema "1" o-- "*" Record
+    Entity "1" o-- "*" Event
+    Event "1" o-- "*" Field
+    Record "1" o-- "*" Field
+    Field "1" --> "1" DataType
+    Schema ..> Annotations
+    Entity ..> Annotations
+    Event ..> Annotations
+    Field ..> Annotations
+    Record ..> Annotations
+    DataType ..> Annotations : EntityRef carries its own
+```
+
+### 3.2 The Visitor walk
+
+`Schema::walk(visitor)` performs a **depth-first** traversal, calling
+`visitor.visit(&cursor)` at every node *before* its children. The `Cursor`
+carries the complete path from the schema root so a visitor always knows
+*where* it is.
+
+```mermaid
+graph TD
+    S["Schema"]
+    S --> SA["Annotations"]
+    S --> E["Entity"]
+    E --> EA["Annotations"]
+    E --> EV["Event"]
+    EV --> EVA["Annotations"]
+    EV --> F["Field → DataType"]
+    F --> ER["EntityRef\n(inline annotations)"]
+    F --> RC["Record(name)\n→ pointer, not inlined"]
+    S --> R["Record (visited once, top-level)"]
+    R --> RF["Field → DataType …"]
+
+    classDef schema fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef hot fill:#bf3989,stroke:#6e1f50,color:#fff;
+    class S,E,EV,R schema;
+    class ER,RC hot;
+```
+
+> **Record walk nuance.** A `Record(name)` field is a *pointer*; the walker
+> does **not** descend into the referenced record at the field site. Each
+> top-level `Record` is visited exactly once from `Schema::records`. Constraints
+> that need to "follow" records (like `quent-ref-tree`) must build their own
+> linking graph during the walk.
+
+---
+
+## 4. `quent-constraints` — the trait and the orchestrator
+
+### 4.1 What a Constraint is
+
+```mermaid
+classDiagram
+    class Visitor {
+        <<trait — quent-schema>>
+        type Output
+        visit(cursor: &Cursor)
+        finish() → Output
+    }
+    class Constraint {
+        <<trait — quent-constraints>>
+        const NAME: &'static str
+    }
+    Constraint --|> Visitor : requires Visitor + Default
+
+    class FsmConstraint {
+        NAME = "quent.fsm.v1"
+    }
+    class RefTargetConstraint {
+        NAME = "quent.ref-target.v1"
+    }
+    class RefTreeConstraint {
+        NAME = "quent.ref-tree.v1"
+    }
+
+    FsmConstraint ..|> Constraint
+    RefTargetConstraint ..|> Constraint
+    RefTreeConstraint ..|> Constraint
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class Visitor,Constraint core;
+    class FsmConstraint,RefTargetConstraint,RefTreeConstraint cons;
+```
+
+A `Constraint` is exactly **a `Visitor` with a unique string name**. The name
+is the same key used in the schema's `Annotations::constraints` map
+(`"quent.fsm.v1"`, `"quent.ref-tree.v1"`, …), so the orchestrator can match
+annotations to constraint implementations.
+
+### 4.2 Single-pass validation
+
+`validate::<(A, B, C)>(&schema)` composes all constraints — plus two built-in
+checks — into a tuple visitor and walks the schema **exactly once**.
+
+```mermaid
+sequenceDiagram
+    participant U as Caller
+    participant V as validate::<(Fsm, RefTree, RefTarget)>
+    participant W as Schema::walk
+    participant Bi as built-in checks
+    participant Fsm as FsmConstraint
+    participant RT as RefTreeConstraint
+    participant TG as RefTargetConstraint
+
+    U->>V: validate(&schema)
+    V->>W: walk( (UnresolvedRefs + Unregistered + (Fsm, RefTree, RefTarget)) )
+
+    loop every element, depth-first
+        W->>Bi: visit(cursor)
+        W->>Fsm: visit(cursor)
+        W->>RT: visit(cursor)
+        W->>TG: visit(cursor)
+    end
+
+    W->>Fsm: finish() → check state graph
+    W->>RT: finish() → check_tree()
+    W->>TG: finish()
+    W-->>V: outputs tuple
+    V-->>U: Report { unregistered, invalid_references, results }
+```
+
+**Always-on built-ins** (not optional):
+
+| Built-in | What it checks |
+| --- | --- |
+| `UnresolvedReferences` | Every `Record(name)` field resolves to a real top-level record |
+| `UnregisteredConstraints` | Annotation names in the schema that were *not* passed to `validate` |
+
+The single-walk design is why each constraint is a `Visitor`: the orchestrator
+just puts them in a tuple and hands the tuple to the walker.
+
+---
+
+## 5. `quent-ref-target` — the prerequisite constraint
+
+`ref-target` answers one narrow question:
+
+> **"This `EntityRef` claims to point at entity `T` — does `T` exist in the schema?"**
+
+```mermaid
+graph LR
+    ER["EntityRef\nannotations"]
+    ER -->|"quent.ref-target.v1\n= &quot;Cluster&quot;"| RT["RefTarget(Identifier)"]
+    RT -->|"schema.entity(&quot;Cluster&quot;)?"| OK{exists?}
+    OK -->|yes| PASS["✅ OK"]
+    OK -->|no| ERR["❌ UnknownTarget"]
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    classDef err fill:#cf222e,stroke:#82071e,color:#fff;
+    class ER core;
+    class RT,OK,PASS cons;
+    class ERR err;
+```
+
+`ref-target` is the **prerequisite** for `ref-tree`. You cannot build a typed
+tree out of references that do not even name a valid entity type.
+
+---
+
+## 6. `quent-fsm` — the event-order constraint
+
+`fsm` answers one narrow question:
+
+> **"Do the events of this entity follow the declared FSM topology?"**
+
+It reads an FSM topology from the entity's annotations, builds a state graph
+(via petgraph), and validates:
+
+- Every declared state is reachable from the initial state.
+- There are no isolated cycles that can never be escaped.
+- The topology itself is consistent (no dangling transitions, no duplicate
+  states).
+
+```mermaid
+graph LR
+    EA["Entity\nannotations"]
+    EA -->|"quent.fsm.v1\n= topology JSON"| FSM["FsmConstraint\nstate graph (petgraph)"]
+    FSM -->|"Bfs + tarjan_scc"| CHK{valid?}
+    CHK -->|yes| PASS2["✅ OK"]
+    CHK -->|no| ERR2["❌ FsmError"]
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    classDef err fill:#cf222e,stroke:#82071e,color:#fff;
+    class EA core;
+    class FSM,CHK,PASS2 cons;
+    class ERR2 err;
+```
+
+---
+
+## 7. `quent-ref-tree` — the tree-structure constraint
+
+`ref-tree` answers one narrow question:
+
+> **"Do the entity references annotated as tree-forming together describe a
+> single tree rooted at exactly one entity?"**
+
+Its five requirements:
+
+```mermaid
+graph TD
+    R1["Req 1 · Exactly ONE root\n(an entity whose events carry no tree-ref)"]
+    R2["Req 2 · Each non-root entity has\n≤1 tree-ref per event / record"]
+    R3["Req 3 · Every tree-ref must also\nbe target-constrained (ref-target)"]
+    R4["Req 4 · All of one entity's tree-refs\npoint at the SAME parent type"]
+    R5["Req 5 · Every entity can follow\ntree-refs up to the root"]
+
+    R3 --> R1
+    R2 --> R4
+    R1 --> R4
+    R4 --> R5
+
+    classDef req fill:#2da44e,stroke:#136229,color:#fff;
+    class R1,R2,R3,R4,R5 req;
+```
+
+Because the `Record` walk nuance (§3.2) means records aren't followed inline,
+`ref-tree` builds its own internal directed graph during the walk and collapses
+it in `finish()`:
+
+```mermaid
+flowchart TD
+    start([finish called]) --> used{any tree-ref\nactually used?}
+    used -->|no| ok0([✅ Ok — no tree to form])
+    used -->|yes| bad{any NotTargetConstrained\nor UnknownTarget?}
+    bad -->|yes| rep([report those errors only])
+    bad -->|no| col[For each entity:\nwalk events + records → unique parent entities]
+
+    col --> cnt{unique parents\nper entity?}
+    cnt -->|0| root[mark as root]
+    cnt -->|1| child[mark non-root,\nadd parent→child edge]
+    cnt -->|2+| conf[❌ ConflictingParents · Req 4]
+
+    root --> roots{how many roots?}
+    roots -->|0| nr[❌ NoRoot · Req 1]
+    roots -->|2+| mr[❌ MultipleRoots · Req 1]
+    roots -->|1| bfs[BFS from root over\ncollapsed entity tree]
+    child --> bfs
+
+    bfs --> reach{every non-root\nreached?}
+    reach -->|no| unr[❌ Unreachable · Req 5]
+    reach -->|yes| done([✅ Ok — valid tree])
+
+    classDef ok fill:#2da44e,stroke:#136229,color:#fff;
+    classDef err fill:#cf222e,stroke:#82071e,color:#fff;
+    class ok0,done,bfs ok;
+    class rep,conf,nr,mr,unr err;
+```
+
+---
+
+## 8. How the crates interplay at runtime
+
+### 8.1 Constraint composition
+
+All three constraints are `Visitor + Constraint`. They compose into a tuple
+and are passed to `Schema::walk` in a **single pass**:
+
+```mermaid
+graph LR
+    subgraph schema_box["quent-schema (one walk)"]
+        W["Schema::walk"]
+    end
+
+    subgraph constraints_box["quent-constraints (orchestrates)"]
+        VAL["validate::<(Fsm, RefTree, RefTarget)>"]
+        BI["built-in checks\n(UnresolvedRefs, Unregistered)"]
+    end
+
+    subgraph impls_box["constraint impls (execute in lock-step)"]
+        FSM["FsmConstraint\n• reads Entity annotations\n• builds per-entity state graph"]
+        RTR["RefTreeConstraint\n• reads EntityRef annotations\n• builds entity/event/record graph"]
+        TGT["RefTargetConstraint\n• reads EntityRef annotations\n• verifies entity name exists"]
+    end
+
+    VAL -->|one walk| W
+    W --> BI
+    W --> FSM
+    W --> RTR
+    W --> TGT
+
+    FSM -->|"finish()"| FSMOut["Result&lt;(), FsmError&gt;"]
+    RTR -->|"finish()"| RTROut["Result&lt;(), RefTreeError&gt;"]
+    TGT -->|"finish()"| TGTOut["Result&lt;(), RefTargetError&gt;"]
+
+    FSMOut & RTROut & TGTOut --> REP["Report { results: (Fsm, RefTree, RefTarget) }"]
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class schema_box,W,VAL,BI core;
+    class FSM,RTR,TGT,FSMOut,RTROut,TGTOut,REP cons;
+```
+
+### 8.2 `ref-tree` depends on `ref-target` (not on the constraint, but on its data)
+
+`ref-tree` does not *call* `RefTargetConstraint` during its walk. Instead, it
+**reads the same annotation data** that `ref-target` writes, using the shared
+`RefTarget::from_annotations(...)` helper. This is why requirement 3 exists:
+if a tree-forming `EntityRef` lacks the `ref-target` annotation, `ref-tree`
+has no parent to point at.
+
+```mermaid
+graph LR
+    ANN["EntityRef Annotations\nquent.ref-tree.v1 = marker\nquent.ref-target.v1 = &quot;Node&quot;"]
+    ANN -->|"read by"| RTR2["RefTreeConstraint\nuses target identifier\nto build internal graph"]
+    ANN -->|"read by"| TGT2["RefTargetConstraint\nverifies &quot;Node&quot; exists\nin schema.entities"]
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class ANN core;
+    class RTR2,TGT2 cons;
+```
+
+### 8.3 `fsm` and `ref-tree` are independent peers
+
+They never call each other. Run together, they validate **two orthogonal
+dimensions** of the same schema in one pass:
+
+```mermaid
+graph LR
+    subgraph time_axis["FSM · time axis (how one entity evolves)"]
+        FS["FsmConstraint\n'what events can\nfollow what states'"]
+    end
+    subgraph space_axis["Ref-tree · space axis (how entities relate)"]
+        RT3["RefTreeConstraint\n'who owns whom\nin the hierarchy'"]
+    end
+    SCH["Schema"] --> FS & RT3
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class SCH core;
+    class FS,RT3 cons;
+```
+
+| | `quent-fsm` | `quent-ref-tree` |
+| --- | --- | --- |
+| Validates | **temporal order** of one entity's events | **spatial hierarchy** across all entities |
+| Annotation lives on | `Entity` (FSM topology JSON) | `EntityRef` (marker + target) |
+| Internal model | per-entity state graph (petgraph) | whole-schema entity/event/record graph |
+| Graph algorithm | BFS + Tarjan SCC | DFS collapse + BFS reachability |
+| Output | `Result<(), FsmError>` | `Result<(), RefTreeError>` |
+
+---
+
+## 9. Real-world example: a Kubernetes-style container platform
+
+### 9.1 The domain hierarchy
+
+A container platform has a natural ownership tree. Each entity is *owned by*
+or *part of* its parent:
+
+```mermaid
+graph TD
+    Cluster["Cluster\n(root — owns nothing)"]
+    Node["Node\nis part of a Cluster"]
+    Pod["Pod\nis scheduled on a Node"]
+    Container["Container\nis part of a Pod"]
+
+    Cluster --> Node --> Pod --> Container
+
+    classDef root fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef child fill:#2da44e,stroke:#136229,color:#fff;
+    class Cluster root;
+    class Node,Pod,Container child;
+```
+
+### 9.2 The event lifecycle of each entity (FSM dimension)
+
+Each entity has a defined set of lifecycle events. `quent-fsm` enforces the
+valid ordering:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    state "Cluster" as CL {
+        [*] --> Provisioned : provisioned
+        Provisioned --> Decommissioned : decommissioned
+    }
+    state "Node" as ND {
+        [*] --> Joined : joined
+        Joined --> Drained : drained
+        Joined --> Failed : failed
+        Drained --> [*]
+        Failed --> [*]
+    }
+    state "Pod" as PD {
+        [*] --> Scheduled : scheduled
+        Scheduled --> Running : running
+        Running --> Succeeded : succeeded
+        Running --> Failed2 : failed
+        Succeeded --> [*]
+        Failed2 --> [*]
+    }
+    state "Container" as CT {
+        [*] --> Started : started
+        Started --> Exited : exited
+        Exited --> [*]
+    }
+```
+
+### 9.3 The tree-forming references (ref-tree + ref-target dimension)
+
+Each non-root entity's first event carries a **tree-forming reference** to its
+parent. That field's `EntityRef` is annotated with both `quent.ref-tree.v1`
+(tree-forming marker) and `quent.ref-target.v1` (the parent entity name).
+
+```mermaid
+graph LR
+    subgraph Node_event["Event: Node.joined"]
+        NF["field 'cluster'\ntype: EntityRef\nref-tree.v1 = marker\nref-target.v1 = &quot;Cluster&quot;"]
+    end
+    subgraph Pod_event["Event: Pod.scheduled"]
+        PF["field 'node'\ntype: EntityRef\nref-tree.v1 = marker\nref-target.v1 = &quot;Node&quot;"]
+    end
+    subgraph Container_event["Event: Container.started"]
+        CF["field 'pod'\ntype: EntityRef\nref-tree.v1 = marker\nref-target.v1 = &quot;Pod&quot;"]
+    end
+
+    NF -->|"tree-ref points at"| CL2["Entity: Cluster"]
+    PF -->|"tree-ref points at"| ND2["Entity: Node"]
+    CF -->|"tree-ref points at"| PD2["Entity: Pod"]
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class CL2,ND2,PD2 core;
+    class NF,PF,CF cons;
+```
+
+### 9.4 Building the schema with the builder API
+
+```rust
+use quent_constraints::{validate};
+use quent_ref_target::RefTargetConstraint;
+use quent_ref_tree::{RefTreeConstraint, RefTreeError};
+use quent_fsm::FsmConstraint;
+use quent_schema::{
+    Cardinality, DataType, Identifier,
+    builder::{AnnotationsBuilder, EntityBuilder, EventBuilder, SchemaBuilder},
+};
+
+fn id(s: &str) -> Identifier {
+    Identifier::try_new(s).unwrap()
+}
+
+/// Builds a DataType::EntityRef that is BOTH tree-forming and target-constrained.
+/// Both constraints read from the same annotations map.
+fn parent_ref(parent: &str) -> DataType {
+    let target = serde_json::to_string(&id(parent)).unwrap();
+    DataType::EntityRef {
+        data: None,
+        annotations: AnnotationsBuilder::new()
+            .constraint(RefTreeConstraint::NAME, None)   // tree-forming marker
+            .unwrap()
+            .constraint(RefTargetConstraint::NAME, Some(target)) // target name
+            .unwrap()
+            .build(),
+    }
+}
+
+fn build_platform_schema() -> quent_schema::Schema {
+    // Cluster: the root. No tree-forming refs in any of its events.
+    let cluster = EntityBuilder::new(id("Cluster"))
+        .event(EventBuilder::new(id("provisioned"), Cardinality::Once).build())
+        .unwrap()
+        .event(EventBuilder::new(id("decommissioned"), Cardinality::Once).build())
+        .unwrap()
+        .build();
+
+    // Node: first event carries a tree-ref to Cluster.
+    let node = EntityBuilder::new(id("Node"))
+        .event(
+            EventBuilder::new(id("joined"), Cardinality::Once)
+                .field(quent_schema::Field::new(
+                    id("cluster"),
+                    parent_ref("Cluster"),
+                    Default::default(),
+                ))
+                .unwrap()
+                .build(),
+        )
+        .unwrap()
+        .event(EventBuilder::new(id("drained"), Cardinality::Once).build())
+        .unwrap()
+        .event(EventBuilder::new(id("failed"), Cardinality::Once).build())
+        .unwrap()
+        .build();
+
+    // Pod: tree-ref to Node on its "scheduled" event.
+    let pod = EntityBuilder::new(id("Pod"))
+        .event(
+            EventBuilder::new(id("scheduled"), Cardinality::Once)
+                .field(quent_schema::Field::new(
+                    id("node"),
+                    parent_ref("Node"),
+                    Default::default(),
+                ))
+                .unwrap()
+                .build(),
+        )
+        .unwrap()
+        .event(EventBuilder::new(id("running"), Cardinality::Once).build())
+        .unwrap()
+        .event(EventBuilder::new(id("succeeded"), Cardinality::Once).build())
+        .unwrap()
+        .event(EventBuilder::new(id("failed"), Cardinality::Once).build())
+        .unwrap()
+        .build();
+
+    // Container: tree-ref to Pod on its "started" event.
+    let container = EntityBuilder::new(id("Container"))
+        .event(
+            EventBuilder::new(id("started"), Cardinality::Once)
+                .field(quent_schema::Field::new(
+                    id("pod"),
+                    parent_ref("Pod"),
+                    Default::default(),
+                ))
+                .unwrap()
+                .build(),
+        )
+        .unwrap()
+        .event(EventBuilder::new(id("exited"), Cardinality::Once).build())
+        .unwrap()
+        .build();
+
+    SchemaBuilder::new(id("K8sPlatform"))
+        .entities([cluster, node, pod, container])
+        .unwrap()
+        .build()
+}
+```
+
+### 9.5 Running all three constraints together
+
+```rust
+fn main() {
+    let schema = build_platform_schema();
+
+    // A single walk validates FSM order, ref-target existence, and ref-tree shape.
+    let report = validate::<(FsmConstraint, RefTreeConstraint, RefTargetConstraint)>(&schema);
+
+    let (fsm_result, reftree_result, reftarget_result) = report.results;
+
+    match fsm_result {
+        Ok(()) => println!("✅ all entity FSM topologies are valid"),
+        Err(e) => eprintln!("❌ FSM violation: {e}"),
+    }
+    match reftree_result {
+        Ok(()) => println!("✅ entity references form a valid tree rooted at Cluster"),
+        Err(RefTreeError::Multiple(errs)) => {
+            eprintln!("❌ {} tree violations:", errs.len());
+            for e in errs { eprintln!("  - {e}"); }
+        }
+        Err(e) => eprintln!("❌ tree violation: {e}"),
+    }
+    match reftarget_result {
+        Ok(()) => println!("✅ all EntityRef targets are valid"),
+        Err(e) => eprintln!("❌ ref-target violation: {e}"),
+    }
+}
+```
+
+### 9.6 What the constraint sees during the walk
+
+During the walk `ref-tree` builds this internal graph…
+
+```mermaid
+graph LR
+    subgraph Entities["Entity nodes"]
+        ECl["Entity(Cluster)"]
+        ENo["Entity(Node)"]
+        EPo["Entity(Pod)"]
+        ECo["Entity(Container)"]
+    end
+
+    subgraph Events["Event nodes"]
+        EvProv["Event(Cluster, provisioned)"]
+        EvJoin["Event(Node, joined)"]
+        EvSched["Event(Pod, scheduled)"]
+        EvStart["Event(Container, started)"]
+    end
+
+    ECl --> EvProv
+    ENo --> EvJoin
+    EPo --> EvSched
+    ECo --> EvStart
+
+    EvJoin  -->|"tree-ref"| ECl
+    EvSched -->|"tree-ref"| ENo
+    EvStart -->|"tree-ref"| EPo
+
+    classDef entity fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef event fill:#d4a015,stroke:#7d5b00,color:#fff;
+    class ECl,ENo,EPo,ECo entity;
+    class EvProv,EvJoin,EvSched,EvStart event;
+```
+
+…and `finish()` collapses it to the clean entity tree:
+
+```mermaid
+graph TD
+    Cluster2["Cluster (root)"]
+    Node2["Node"]
+    Pod2["Pod"]
+    Container2["Container"]
+
+    Cluster2 --> Node2 --> Pod2 --> Container2
+
+    classDef root fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef child fill:#2da44e,stroke:#136229,color:#fff;
+    class Cluster2 root;
+    class Node2,Pod2,Container2 child;
+```
+
+### 9.7 How violations map to errors
+
+```mermaid
+graph TD
+    subgraph CP["❌ ConflictingParents (Req 4)"]
+        CP1["Pod.scheduled → Node"]
+        CP2["Pod.evicted   → Cluster"]
+        CP1 -. "same entity, different\nparent types" .-> CPX["ConflictingParents"]
+        CP2 -. .-> CPX
+    end
+
+    subgraph MR["❌ MultipleRoots (Req 1)"]
+        MR1["Cluster (no parent)"]
+        MR2["Region  (no parent)"]
+        MR1 -. "both have zero parents" .-> MRX["MultipleRoots"]
+        MR2 -. .-> MRX
+    end
+
+    subgraph UR["❌ Unreachable (Req 5)"]
+        UR1["A → B"]
+        UR2["B → A"]
+        UR1 -. "cycle, never reaches root" .-> URX["Unreachable"]
+        UR2 -. .-> URX
+    end
+
+    subgraph NT["❌ NotTargetConstrained (Req 3)"]
+        NT1["EntityRef has\nref-tree.v1 marker"]
+        NT2["but NO\nref-target.v1"]
+        NT1 -. "missing prerequisite" .-> NTX["NotTargetConstrained"]
+        NT2 -. .-> NTX
+    end
+
+    subgraph NR["❌ NoRoot (Req 1)"]
+        NR1["Every entity has\nat least one tree-ref"]
+        NR1 -. "nowhere to start BFS" .-> NRX["NoRoot"]
+    end
+
+    classDef err fill:#cf222e,stroke:#82071e,color:#fff;
+    class CPX,MRX,URX,NTX,NRX err;
+```
+
+| Trigger | Error |
+| --- | --- |
+| An entity's events point at two different parent types | `ConflictingParents` |
+| Two entities have zero tree-refs in all their events | `MultipleRoots` |
+| Every entity has at least one tree-ref (no root exists) | `NoRoot` |
+| An entity's events form a cycle that never touches the root | `Unreachable` |
+| A `ref-tree` marker exists but `ref-target` annotation is missing | `NotTargetConstrained` |
+| A `ref-target` annotation names an entity that isn't in the schema | `UnknownTarget` |
+| An event carries more than one tree-forming ref | `MultiplePerEvent` |
+
+---
+
+## 10. Why this architecture is nice
+
+```mermaid
+graph LR
+    subgraph stable["stable (never changes)"]
+        S["quent-schema\ndata + walk"]
+        C["quent-constraints\ntrait + orchestrator"]
+    end
+
+    subgraph pluggable["pluggable (add new crates freely)"]
+        F["quent-fsm"]
+        RT["quent-ref-target"]
+        RTR["quent-ref-tree"]
+        X["quent-… (future)"]
+    end
+
+    C --> S
+    F & RT & RTR & X --> C
+
+    S -. "opaque annotation blobs" .-> F & RT & RTR & X
+    F & RT & RTR & X -->|"share one walk"| REP2["Report"]
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class stable,S,C core;
+    class pluggable,F,RT,RTR,X,REP2 cons;
+```
+
+**Separation of concerns.** The schema never learns domain rules. New rules ship
+as new crates; `quent-schema` never changes.
+
+**Forward compatibility.** An unknown annotation name is *reported*
+(`UnregisteredConstraints`), never silently ignored. Codegen can emit a working
+API even before understanding a new constraint.
+
+**Single-pass efficiency.** `validate::<(A, B, C)>` composes visitors into a
+tuple and walks the schema once, regardless of how many constraints are active.
+
+**Composability.** `ref-tree` reusing `ref-target`'s annotation data shows
+constraints can layer on each other instead of duplicating logic.
+
+**Orthogonality.** `fsm` and `ref-tree` describe the same schema from two
+independent dimensions — time and space — without any coupling between them.
+
+---
+
+## 11. Adding your own constraint
+
+Any crate can participate by implementing `Visitor + Constraint`:
+
+```rust
+use quent_schema::Visitor;
+use quent_constraints::Constraint;
+
+/// Example: enforce that every Entity has at least one event.
+#[derive(Default)]
+pub struct NonEmptyEntitiesConstraint {
+    violations: Vec<String>,
+}
+
+impl Visitor for NonEmptyEntitiesConstraint {
+    type Output = Result<(), Vec<String>>;
+
+    fn visit(&mut self, cursor: &quent_schema::Cursor) {
+        if let Some(entity) = cursor.as_entity() {
+            if entity.events.is_empty() {
+                self.violations.push(entity.name.to_string());
+            }
+        }
+    }
+
+    fn finish(self) -> Self::Output {
+        if self.violations.is_empty() { Ok(()) } else { Err(self.violations) }
+    }
+}
+
+impl Constraint for NonEmptyEntitiesConstraint {
+    const NAME: &'static str = "my-org.non-empty-entities.v1";
+}
+
+// Usage: compose it in alongside the built-in constraints.
+// let report = validate::<(FsmConstraint, RefTreeConstraint, NonEmptyEntitiesConstraint)>(&schema);
+```
+
+The new constraint is automatically included in the single-walk pass with no
+changes required to `quent-schema` or `quent-constraints`.

--- a/docs/ref-tree-explained.md
+++ b/docs/ref-tree-explained.md
@@ -1,0 +1,623 @@
+# The `quent-ref-tree` crate, explained
+
+A guided tour of the new `quent-ref-tree` crate and how it fits together with
+`quent-schema`, `quent-constraints`, `quent-ref-target`, and `quent-fsm`.
+
+> TL;DR — `quent-ref-tree` is a **constraint**. It does not define new schema
+> data; it *validates* that the entity references already in a schema form a
+> single tree rooted at one entity. It is implemented as a `Visitor` (from
+> `quent-schema`) that also implements the `Constraint` marker trait (from
+> `quent-constraints`), exactly like `quent-fsm` and `quent-ref-target`.
+
+---
+
+## 1. The big picture: who depends on whom
+
+Everything is built around one idea: **the schema is a minimal, dumb data model,
+and every "rule" lives outside it as a constraint.** Constraints are just
+visitors that walk the schema and collect violations.
+
+```mermaid
+graph TD
+    schema["quent-schema<br/><i>data model + Visitor/Cursor walk</i>"]
+    constraints["quent-constraints<br/><i>Constraint trait + validate() orchestrator</i>"]
+    fsm["quent-fsm<br/><i>event-order constraint</i>"]
+    reftarget["quent-ref-target<br/><i>reference points at a valid entity</i>"]
+    reftree["quent-ref-tree<br/><i>references form one tree</i>"]
+
+    constraints --> schema
+    fsm --> schema
+    fsm --> constraints
+    reftarget --> schema
+    reftarget --> constraints
+    reftree --> schema
+    reftree --> constraints
+    reftree -. "depends on (req 3)" .-> reftarget
+
+    classDef core fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    classDef cons fill:#2da44e,stroke:#136229,color:#fff;
+    class schema,constraints core;
+    class fsm,reftarget,reftree cons;
+```
+
+Key takeaways:
+
+- **`quent-schema`** is the foundation. It knows nothing about FSMs, targets, or
+  trees.
+- **`quent-constraints`** defines *what a constraint is* and *how to run a bunch
+  of them in one pass*.
+- **`quent-fsm`, `quent-ref-target`, `quent-ref-tree`** are sibling constraint
+  crates. They are peers — except `ref-tree` additionally **builds on**
+  `ref-target` (a tree-forming reference is *required* to also be
+  target-constrained).
+
+---
+
+## 2. `quent-schema` — the data model being validated
+
+A `Schema` is a tree of plain data. Constraints are attached as opaque
+`Annotations` (named `Constraint` blobs) on almost any element.
+
+```mermaid
+classDiagram
+    class Schema {
+        name: Identifier
+        entities: Map
+        records: Map
+        annotations
+    }
+    class Entity {
+        name: Identifier
+        events: Map
+        annotations
+    }
+    class Event {
+        name: Identifier
+        cardinality: Once|Multi
+        payload: Map
+        annotations
+    }
+    class Record {
+        name: Identifier
+        fields: Map
+        annotations
+    }
+    class Field {
+        name: Identifier
+        ty: DataType
+        annotations
+    }
+    class DataType {
+        Bool U8..U64 I8..I64 F32 F64
+        String Uuid
+        Option(Box~DataType~)
+        List(Box~DataType~)
+        Record(Identifier)
+        DynamicRecord
+        EntityRef
+    }
+    class Annotations {
+        docs: Option~String~
+        constraints: Map~name, Constraint~
+        metadata: Map
+    }
+
+    Schema "1" o-- "*" Entity
+    Schema "1" o-- "*" Record
+    Entity "1" o-- "*" Event
+    Event "1" o-- "*" Field
+    Record "1" o-- "*" Field
+    Field "1" --> "1" DataType
+    Schema ..> Annotations
+    Entity ..> Annotations
+    Event ..> Annotations
+    Field ..> Annotations
+    Record ..> Annotations
+    DataType ..> Annotations : EntityRef carries its own
+```
+
+The two `DataType` variants that matter most here:
+
+- **`EntityRef { data, annotations }`** — a reference to *some* entity. On its
+  own it is "type-erased": it does not say *which* entity type it points to.
+  Constraints in its `annotations` are what give it meaning.
+- **`Record(Identifier)`** — a named reference to a top-level `Record`. Records
+  are visited once from `Schema::records`, so a `Record(name)` field is a
+  pointer, not an inline expansion.
+
+### The Visitor walk
+
+`Schema::walk(visitor)` performs a depth-first traversal, calling
+`visitor.visit(&cursor)` on every element *before* its children. The `Cursor`
+is the full path from the schema root to the current element — that is how a
+constraint knows *where* it is (e.g. "this EntityRef is inside Event X of
+Entity Y").
+
+```mermaid
+graph TD
+    S["Schema"] --> SA["Annotations"]
+    S --> E["Entity"]
+    E --> EA["Annotations"]
+    E --> EV["Event"]
+    EV --> EVA["Annotations"]
+    EV --> F["Field"]
+    F --> FA["Annotations"]
+    F --> DT["DataType"]
+    DT --> O["Option/List → inner DataType"]
+    DT --> ER["EntityRef → its Annotations, then carried data"]
+    S --> R["Record (visited once, top-level)"]
+    R --> RF["Field → DataType ..."]
+
+    classDef hot fill:#bf3989,stroke:#6e1f50,color:#fff;
+    class ER,DT,R hot;
+```
+
+> Important nuance the `ref-tree` algorithm relies on: a `Record` referenced by
+> a field is **not** descended into at the field site. The walker visits each
+> top-level `Record` exactly once. So to "follow" a record from an event, a
+> constraint must build its own graph linking `Event → Record(name)` and then
+> `Record → its parent`. (This is exactly what `ref-tree` does — and also where
+> the open review finding lives.)
+
+---
+
+## 3. `quent-constraints` — the contract and the orchestrator
+
+Two tiny pieces:
+
+```mermaid
+classDiagram
+    class Visitor {
+        <<trait, from quent-schema>>
+        type Output
+        visit(cursor)
+        finish() Output
+    }
+    class Constraint {
+        <<trait, from quent-constraints>>
+        const NAME: str
+    }
+    Constraint --|> Visitor : requires Visitor + Default
+
+    class RefTreeConstraint
+    class RefTargetConstraint
+    class FsmConstraint
+    RefTreeConstraint ..|> Constraint
+    RefTargetConstraint ..|> Constraint
+    FsmConstraint ..|> Constraint
+```
+
+- A **`Constraint`** is "a `Visitor` that also has a unique `NAME`". The `NAME`
+  is the key used in a schema's annotations (`"quent.ref-tree.v1"`,
+  `"quent.fsm.v1"`, ...).
+- **`validate::<(A, B, C)>(schema)`** runs *all* constraints — plus two built-in
+  checks — in **a single walk**, then hands back a `Report` with each
+  constraint's `Output` in tuple order.
+
+```mermaid
+sequenceDiagram
+    participant U as caller
+    participant V as validate::<(RefTree, RefTarget)>
+    participant W as Schema::walk
+    participant Chk as built-in checks
+    participant RT as RefTreeConstraint
+    participant TG as RefTargetConstraint
+
+    U->>V: validate(&schema)
+    V->>W: walk( (UnresolvedRefs, Unregistered, (RefTree, RefTarget)) )
+    loop every element, depth-first
+        W->>Chk: visit(cursor)
+        W->>RT: visit(cursor)
+        W->>TG: visit(cursor)
+    end
+    W->>RT: finish() → check_tree()
+    W->>TG: finish()
+    W-->>V: outputs
+    V-->>U: Report { unregistered, invalid_references, results }
+```
+
+The two always-on built-ins:
+
+- **`UnresolvedReferences`** — every `Record(name)` resolves to a real
+  top-level record.
+- **`UnregisteredConstraints`** — collects any constraint names present in the
+  schema that you did *not* pass to `validate` (so nothing silently goes
+  unchecked).
+
+This "all constraints share one walk" design is why each constraint is a
+`Visitor`: the orchestrator composes them into a tuple visitor and walks once.
+
+---
+
+## 4. `quent-ref-target` — the prerequisite constraint
+
+`ref-target` answers a narrow question: **"this `EntityRef` claims to point at
+entity `T` — does `T` actually exist in the schema?"**
+
+- The target is stored as opaque constraint data: the JSON of an `Identifier`
+  (e.g. `"Cluster"`), under the name `quent.ref-target.v1`.
+- `RefTarget::from_annotations(...)` is the helper `ref-tree` reuses to read
+  that target back out.
+
+```mermaid
+graph LR
+    ref["EntityRef annotations"] -->|"quent.ref-target.v1 = &quot;Cluster&quot;"| rt["RefTarget(Identifier)"]
+    rt -->|"schema.entity(&quot;Cluster&quot;)?"| ok{exists?}
+    ok -->|yes| pass["OK"]
+    ok -->|no| err["UnknownTarget"]
+```
+
+This is the foundation tree-forming references stand on: you cannot build a
+*typed* tree out of references that don't even name a valid entity type.
+
+---
+
+## 5. `quent-ref-tree` — the main event
+
+### What it guarantees
+
+> The entity references annotated as *tree-forming* must, together, describe a
+> **single tree that connects every entity, rooted at exactly one entity.**
+
+The canonical use is a "preferred parent" link: a way to walk from any entity
+back to one root (hierarchical "is owned by / is part of" or causal "is spawned
+by" relations).
+
+Its five requirements (from the crate docs):
+
+```mermaid
+graph TD
+    R1["1 · exactly ONE root<br/>(an entity whose events carry no tree-ref)"]
+    R2["2 · each non-root has ≤1 tree-ref per event/record"]
+    R3["3 · every tree-ref must also be target-constrained<br/>(depends on ref-target)"]
+    R4["4 · all of one entity's tree-refs point at the SAME parent type"]
+    R5["5 · every entity can follow tree-refs up to the root"]
+
+    R3 --> R1 --> R4 --> R5
+    R2 --> R4
+```
+
+### How it works internally
+
+Because records break the walk (section 2), `ref-tree` can't just read parents
+off the cursor. Instead, during the walk it **builds its own directed graph**
+with three kinds of nodes, then collapses it in `finish()`.
+
+```mermaid
+graph LR
+    subgraph "Node kinds in the internal graph"
+        En["Entity(name)"]
+        Ev["Event(entity, name)"]
+        Rec["Record(name)"]
+    end
+    En -->|"entity owns event"| Ev
+    Ev -->|"event field is a Record"| Rec
+    Rec -->|"nested record field"| Rec2["Record(other)"]
+    Ev -->|"tree-ref target"| Parent["Entity(parent)"]
+    Rec -->|"tree-ref target"| Parent
+```
+
+Edges are added on three kinds of `visit` events:
+
+| When the walker sees…                         | …it adds the edge                         |
+| --------------------------------------------- | ----------------------------------------- |
+| an `Event` under an `Entity`                  | `Entity ──▶ Event`                        |
+| a `Record(name)` field (in an event/record)   | `Event ──▶ Record` or `Record ──▶ Record` |
+| a tree-forming `EntityRef` (target = `P`)     | `Event ──▶ Entity(P)` / `Record ──▶ Entity(P)` |
+
+Then `finish()` runs the collapse + validation:
+
+```mermaid
+flowchart TD
+    start([finish]) --> used{any tree-ref<br/>actually used?}
+    used -->|no| ok([Ok — no tree to form])
+    used -->|yes| bad{any NotTargetConstrained<br/>or UnknownTarget?}
+    bad -->|yes| report([report those errors only])
+    bad -->|no| collapse[for each entity:<br/>walk its events+records to find<br/>UNIQUE parent entities]
+
+    collapse --> count{how many<br/>unique parents?}
+    count -->|0| root[mark as root]
+    count -->|1| child[mark non-root,<br/>add parent→child edge]
+    count -->|"2+"| conflict[ConflictingParents · req 4]
+
+    root --> roots{how many roots?}
+    roots -->|0| noroot[NoRoot · req 1]
+    roots -->|"2+"| multi[MultipleRoots · req 1]
+    roots -->|1| bfs[BFS from root over<br/>collapsed entity tree]
+    child --> bfs
+    bfs --> reach{every non-root<br/>reached?}
+    reach -->|no| unreach[Unreachable · req 5]
+    reach -->|yes| done([Ok — valid tree])
+```
+
+The `entity_unique_parents` helper is the clever bit: from an `Entity` node it
+does a DFS through that entity's `Event` and `Record` nodes (with a `seen` set
+so self-referential records don't loop), and collects every `Entity` node it
+can reach. Those are the entity's candidate parents.
+
+- **0 parents** → root candidate.
+- **exactly 1** → a normal child; contributes one edge to the collapsed tree.
+- **2+ distinct** → `ConflictingParents` (req 4 violated).
+
+Finally it BFS-walks the collapsed `parent → child` tree from the unique root;
+any entity not reached is `Unreachable` (e.g. a cycle that never touches the
+root).
+
+### The error taxonomy
+
+```mermaid
+graph TD
+    E["RefTreeError"]
+    E --> a["NotTargetConstrained · req 3"]
+    E --> b["UnknownTarget · ill-formed target"]
+    E --> c["MultiplePerEvent · req 2"]
+    E --> d["MultipleRefsInRecord · req 2"]
+    E --> f["NoRoot · req 1"]
+    E --> g["MultipleRoots · req 1"]
+    E --> h["ConflictingParents · req 4"]
+    E --> i["Unreachable · req 5"]
+    E --> j["Multiple(Vec) · aggregate"]
+```
+
+---
+
+## 6. Relationship to `quent-fsm` (a sibling constraint)
+
+`fsm` and `ref-tree` never talk to each other, but they are *structurally
+identical* and often describe the same schema from different angles:
+
+| Aspect              | `quent-fsm`                                  | `quent-ref-tree`                                  |
+| ------------------- | -------------------------------------------- | ------------------------------------------------- |
+| Constrains          | the **order of one entity's events** in time | the **parent links between entities**             |
+| Annotation lives on | the **`Entity`** (FSM topology JSON)         | the **`EntityRef`** (a marker + target)           |
+| Internal model      | a state graph per entity (petgraph)          | one entity/event/record graph for the whole schema |
+| Built-in helpers    | `Bfs`, `tarjan_scc` for reachability/cycles  | `Bfs` for root-reachability                       |
+| Output              | `Result<(), FsmError>`                       | `Result<(), RefTreeError>`                        |
+
+Both are just `Visitor + Constraint`, so you can validate them together:
+
+```rust
+let report = validate::<(FsmConstraint, RefTreeConstraint, RefTargetConstraint)>(&schema);
+```
+
+Think of it as: **FSM = how one entity evolves over time; ref-tree = how
+entities are organized in space (the ownership hierarchy).**
+
+---
+
+## 7. A real-world example: observing a Kubernetes-style platform
+
+Imagine instrumenting a container platform. The natural ownership hierarchy is
+a textbook tree:
+
+```mermaid
+graph TD
+    Cluster --> Node1["Node"]
+    Node1 --> PodA["Pod"]
+    Node1 --> PodB["Pod"]
+    PodA --> C1["Container"]
+    PodA --> C2["Container"]
+    PodB --> C3["Container"]
+
+    classDef root fill:#1f6feb,stroke:#0b3a8c,color:#fff;
+    class Cluster root;
+```
+
+- `Cluster` is the **root** — it is the entry point, owned by nothing.
+- `Node` *is part of* a `Cluster`.
+- `Pod` *is scheduled on* a `Node`.
+- `Container` *is part of* a `Pod`.
+
+Each non-root entity emits an event that carries a **tree-forming reference**
+to its parent. That reference is both `quent.ref-tree.v1` (marker) and
+`quent.ref-target.v1` (which parent type).
+
+### Modeling it with the builder API
+
+```rust
+use quent_constraints::{Constraint, validate};
+use quent_ref_target::RefTargetConstraint;
+use quent_ref_tree::{RefTreeConstraint, RefTreeError};
+use quent_schema::{
+    Cardinality, DataType, Identifier,
+    builder::{AnnotationsBuilder, EntityBuilder, EventBuilder, SchemaBuilder},
+};
+
+fn id(s: &str) -> Identifier {
+    Identifier::try_new(s).unwrap()
+}
+
+/// An `EntityRef` that is BOTH tree-forming and target-constrained to `parent`.
+/// This is the "my parent is one specific entity type" link.
+fn parent_ref(parent: &str) -> DataType {
+    // ref-target data is just the JSON of the target identifier, e.g. "Node".
+    let target = serde_json::to_string(&id(parent)).unwrap();
+    DataType::EntityRef {
+        data: None,
+        annotations: AnnotationsBuilder::new()
+            .constraint(RefTreeConstraint::NAME, None)
+            .unwrap()
+            .constraint(RefTargetConstraint::NAME, Some(target))
+            .unwrap()
+            .build(),
+    }
+}
+
+/// A field whose value carries a parent reference.
+fn parent_field(name: &str, parent: &str) -> quent_schema::Field {
+    quent_schema::Field::new(id(name), parent_ref(parent), Default::default())
+}
+
+fn build_platform_schema() -> quent_schema::Schema {
+    // Root: a Cluster. Its events carry NO tree-forming reference.
+    let cluster = EntityBuilder::new(id("Cluster"))
+        .event(
+            EventBuilder::new(id("provisioned"), Cardinality::Once)
+                .build(),
+        )
+        .unwrap()
+        .build();
+
+    // Node: "is part of" a Cluster.
+    let node = EntityBuilder::new(id("Node"))
+        .event(
+            EventBuilder::new(id("joined"), Cardinality::Once)
+                .field(parent_field("cluster", "Cluster"))
+                .unwrap()
+                .build(),
+        )
+        .unwrap()
+        .build();
+
+    // Pod: "is scheduled on" a Node. It can be rescheduled, but always onto the
+    // same *type* of parent (Node), so req 4 holds even across events.
+    let pod = EntityBuilder::new(id("Pod"))
+        .event(
+            EventBuilder::new(id("scheduled"), Cardinality::Once)
+                .field(parent_field("node", "Node"))
+                .unwrap()
+                .build(),
+        )
+        .unwrap()
+        .build();
+
+    // Container: "is part of" a Pod.
+    let container = EntityBuilder::new(id("Container"))
+        .event(
+            EventBuilder::new(id("started"), Cardinality::Once)
+                .field(parent_field("pod", "Pod"))
+                .unwrap()
+                .build(),
+        )
+        .unwrap()
+        .build();
+
+    SchemaBuilder::new(id("K8sPlatform"))
+        .entities([cluster, node, pod, container])
+        .unwrap()
+        .build()
+}
+
+fn main() {
+    let schema = build_platform_schema();
+
+    // Validate the tree constraint together with its prerequisite.
+    let report = validate::<(RefTreeConstraint, RefTargetConstraint)>(&schema);
+
+    match report.results.0 {
+        Ok(()) => println!("✅ references form a valid tree rooted at Cluster"),
+        Err(RefTreeError::Multiple(errs)) => {
+            eprintln!("❌ {} tree violations:", errs.len());
+            for e in errs {
+                eprintln!("  - {e}");
+            }
+        }
+        Err(e) => eprintln!("❌ tree violation: {e}"),
+    }
+}
+```
+
+### What the constraint sees internally
+
+For the schema above, `ref-tree` builds this graph during the walk…
+
+```mermaid
+graph LR
+    subgraph Entities
+        Cl["Entity(Cluster)"]
+        No["Entity(Node)"]
+        Po["Entity(Pod)"]
+        Co["Entity(Container)"]
+    end
+    Cl --> EvCl["Event(Cluster, provisioned)"]
+    No --> EvNo["Event(Node, joined)"]
+    Po --> EvPo["Event(Pod, scheduled)"]
+    Co --> EvCo["Event(Container, started)"]
+
+    EvNo -->|tree-ref| Cl
+    EvPo -->|tree-ref| No
+    EvCo -->|tree-ref| Po
+```
+
+…and `finish()` collapses it to the clean tree (one root, everyone reaches it):
+
+```mermaid
+graph TD
+    Cluster --> Node --> Pod --> Container
+    classDef root fill:#2da44e,stroke:#136229,color:#fff;
+    class Cluster root;
+```
+
+### How it would fail (mapping back to requirements)
+
+```mermaid
+graph TD
+    subgraph "❌ ConflictingParents (req 4)"
+        P1["Pod.scheduled → Node"]
+        P2["Pod.evicted → Cluster"]
+        P1 -.both on Pod.-> X1["two parent types"]
+        P2 -.-> X1
+    end
+    subgraph "❌ MultipleRoots (req 1)"
+        R1["Cluster (no parent)"]
+        R2["Region (no parent)"]
+    end
+    subgraph "❌ Unreachable (req 5)"
+        A["A → B"]
+        B["B → A"]
+        A -.cycle, never hits root.-> B
+    end
+    subgraph "❌ NotTargetConstrained (req 3)"
+        E["EntityRef has ref-tree marker<br/>but no ref-target"]
+    end
+```
+
+- Give `Pod` two events pointing at different parent **types** → `ConflictingParents`.
+- Add a second entity with no parent link → `MultipleRoots`.
+- Make `A → B` and `B → A` with neither reaching `Cluster` → two `Unreachable`.
+- Mark a reference tree-forming but forget the target → `NotTargetConstrained`.
+
+---
+
+## 8. Why this architecture is nice
+
+```mermaid
+graph LR
+    subgraph "schema (stable, dumb data)"
+        s1["entities, events, fields, records"]
+        s2["opaque annotations"]
+    end
+    subgraph "constraints (pluggable rules)"
+        c1["fsm"]
+        c2["ref-target"]
+        c3["ref-tree"]
+        c4["...future..."]
+    end
+    s2 -. "named blobs" .-> c1 & c2 & c3 & c4
+    c1 & c2 & c3 & c4 -->|"one walk"| v["validate() → Report"]
+```
+
+- **Separation of concerns** — the schema never learns domain rules; new
+  constraints ship as new crates without touching `quent-schema`.
+- **Forward compatibility** — an unknown constraint is *reported*
+  (`UnregisteredConstraints`), never silently ignored, and codegen can still
+  emit a working API even before it understands a new constraint.
+- **Single-pass efficiency** — `validate::<(A, B, C)>` composes visitors into a
+  tuple and walks the schema once.
+- **Composability** — `ref-tree` reusing `ref-target` shows constraints can
+  layer on each other instead of duplicating logic.
+
+---
+
+## 9. One-paragraph summary
+
+`quent-schema` gives you a minimal, serializable model of entities/events/records
+plus a `Visitor` walk. `quent-constraints` defines the `Constraint` trait (a
+named `Visitor`) and a `validate()` orchestrator that runs many constraints in a
+single walk and returns a `Report`. `quent-ref-target`, `quent-fsm`, and the new
+`quent-ref-tree` are independent constraint crates that implement `Visitor +
+Constraint`. `quent-ref-tree` marks certain entity references as "tree-forming",
+builds an internal entity/event/record graph as it walks, and in `finish()`
+collapses that graph to verify the references describe exactly one
+root-connected tree — reusing `quent-ref-target` to guarantee every such
+reference names a real parent entity.


### PR DESCRIPTION
# Description

Adds diagram based illustration of all the new experimental design crates into the docs. All constructs in the diagrams carry consistent coloring scheme to enable quick grasp of the category.

