### PR TITLE
feat(exporter): write build-time provenance to a model.qmi sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-build-info"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "quent-codegen"
 version = "0.1.0"
 dependencies = [
@@ -1858,6 +1866,7 @@ version = "0.1.0"
 dependencies = [
  "ciborium",
  "dashmap",
+ "quent-build-info",
  "quent-collector-proto",
  "quent-exporter",
  "quent-exporter-types",
@@ -2008,6 +2017,7 @@ dependencies = [
  "criterion",
  "pprof",
  "quent-attributes",
+ "quent-build-info",
  "quent-collector",
  "quent-collector-proto",
  "quent-events",
@@ -2055,6 +2065,7 @@ name = "quent-model"
 version = "0.1.0"
 dependencies = [
  "quent-attributes",
+ "quent-build-info",
  "quent-events",
  "quent-exporter",
  "quent-instrumentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     # Application-agnostic crates
     "crates/analyzer",
     "crates/attributes",
+    "crates/build-info",
     "crates/codegen",
     "crates/collector/server",
     "crates/collector/client",
@@ -64,6 +65,7 @@ members = [
 default-members = [
     "crates/analyzer",
     "crates/attributes",
+    "crates/build-info",
     "crates/codegen",
     "crates/collector/server",
     "crates/collector/client",

--- a/crates/build-info/Cargo.toml
+++ b/crates/build-info/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "quent-build-info"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/build-info/build.rs
+++ b/crates/build-info/build.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Captures the quent repository's git provenance at build time and exposes it
+//! to the crate as `QUENT_BUILD_*` env vars (read by `quent_build_info::quent`).
+
+use std::path::PathBuf;
+
+// Shared git capture (see `src/git.rs`). Included rather than imported because a
+// crate's own `build.rs` cannot depend on its library.
+include!("src/git.rs");
+
+fn main() {
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    emit("QUENT_BUILD", &manifest_dir);
+}

--- a/crates/build-info/src/git.rs
+++ b/crates/build-info/src/git.rs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Git capture shared between this crate's `build.rs` (via `include!`) and the
+// `emit_source` build-script helper (via `mod git`). Kept dependency-free and
+// free of `//!` inner-doc comments so it is valid in both contexts.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Raw git fields captured from a working tree. A field is `None` when it could
+/// not be determined (e.g. the source is not a git checkout), so the build never
+/// fails and absent provenance stays distinguishable from a real value.
+pub struct RawGit {
+    pub commit: Option<String>,
+    pub branch: Option<String>,
+    pub dirty: Option<bool>,
+    pub remote: Option<String>,
+    pub built_at: Option<String>,
+    /// Absolute path to the `.git` directory, if this is a git working tree.
+    pub git_dir: Option<String>,
+}
+
+fn run(dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+// Strip userinfo (a possible embedded token/password) from http(s) remote URLs
+// so it is never baked into provenance and leaked via an exported sidecar. ssh
+// and scp-style URLs keep their login user, which is not a secret.
+fn sanitize_remote(url: String) -> String {
+    for scheme in ["https://", "http://"] {
+        if let Some(rest) = url.strip_prefix(scheme) {
+            let authority_end = rest.find('/').unwrap_or(rest.len());
+            if let Some(at) = rest[..authority_end].find('@') {
+                return format!("{scheme}{}", &rest[at + 1..]);
+            }
+            return url;
+        }
+    }
+    url
+}
+
+/// Capture git provenance for the working tree containing `dir`. Each field is
+/// `None` when unavailable.
+pub fn capture(dir: &Path) -> RawGit {
+    RawGit {
+        commit: run(dir, &["rev-parse", "HEAD"]),
+        branch: run(dir, &["rev-parse", "--abbrev-ref", "HEAD"]),
+        dirty: run(dir, &["status", "--porcelain"]).map(|status| !status.is_empty()),
+        remote: run(dir, &["remote", "get-url", "origin"]).map(sanitize_remote),
+        built_at: run(dir, &["log", "-1", "--format=%cI"]),
+        git_dir: run(dir, &["rev-parse", "--absolute-git-dir"]),
+    }
+}
+
+/// Emit `cargo:rustc-env={prefix}_*` for each captured field plus
+/// `rerun-if-changed` triggers. Only known fields are emitted, so `option_env!`
+/// resolves to `None` for absent values. Called from build scripts.
+pub fn emit(prefix: &str, dir: &Path) {
+    let git = capture(dir);
+    if let Some(commit) = &git.commit {
+        println!("cargo:rustc-env={prefix}_COMMIT={commit}");
+    }
+    if let Some(branch) = &git.branch {
+        println!("cargo:rustc-env={prefix}_BRANCH={branch}");
+    }
+    if let Some(dirty) = git.dirty {
+        println!("cargo:rustc-env={prefix}_DIRTY={dirty}");
+    }
+    if let Some(remote) = &git.remote {
+        println!("cargo:rustc-env={prefix}_REMOTE={remote}");
+    }
+    if let Some(built_at) = &git.built_at {
+        println!("cargo:rustc-env={prefix}_BUILT_AT={built_at}");
+    }
+    if let Some(git_dir) = &git.git_dir {
+        // Rerun when the checked-out commit / branch changes. `dirty` tracking is
+        // best-effort: an unstaged edit to a tracked file touches none of these,
+        // so a stale `dirty=false` is possible until the next ref/index change.
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        println!("cargo:rerun-if-changed={git_dir}/index");
+        println!("cargo:rerun-if-changed={git_dir}/packed-refs");
+        if let Some(branch) = &git.branch
+            && branch != "HEAD"
+        {
+            println!("cargo:rerun-if-changed={git_dir}/refs/heads/{branch}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_remote;
+
+    #[test]
+    fn sanitize_remote_strips_http_userinfo_only() {
+        // https/http: userinfo (which may carry a token/password) is removed.
+        assert_eq!(
+            sanitize_remote("https://ghp_secret@github.com/o/r.git".to_string()),
+            "https://github.com/o/r.git"
+        );
+        assert_eq!(
+            sanitize_remote("https://user:pass@host:443/o/r.git".to_string()),
+            "https://host:443/o/r.git"
+        );
+        // No userinfo: unchanged.
+        assert_eq!(
+            sanitize_remote("https://github.com/o/r.git".to_string()),
+            "https://github.com/o/r.git"
+        );
+        // ssh/scp: login user is not a secret and is required to clone, so kept.
+        assert_eq!(
+            sanitize_remote("git@github.com:o/r.git".to_string()),
+            "git@github.com:o/r.git"
+        );
+        assert_eq!(
+            sanitize_remote("ssh://git@host/o/r.git".to_string()),
+            "ssh://git@host/o/r.git"
+        );
+    }
+}

--- a/crates/build-info/src/lib.rs
+++ b/crates/build-info/src/lib.rs
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Build-time provenance written alongside exported artifacts.
+//!
+//! An instrumentation `Context` writes an [`ArtifactInfo`] sidecar
+//! (`model.qmi`) into each context directory so downstream tools (e.g.
+//! `quent-open`) can locate & check out the crate that produced the artifacts,
+//! without a hand-maintained config:
+//!
+//! * [`BuildInfo`] — git provenance. The [`quent`] framework's info is captured
+//!   by this crate's `build.rs`; a downstream crate captures its own by calling
+//!   [`emit_source`] from its `build.rs`. Each field is optional so absent
+//!   provenance stays distinguishable from a real value.
+//! * [`ModelInfo`] — the model's identity. The Rust type path and name come from
+//!   [`std::any::type_name`]; the cargo package and source git come from a
+//!   per-model [`ModelSource`] impl that `model!` generates (so out-of-repo
+//!   crates record their own package and git without any provenance threading).
+//!
+//! Keeping the provenance in a sidecar (rather than embedded in the artifacts)
+//! means a single, format-agnostic implementation for all exporters and clean
+//! event streams that third-party importers can read as a single object type.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+mod git;
+
+/// File name of the provenance sidecar written into a context directory.
+pub const SIDECAR_FILE_NAME: &str = "model.qmi";
+
+/// Git provenance of a repository, captured at build time. Every field except
+/// [`version`](Self::version) is optional and omitted from the serialized
+/// sidecar when unknown.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuildInfo {
+    /// Cargo package version.
+    pub version: String,
+    /// Full commit hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    /// Branch name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// Whether the working tree had uncommitted changes at build time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dirty: Option<bool>,
+    /// `origin` remote URL, with any embedded userinfo stripped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote: Option<String>,
+    /// Commit timestamp (RFC 3339).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub built_at: Option<String>,
+}
+
+/// Identity of the model that produced an artifact. The Rust type to build a
+/// viewer from (an analyzer entry point) is supplied by `quent-open`; this only
+/// records provenance to locate & check out the producing crate.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelInfo {
+    /// Model name (e.g. `"Simulator"`).
+    pub name: String,
+    /// Cargo package defining the model (e.g. `"quent-simulator-instrumentation"`).
+    pub package: String,
+    /// Rust type path of the model's event enum
+    /// (e.g. `"quent_simulator_instrumentation::SimulatorEvent"`).
+    pub type_path: String,
+    /// Git provenance of the crate defining the model.
+    pub source: BuildInfo,
+}
+
+impl BuildInfo {
+    /// A [`BuildInfo`] with no provenance, for placeholders where the source is
+    /// genuinely unknown.
+    pub fn unknown() -> Self {
+        Self {
+            version: "unknown".to_string(),
+            commit: None,
+            branch: None,
+            dirty: None,
+            remote: None,
+            built_at: None,
+        }
+    }
+}
+
+/// The provenance written into the `model.qmi` sidecar of each context directory.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactInfo {
+    /// Build info of the quent framework.
+    pub quent: BuildInfo,
+    /// Identity and source of the model that produced the artifact.
+    pub model: ModelInfo,
+}
+
+impl ArtifactInfo {
+    /// Construct an [`ArtifactInfo`] pairing the [`quent`] framework build info
+    /// with a [`ModelInfo`].
+    pub fn new(model: ModelInfo) -> Self {
+        Self {
+            quent: quent(),
+            model,
+        }
+    }
+
+    /// Write this provenance as the [`SIDECAR_FILE_NAME`] sidecar (pretty JSON)
+    /// in `dir`. JSON is used so the sidecar is self-describing and readable
+    /// regardless of the artifact serialization format.
+    ///
+    /// The write is atomic: the JSON goes to a temp file in `dir` that is then
+    /// renamed over the final name, so a reader never observes a partial or
+    /// torn sidecar.
+    pub fn write_sidecar(&self, dir: &Path) -> std::io::Result<()> {
+        let json = serde_json::to_vec_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let tmp = dir.join(format!(".{SIDECAR_FILE_NAME}.tmp"));
+        std::fs::write(&tmp, json)?;
+        std::fs::rename(&tmp, dir.join(SIDECAR_FILE_NAME))
+    }
+}
+
+/// Build info for the quent framework itself, captured by this crate's `build.rs`.
+pub fn quent() -> BuildInfo {
+    BuildInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        commit: option_env!("QUENT_BUILD_COMMIT").map(str::to_string),
+        branch: option_env!("QUENT_BUILD_BRANCH").map(str::to_string),
+        dirty: option_env!("QUENT_BUILD_DIRTY").map(|v| v == "true"),
+        remote: option_env!("QUENT_BUILD_REMOTE").map(str::to_string),
+        built_at: option_env!("QUENT_BUILD_BUILT_AT").map(str::to_string),
+    }
+}
+
+/// Build a model's source [`BuildInfo`] from `QUENT_SOURCE_*` values captured by
+/// [`emit_source`], falling back to [`quent`] when they are absent.
+///
+/// `version` is the model crate's own version (`env!("CARGO_PKG_VERSION")` at the
+/// call site) — not this crate's. Pass the results of `option_env!("QUENT_SOURCE_*")`.
+/// When a downstream crate has not opted in via [`emit_source`] the values are
+/// `None` and the model is assumed to live in the quent repository (the in-repo
+/// case), so the [`quent`] build info is used.
+pub fn source_or_quent(
+    version: &str,
+    remote: Option<&str>,
+    commit: Option<&str>,
+    branch: Option<&str>,
+    dirty: Option<&str>,
+    built_at: Option<&str>,
+) -> BuildInfo {
+    match (remote, commit) {
+        (Some(remote), Some(commit)) => BuildInfo {
+            version: version.to_string(),
+            commit: Some(commit.to_string()),
+            branch: branch.map(str::to_string),
+            dirty: dirty.map(|v| v == "true"),
+            remote: Some(remote.to_string()),
+            built_at: built_at.map(str::to_string),
+        },
+        _ => quent(),
+    }
+}
+
+/// Provenance of the crate that defines a model: the cargo package it belongs
+/// to and the git origin it was built from.
+///
+/// Each model carries its own implementation, so the recorded package and
+/// source git describe the defining crate — which may live outside the quent
+/// repository.
+pub trait ModelSource {
+    /// Cargo package of the crate defining the model (`env!("CARGO_PKG_NAME")`).
+    fn package() -> &'static str;
+    /// Git provenance of the crate defining the model.
+    fn source() -> BuildInfo;
+
+    /// Assemble the [`ModelInfo`] for this model: the Rust type path and name
+    /// from [`std::any::type_name`], the cargo package and source git from the
+    /// [`package`](Self::package) / [`source`](Self::source) impls above.
+    fn model_info() -> ModelInfo {
+        let type_path = std::any::type_name::<Self>();
+        let event_name = type_path.rsplit("::").next().unwrap_or(type_path);
+        let name = event_name.strip_suffix("Event").unwrap_or(event_name);
+        ModelInfo {
+            name: name.to_string(),
+            package: Self::package().to_string(),
+            type_path: type_path.to_string(),
+            source: Self::source(),
+        }
+    }
+}
+
+/// Call from a downstream crate's `build.rs` to capture that crate's repository
+/// git into `QUENT_SOURCE_*` env vars. The `model!`/`instrumentation!` macros
+/// read them via `option_env!`, so the values bake into the downstream crate.
+///
+/// Requires a `build-dependencies` entry on `quent-build-info` and that the
+/// `build.rs` lives in the same package that invokes the macros.
+pub fn emit_source() {
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    git::emit("QUENT_SOURCE", &manifest_dir);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestModel;
+
+    impl ModelSource for TestModel {
+        fn package() -> &'static str {
+            "quent-build-info"
+        }
+        fn source() -> BuildInfo {
+            BuildInfo::unknown()
+        }
+    }
+
+    #[test]
+    fn unknown_build_info_omits_absent_fields() {
+        // Only `version` is non-optional, so absent provenance serializes to a
+        // single key rather than a string of `"unknown"` sentinels.
+        let json = serde_json::to_string(&BuildInfo::unknown()).unwrap();
+        assert_eq!(json, r#"{"version":"unknown"}"#);
+    }
+
+    #[test]
+    fn artifact_info_roundtrips() {
+        let info = ArtifactInfo::new(TestModel::model_info());
+        let bytes = serde_json::to_vec(&info).unwrap();
+        let back: ArtifactInfo = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(info, back);
+    }
+
+    #[test]
+    fn write_sidecar_is_atomic_and_named() {
+        let dir = std::env::temp_dir().join("quent_build_info_sidecar_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        ArtifactInfo::new(TestModel::model_info())
+            .write_sidecar(&dir)
+            .unwrap();
+
+        assert!(dir.join(SIDECAR_FILE_NAME).is_file());
+        // The temp file used for the atomic rename must not linger.
+        assert!(!dir.join(format!(".{SIDECAR_FILE_NAME}.tmp")).exists());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/collector/server/Cargo.toml
+++ b/crates/collector/server/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [dependencies]
 ciborium = "0.2.2"
 dashmap = "6.1.0"
+quent-build-info = { path = "../../build-info" }
 quent-collector-proto = { path = "../proto" }
 quent-exporter-types = { path = "../../exporter/types" }
 quent-exporter = { path = "../../exporter" }

--- a/crates/collector/server/src/lib.rs
+++ b/crates/collector/server/src/lib.rs
@@ -6,3 +6,8 @@
 //! This allows multiple sources to send events to a centralized place, where it can be further processed / exported.
 
 pub mod server;
+
+/// Re-exported so callers constructing a [`server::CollectorService`] over a
+/// generic event type can bound it without depending on `quent-build-info`
+/// directly.
+pub use quent_build_info::ModelSource;

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
+use quent_build_info::{ArtifactInfo, ModelSource};
 use quent_exporter::{ExporterOptions, create_exporter};
 use quent_exporter_types::Exporter;
 use serde::{Deserialize, Serialize};
@@ -51,7 +52,7 @@ impl<T> CollectorService<T> {
 #[tonic::async_trait]
 impl<T> proto::collector_server::Collector for CollectorService<T>
 where
-    for<'de> T: Serialize + Deserialize<'de> + Send + 'static,
+    for<'de> T: Serialize + Deserialize<'de> + Send + ModelSource + 'static,
 {
     #[tracing::instrument]
     async fn collect_events(
@@ -90,6 +91,15 @@ where
                                     break;
                                 }
                             };
+                            // Write the provenance sidecar once per application,
+                            // alongside the events this exporter just created
+                            // the directory for (filesystem exporters only).
+                            if let Some(dir) = exporter_kind.filesystem_root() {
+                                let info = ArtifactInfo::new(T::model_info());
+                                if let Err(e) = info.write_sidecar(dir) {
+                                    warn!("failed to write provenance sidecar: {e}");
+                                }
+                            }
                             exporters.insert(application_id, Arc::clone(&exporter));
                             exporter
                         };

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -61,6 +61,17 @@ impl ExporterOptions {
             ExporterOptions::Collector(options) => ExporterOptions::Collector(options),
         }
     }
+
+    /// Filesystem output directory for filesystem exporters; `None` for
+    /// exporters (e.g. the collector) that do not write a local directory.
+    /// Used to locate where a provenance sidecar should be written.
+    pub fn filesystem_root(&self) -> Option<&std::path::Path> {
+        match self {
+            ExporterOptions::FileSystem(options) => Some(&options.root),
+            #[cfg(feature = "collector")]
+            ExporterOptions::Collector(_) => None,
+        }
+    }
 }
 
 /// Selects an importer and its options.

--- a/crates/instrumentation/Cargo.toml
+++ b/crates/instrumentation/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish.workspace = true
 [dependencies]
 quent-attributes = { path = "../attributes" }
+quent-build-info = { path = "../build-info" }
 quent-events = { path = "../events" }
 quent-exporter = { path = "../exporter" }
 quent-exporter-types = { path = "../exporter/types" }

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -38,6 +38,15 @@ type BenchResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 #[derive(Serialize, Deserialize)]
 struct BenchEvent;
 
+impl quent_build_info::ModelSource for BenchEvent {
+    fn package() -> &'static str {
+        "quent-instrumentation"
+    }
+    fn source() -> quent_build_info::BuildInfo {
+        quent_build_info::BuildInfo::unknown()
+    }
+}
+
 // Starts the in-process collector server and leaks its runtime, so the
 // server task and its file handles outlive `try_bench_emit`. Dropping the
 // runtime mid-operation triggers an internal `unwrap` panic in tokio's

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Quent Instrumentation API
 //!
+use quent_build_info::{ArtifactInfo, ModelSource};
 use quent_events::Event;
 use quent_exporter::{ExporterOptions, create_exporter};
 use quent_exporter_types::Exporter;
@@ -101,7 +102,10 @@ impl<T> Context<T>
 where
     T: Serialize + Send + 'static,
 {
-    pub fn try_new(exporter: Option<ExporterOptions>) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn try_new(exporter: Option<ExporterOptions>) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        T: ModelSource,
+    {
         let id = Uuid::now_v7();
         let kind = match exporter {
             None => {
@@ -139,7 +143,19 @@ where
 
         debug!("constructing exporter");
         let kind = kind.in_context_dir(id);
+        // Provenance sidecar destination, captured before `kind` is consumed.
+        let sidecar_dir = kind.filesystem_root().map(std::path::Path::to_path_buf);
         let exporter: Arc<dyn Exporter<T>> = handle.block_on(create_exporter(kind))?;
+
+        // Write the provenance sidecar once per context, alongside the events
+        // the exporter just created the directory for. Filesystem exporters
+        // only; the collector server writes it for collector-routed events.
+        if let Some(dir) = sidecar_dir {
+            let info = ArtifactInfo::new(T::model_info());
+            if let Err(e) = info.write_sidecar(&dir) {
+                warn!("failed to write provenance sidecar: {e}");
+            }
+        }
 
         let cancellation_token = CancellationToken::new();
         let cloned_token = cancellation_token.clone();
@@ -233,6 +249,15 @@ mod tests {
 
     #[derive(Debug, serde::Serialize)]
     struct TestEvent;
+
+    impl ModelSource for TestEvent {
+        fn package() -> &'static str {
+            "quent-instrumentation"
+        }
+        fn source() -> quent_build_info::BuildInfo {
+            quent_build_info::BuildInfo::unknown()
+        }
+    }
 
     #[test]
     fn noop_exporter() {

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -202,6 +202,27 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
             }
         )*
 
+        // Records this model's package and source git so exporters can trace an
+        // artifact back to the crate that defines it — including out-of-repo
+        // crates, whose own `build.rs` populates `QUENT_SOURCE_*` (in-repo it
+        // falls back to quent's git). `env!`/`option_env!` resolve in the crate
+        // that invokes `model!`. The type path and name come from `type_name`.
+        impl quent_model::build_info::ModelSource for #event_type {
+            fn package() -> &'static str {
+                env!("CARGO_PKG_NAME")
+            }
+            fn source() -> quent_model::build_info::BuildInfo {
+                quent_model::build_info::source_or_quent(
+                    env!("CARGO_PKG_VERSION"),
+                    option_env!("QUENT_SOURCE_REMOTE"),
+                    option_env!("QUENT_SOURCE_COMMIT"),
+                    option_env!("QUENT_SOURCE_BRANCH"),
+                    option_env!("QUENT_SOURCE_DIRTY"),
+                    option_env!("QUENT_SOURCE_BUILT_AT"),
+                )
+            }
+        }
+
         const _: () = {
             assert!(
                 <#root as quent_model::ResourceGroup>::IS_ROOT,

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -12,6 +12,7 @@ serde = ["dep:serde", "quent-model-macros/serde", "uuid/serde"]
 uuid = { workspace = true, features = ["v7"] }
 serde = { workspace = true, optional = true }
 quent-attributes = { path = "../attributes" }
+quent-build-info = { path = "../build-info" }
 quent-model-macros = { path = "../model-macros" }
 quent-events = { path = "../events" }
 quent-exporter = { path = "../exporter" }

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -84,6 +84,7 @@ pub trait ResourceGroup {
 
 // Re-export instrumentation types needed by generated code.
 pub use quent_attributes as attributes;
+pub use quent_build_info as build_info;
 pub use quent_events::Event;
 pub use quent_exporter as exporter;
 pub use quent_instrumentation::Context;

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -45,7 +45,7 @@ pub fn collector_service<E>(
     options: CollectorServiceOptions,
 ) -> Result<Router, Box<dyn std::error::Error>>
 where
-    E: Serialize + Send + Sync + 'static,
+    E: Serialize + Send + Sync + 'static + quent_collector::ModelSource,
     for<'de> E: Deserialize<'de>,
 {
     let collector = CollectorService::<E>::new(options);


### PR DESCRIPTION
Emit artifact provenance so downstream tools (e.g. quent-open) can locate and check out the producing crate and pick the Rust type to build a viewer, without a hand-maintained config.

Rather than embedding a header in every artifact (which forced per-format header machinery and header-skipping importers), the instrumentation Context writes a single `model.qmi` JSON sidecar into its per-context directory, once per context. With one exporter per observer planned (#229) this keeps provenance to one file per trace and leaves event streams pure.

- New `quent-build-info` crate: `BuildInfo`/`ModelInfo`/`ArtifactInfo` types, `ModelSource`, `model_info`, and a `build.rs` capturing the quent repo git (degrades to "unknown" without .git). `ArtifactInfo::write_sidecar` writes `model.qmi` as pretty JSON.
- `model!` generates a per-model `ModelSource` impl so out-of-repo crates record their own package and git (via `emit_source()` in their build.rs); in-repo models fall back to quent's git. Only a `T: ModelSource` bound is threaded — exporters/importers and call sites are otherwise untouched.
- The collector server writes the sidecar once per application when it persists collector-routed events.

Closes #231.
Contributes to #234. 