### PR TITLE
feat(server): add MCP server for telemetry analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +318,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +471,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -601,6 +648,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +735,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -798,12 +885,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -811,6 +914,23 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -841,9 +961,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -879,6 +1003,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1083,6 +1208,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1317,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1512,6 +1667,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -2174,8 +2335,11 @@ dependencies = [
  "quent-query-engine-ui",
  "quent-time",
  "quent-ui",
+ "rmcp",
  "rust-embed",
+ "schemars",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -2269,7 +2433,7 @@ dependencies = [
  "quent-query-engine-model",
  "quent-simulator-instrumentation",
  "quent-stdlib",
- "rand",
+ "rand 0.9.3",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2398,7 +2562,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2408,7 +2583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2419,6 +2594,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2447,6 +2628,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2485,6 +2686,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -2596,6 +2840,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,6 +2907,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2695,7 +2976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2761,6 +3042,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3542,10 +3836,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,8 +109,10 @@ petgraph = "0.8.3"
 postcard = { version = "1", features = ["alloc"] }
 prost = "0.14.1"
 pyo3 = "0.29"
+rmcp = { version = "1.7.0", default-features = false }
 rmp-serde = "1"
 rustc-hash = "2"
+schemars = "1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 smallvec = {version = "1.15.1", features = ["serde"] }

--- a/domains/query_engine/server/Cargo.toml
+++ b/domains/query_engine/server/Cargo.toml
@@ -6,6 +6,13 @@ publish.workspace = true
 [features]
 swagger = ["dep:utoipa", "dep:utoipa-swagger-ui"]
 ui = ["dep:mime_guess", "dep:rust-embed"]
+mcp = [
+    "dep:rmcp",
+    "dep:schemars",
+    "dep:serde_json",
+    "tokio/io-std",
+    "tokio/macros",
+]
 
 [dependencies]
 axum = { version = "0.8.7" }
@@ -19,7 +26,15 @@ quent-query-engine-analyzer = { path = "../../../domains/query_engine/analyzer" 
 quent-query-engine-ui = { path = "../../../domains/query_engine/ui" }
 quent-time = { path = "../../../crates/time" }
 quent-ui = { path = "../../../crates/ui" }
+rmcp = { workspace = true, features = [
+    "server",
+    "macros",
+    "transport-io",
+    "transport-streamable-http-server",
+], optional = true }
+schemars = { workspace = true, optional = true }
 serde.workspace = true
+serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"]}
 tonic.workspace = true

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -109,12 +109,7 @@ where
             // Sent when a browser client resumes an interrupted SSE stream.
             const LAST_EVENT_ID: HeaderName = HeaderName::from_static("last-event-id");
             cors = cors
-                .allow_methods([
-                    Method::GET,
-                    Method::POST,
-                    Method::OPTIONS,
-                    Method::DELETE,
-                ])
+                .allow_methods([Method::GET, Method::POST, Method::OPTIONS, Method::DELETE])
                 .allow_headers([
                     CONTENT_TYPE,
                     MCP_SESSION_ID,

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -15,6 +15,8 @@ use tower_http::cors::CorsLayer;
 
 pub mod analyzer_cache;
 pub mod error;
+#[cfg(feature = "mcp")]
+pub mod mcp;
 mod state;
 mod timeline_cache;
 mod ui;
@@ -66,7 +68,15 @@ where
         timelines: TimelineCache::new(),
     };
 
+    #[cfg(feature = "mcp")]
+    let mcp_service = mcp::http_service(state.clone());
+
     let mut http_routes = axum::Router::new().nest("/api/engines", ui::routes(state));
+
+    #[cfg(feature = "mcp")]
+    {
+        http_routes = http_routes.nest_service("/mcp", mcp_service);
+    }
 
     #[cfg(feature = "swagger")]
     {
@@ -78,7 +88,7 @@ where
     }
 
     if let Some(cors) = cors {
-        let cors = CorsLayer::new()
+        let mut cors = CorsLayer::new()
             .allow_origin(cors.parse::<axum::http::HeaderValue>().unwrap())
             .allow_methods([
                 axum::http::Method::GET,
@@ -86,6 +96,34 @@ where
                 axum::http::Method::OPTIONS,
             ])
             .allow_headers([axum::http::header::CONTENT_TYPE]);
+
+        // The streamable HTTP MCP transport adds session/protocol headers, uses
+        // DELETE to tear down a session, and returns the session id to the
+        // client, so browser-based MCP clients need these allowed and exposed.
+        #[cfg(feature = "mcp")]
+        {
+            use axum::http::{HeaderName, Method, header::CONTENT_TYPE};
+            const MCP_SESSION_ID: HeaderName = HeaderName::from_static("mcp-session-id");
+            const MCP_PROTOCOL_VERSION: HeaderName =
+                HeaderName::from_static("mcp-protocol-version");
+            // Sent when a browser client resumes an interrupted SSE stream.
+            const LAST_EVENT_ID: HeaderName = HeaderName::from_static("last-event-id");
+            cors = cors
+                .allow_methods([
+                    Method::GET,
+                    Method::POST,
+                    Method::OPTIONS,
+                    Method::DELETE,
+                ])
+                .allow_headers([
+                    CONTENT_TYPE,
+                    MCP_SESSION_ID,
+                    MCP_PROTOCOL_VERSION,
+                    LAST_EVENT_ID,
+                ])
+                .expose_headers([MCP_SESSION_ID]);
+        }
+
         http_routes = http_routes.layer(cors);
     }
 

--- a/domains/query_engine/server/src/mcp.rs
+++ b/domains/query_engine/server/src/mcp.rs
@@ -185,7 +185,13 @@ where
         Parameters(arg): Parameters<ListEnginesArg>,
     ) -> Result<CallToolResult, ErrorData> {
         if arg.with_metadata {
-            json_ok(self.state.analyzers.list_with_metadata().await.map_err(err)?)
+            json_ok(
+                self.state
+                    .analyzers
+                    .list_with_metadata()
+                    .await
+                    .map_err(err)?,
+            )
         } else {
             let engines: Vec<ui::Engine> = self
                 .state
@@ -382,7 +388,12 @@ where
 }
 
 /// Recursively render a [`PlanTree`] node and its children into `out`.
-fn render_plan_tree<M: QueryEngineModel>(model: &M, node: &PlanTree, depth: usize, out: &mut String) {
+fn render_plan_tree<M: QueryEngineModel>(
+    model: &M,
+    node: &PlanTree,
+    depth: usize,
+    out: &mut String,
+) {
     let indent = "  ".repeat(depth);
     let worker = node
         .worker
@@ -401,7 +412,10 @@ fn render_plan_tree<M: QueryEngineModel>(model: &M, node: &PlanTree, depth: usiz
         .collect();
     operator_names.sort();
     if !operator_names.is_empty() {
-        out.push_str(&format!("{indent}  operators: {}\n", operator_names.join(", ")));
+        out.push_str(&format!(
+            "{indent}  operators: {}\n",
+            operator_names.join(", ")
+        ));
     }
 
     for child in &node.children {

--- a/domains/query_engine/server/src/mcp.rs
+++ b/domains/query_engine/server/src/mcp.rs
@@ -1,0 +1,464 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Model Context Protocol (MCP) server exposing the analyzer surface as tools.
+//!
+//! This lets AI agents connect to a running quent analysis server and explore
+//! telemetry data. The handler is generic over [`UiAnalyzer`], reusing the same
+//! [`ServiceState`] (analyzer + timeline caches) as the REST API, so out-of-repo
+//! analyzers get MCP support for free.
+//!
+//! Two transports are provided:
+//! - [`http_service`] returns a tower service that mounts into the Axum analyzer
+//!   router (e.g. at `/mcp`).
+//! - [`serve_stdio`] runs the server over stdin/stdout for clients that spawn it
+//!   as a subprocess.
+//!
+//! The tools mirror the REST endpoints (`list_engines`, `get_engine`,
+//! `list_query_groups`, `list_queries`, `get_query`, `single_timeline`) and add
+//! a few agent-friendly summaries (`engine_overview`, `plan_tree`,
+//! `slowest_operators`).
+
+use std::sync::Arc;
+
+use rmcp::{
+    ErrorData, ServerHandler, ServiceExt,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+    transport::{
+        io::stdio,
+        streamable_http_server::{
+            session::local::LocalSessionManager,
+            tower::{StreamableHttpServerConfig, StreamableHttpService},
+        },
+    },
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use quent_analyzer::Entity;
+use quent_query_engine_analyzer::{
+    QueryEngineModel, plan::tree::PlanTree, query_group::QueryGroup, ui::UiAnalyzer,
+};
+use quent_query_engine_ui as ui;
+use quent_ui::timeline::request::SingleTimelineRequest;
+
+use crate::{
+    analyzer_cache::{AnalyzerCache, ImporterFn, ListerFn},
+    error::ServerError,
+    state::ServiceState,
+    timeline_cache::TimelineCache,
+};
+
+/// Default name reported to MCP clients.
+const SERVER_NAME: &str = "quent-analyzer";
+
+/// Env var to relax the HTTP transport's Host allowlist for non-local
+/// deployments: a comma-separated list of allowed hosts, or `*` to disable the
+/// check. Unset keeps rmcp's secure loopback-only default. See [`http_service`].
+const ENV_ALLOWED_HOSTS: &str = "QUENT_MCP_ALLOWED_HOSTS";
+
+/// Human-readable guidance shown to agents on connect.
+const INSTRUCTIONS: &str = "\
+Quent exposes query-engine telemetry for performance analysis. Typical exploration flow:
+1. `list_engines` to discover capture sessions (engines). Pass with_metadata=true for names/durations.
+2. `engine_overview` for a quick summary (counts + duration) of one engine.
+3. `list_query_groups` then `list_queries` to drill into the queries an engine ran.
+4. `get_query` for the full query bundle (entities, plan tree, resource tree).
+5. `plan_tree` / `slowest_operators` for digested views of a single query.
+6. `single_timeline` for binned resource-usage timelines (advanced; request shape matches the
+   REST POST /api/engines/{engine_id}/timeline/single body — use get_query to find resource ids).
+All ids are UUID strings.";
+
+#[derive(Deserialize, JsonSchema)]
+struct ListEnginesArg {
+    /// Include engine metadata (name, duration). Slower: reads each engine's events.
+    #[serde(default)]
+    with_metadata: bool,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct EngineArg {
+    /// UUID of the engine.
+    engine_id: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct QueryGroupArg {
+    /// UUID of the engine.
+    engine_id: String,
+    /// UUID of the query group.
+    query_group_id: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct QueryArg {
+    /// UUID of the engine.
+    engine_id: String,
+    /// UUID of the query.
+    query_id: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct SlowestOperatorsArg {
+    /// UUID of the engine.
+    engine_id: String,
+    /// UUID of the query.
+    query_id: String,
+    /// Maximum number of operators to return (default 10).
+    #[serde(default)]
+    limit: Option<u32>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct SingleTimelineArg {
+    /// UUID of the engine.
+    engine_id: String,
+    /// Timeline request body, matching the REST `POST /timeline/single` shape.
+    request: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct OperatorTiming {
+    operator_id: Uuid,
+    operator_type_name: Option<String>,
+    instance_name: Option<String>,
+    active_duration_s: Option<f64>,
+}
+
+/// Parse a UUID tool argument, mapping failures to an MCP invalid-params error.
+fn parse_uuid(value: &str, field: &str) -> Result<Uuid, ErrorData> {
+    Uuid::parse_str(value)
+        .map_err(|e| ErrorData::invalid_params(format!("invalid {field}: {e}"), None))
+}
+
+/// Map any analyzer/server error into an MCP internal error.
+fn err<E: Into<ServerError>>(e: E) -> ErrorData {
+    ErrorData::internal_error(e.into().to_string(), None)
+}
+
+/// Serialize a value as JSON tool content.
+fn json_ok<T: Serialize>(value: T) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::success(vec![Content::json(value)?]))
+}
+
+/// MCP server exposing the query-engine analyzer surface as tools.
+pub struct QuentMcpServer<A: UiAnalyzer + Send + Sync + 'static> {
+    state: ServiceState<A>,
+    tool_router: ToolRouter<Self>,
+}
+
+impl<A> Clone for QuentMcpServer<A>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            tool_router: self.tool_router.clone(),
+        }
+    }
+}
+
+#[tool_router]
+impl<A> QuentMcpServer<A>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+    <A as UiAnalyzer>::EntityRef: Serialize,
+{
+    /// Build a server over an existing analyzer service state.
+    pub fn new(state: ServiceState<A>) -> Self {
+        Self {
+            state,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        description = "List all engines (telemetry capture sessions). Set with_metadata=true to \
+                       include each engine's name and duration."
+    )]
+    async fn list_engines(
+        &self,
+        Parameters(arg): Parameters<ListEnginesArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if arg.with_metadata {
+            json_ok(self.state.analyzers.list_with_metadata().await.map_err(err)?)
+        } else {
+            let engines: Vec<ui::Engine> = self
+                .state
+                .analyzers
+                .list()
+                .map_err(err)?
+                .into_iter()
+                .map(ui::Engine::new)
+                .collect();
+            json_ok(engines)
+        }
+    }
+
+    #[tool(description = "Get details (name, duration, implementation) for one engine by id.")]
+    async fn get_engine(
+        &self,
+        Parameters(arg): Parameters<EngineArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        let engine = analyzer.query_engine_model().engine().map_err(err)?;
+        json_ok(engine.to_ui().map_err(err)?)
+    }
+
+    #[tool(description = "List all query groups for an engine.")]
+    async fn list_query_groups(
+        &self,
+        Parameters(arg): Parameters<EngineArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        let groups: Vec<ui::QueryGroup> = analyzer
+            .query_engine_model()
+            .query_groups()
+            .map(QueryGroup::to_ui)
+            .collect();
+        json_ok(groups)
+    }
+
+    #[tool(description = "List all queries in a query group.")]
+    async fn list_queries(
+        &self,
+        Parameters(arg): Parameters<QueryGroupArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let query_group_id = parse_uuid(&arg.query_group_id, "query_group_id")?;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        let queries = analyzer
+            .query_engine_model()
+            .queries()
+            .filter(|q| q.query_group_id() == Some(query_group_id))
+            .map(|q| q.to_ui())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(err)?;
+        json_ok(queries)
+    }
+
+    #[tool(
+        description = "Get the full query bundle for one query: entities, plan tree, and resource \
+                       tree. Large; prefer plan_tree / slowest_operators for a quick look."
+    )]
+    async fn get_query(
+        &self,
+        Parameters(arg): Parameters<QueryArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let query_id = parse_uuid(&arg.query_id, "query_id")?;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        json_ok(analyzer.query_bundle(query_id).map_err(err)?)
+    }
+
+    #[tool(
+        description = "Summarize an engine: counts of query groups, queries, and workers, plus \
+                       engine name and duration."
+    )]
+    async fn engine_overview(
+        &self,
+        Parameters(arg): Parameters<EngineArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        let model = analyzer.query_engine_model();
+        let engine = model.engine().map_err(err)?.to_ui().map_err(err)?;
+        json_ok(serde_json::json!({
+            "engine": engine,
+            "num_query_groups": model.query_groups().count(),
+            "num_queries": model.queries().count(),
+            "num_workers": model.workers().count(),
+        }))
+    }
+
+    #[tool(
+        description = "Render the plan tree of one query as indented text, annotating each plan \
+                       with its worker and operator type names."
+    )]
+    async fn plan_tree(
+        &self,
+        Parameters(arg): Parameters<QueryArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let query_id = parse_uuid(&arg.query_id, "query_id")?;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        let model = analyzer.query_engine_model();
+        let tree = model.plan_tree(query_id).map_err(err)?;
+
+        let mut out = String::new();
+        render_plan_tree(model, &tree, 0, &mut out);
+        Ok(CallToolResult::success(vec![Content::text(out)]))
+    }
+
+    #[tool(
+        description = "List a query's operators ranked by active duration (longest first). \
+                       Useful for spotting bottlenecks."
+    )]
+    async fn slowest_operators(
+        &self,
+        Parameters(arg): Parameters<SlowestOperatorsArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let query_id = parse_uuid(&arg.query_id, "query_id")?;
+        let limit = arg.limit.unwrap_or(10) as usize;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        let model = analyzer.query_engine_model();
+        let epoch = model.query_epoch(query_id).map_err(err)?;
+        let plans = model.query_plans(query_id).map_err(err)?;
+
+        let mut timings: Vec<OperatorTiming> = model
+            .plans_operators(plans)
+            .map_err(err)?
+            .map(|op| {
+                let ui = op.to_ui(epoch);
+                OperatorTiming {
+                    operator_id: ui.id,
+                    operator_type_name: ui.operator_type_name,
+                    instance_name: ui.instance_name,
+                    active_duration_s: ui.active_span.map(|span| span.duration()),
+                }
+            })
+            .collect();
+
+        // Longest active duration first; operators without a span sort last.
+        timings.sort_by(|a, b| {
+            let a = a.active_duration_s.unwrap_or(f64::NEG_INFINITY);
+            let b = b.active_duration_s.unwrap_or(f64::NEG_INFINITY);
+            b.total_cmp(&a)
+        });
+        timings.truncate(limit);
+        json_ok(timings)
+    }
+
+    #[tool(
+        description = "Fetch a single binned resource (or resource-group) timeline. The `request` \
+                       field matches the REST POST /api/engines/{engine_id}/timeline/single body."
+    )]
+    async fn single_timeline(
+        &self,
+        Parameters(arg): Parameters<SingleTimelineArg>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let engine_id = parse_uuid(&arg.engine_id, "engine_id")?;
+        let request: SingleTimelineRequest<ui::QueryFilter, ui::OperatorFilter> =
+            serde_json::from_value(arg.request).map_err(|e| {
+                ErrorData::invalid_params(format!("invalid timeline request: {e}"), None)
+            })?;
+        let analyzer = self.state.analyzers.get(engine_id).await.map_err(err)?;
+        let response = self
+            .state
+            .timelines
+            .cached_single_timeline(analyzer, engine_id, request)
+            .await
+            .map_err(err)?;
+        json_ok(response)
+    }
+}
+
+#[tool_handler]
+impl<A> ServerHandler for QuentMcpServer<A>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+    <A as UiAnalyzer>::EntityRef: Serialize,
+{
+    fn get_info(&self) -> ServerInfo {
+        // `ServerInfo`/`Implementation` are `#[non_exhaustive]`, so build via
+        // defaults and field assignment rather than struct literals.
+        let mut server_info = Implementation::from_build_env();
+        server_info.name = SERVER_NAME.to_string();
+        server_info.version = env!("CARGO_PKG_VERSION").to_string();
+
+        let mut info = ServerInfo::default();
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.server_info = server_info;
+        info.instructions = Some(INSTRUCTIONS.to_string());
+        info
+    }
+}
+
+/// Recursively render a [`PlanTree`] node and its children into `out`.
+fn render_plan_tree<M: QueryEngineModel>(model: &M, node: &PlanTree, depth: usize, out: &mut String) {
+    let indent = "  ".repeat(depth);
+    let worker = node
+        .worker
+        .map(|w| format!(" (worker {w})"))
+        .unwrap_or_default();
+    out.push_str(&format!("{indent}plan {}{worker}\n", node.id));
+
+    let mut operator_names: Vec<String> = model
+        .operators()
+        .filter(|op| op.plan_id() == Some(node.id))
+        .map(|op| {
+            op.operator_type_name()
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("operator {}", op.id()))
+        })
+        .collect();
+    operator_names.sort();
+    if !operator_names.is_empty() {
+        out.push_str(&format!("{indent}  operators: {}\n", operator_names.join(", ")));
+    }
+
+    for child in &node.children {
+        render_plan_tree(model, child, depth + 1, out);
+    }
+}
+
+/// Build a [`StreamableHttpService`] that can be mounted into an Axum router.
+///
+/// Mount it with `router.nest_service("/mcp", mcp::http_service(state))`.
+pub fn http_service<A>(
+    state: ServiceState<A>,
+) -> StreamableHttpService<QuentMcpServer<A>, LocalSessionManager>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+    <A as UiAnalyzer>::EntityRef: Serialize,
+{
+    // rmcp's default Host allowlist is loopback-only — a DNS-rebinding guard
+    // that stops a malicious web page from driving a victim's local analyzer.
+    // Keep that secure default. Non-local deployments (reached via a hostname or
+    // IP) opt in via `QUENT_MCP_ALLOWED_HOSTS`: a comma-separated host list, or
+    // `*` to disable the check entirely (e.g. when fronted by an authenticating
+    // proxy). See [`ENV_ALLOWED_HOSTS`].
+    let mut config = StreamableHttpServerConfig::default();
+    if let Ok(hosts) = std::env::var(ENV_ALLOWED_HOSTS) {
+        let hosts = hosts.trim();
+        config = if hosts == "*" {
+            config.disable_allowed_hosts()
+        } else {
+            config.with_allowed_hosts(hosts.split(',').map(|h| h.trim().to_string()))
+        };
+    }
+    StreamableHttpService::new(
+        move || Ok(QuentMcpServer::new(state.clone())),
+        Arc::new(LocalSessionManager::default()),
+        config,
+    )
+}
+
+/// Serve the MCP server over stdio until the client disconnects.
+///
+/// Builds the analyzer service state from `importer`/`lister` (the same
+/// callbacks the HTTP server uses) and runs the protocol on stdin/stdout.
+/// Logs must go to stderr — stdout carries the MCP protocol.
+pub async fn serve_stdio<A>(
+    importer: Box<ImporterFn<A>>,
+    lister: Box<ListerFn>,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+    <A as UiAnalyzer>::EntityRef: Serialize,
+{
+    let state = ServiceState {
+        analyzers: AnalyzerCache::<A>::new(importer, lister),
+        timelines: TimelineCache::new(),
+    };
+    let service = QuentMcpServer::new(state).serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/examples/simulator/server/Cargo.toml
+++ b/examples/simulator/server/Cargo.toml
@@ -3,9 +3,13 @@ name = "quent-simulator-server"
 version.workspace = true
 edition.workspace =  true
 publish.workspace = true
+# With the `mcp` feature there are two eligible binaries; keep `cargo run` on the
+# HTTP server (the stdio MCP binary is run explicitly via `--bin quent-simulator-mcp`).
+default-run = "quent-simulator-server"
 [features]
 ui = ["quent-query-engine-server/ui"]
 swagger = ["quent-query-engine-server/swagger"]
+mcp = ["quent-query-engine-server/mcp"]
 
 [dependencies]
 axum = { version = "0.8.7" }
@@ -18,6 +22,15 @@ quent-simulator-instrumentation = { path = "../instrumentation" }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"]}
 tracing.workspace = true
 uuid.workspace = true
+
+[[bin]]
+name = "quent-simulator-server"
+path = "src/main.rs"
+
+[[bin]]
+name = "quent-simulator-mcp"
+path = "src/bin/mcp.rs"
+required-features = ["mcp"]
 
 [build-dependencies]
 ts-rs = {workspace = true, features = ["uuid-impl", "serde-json-impl"] }

--- a/examples/simulator/server/src/bin/mcp.rs
+++ b/examples/simulator/server/src/bin/mcp.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stdio MCP server for the simulator.
+//!
+//! Exposes the same analysis tools as the HTTP `/mcp` endpoint, but over
+//! stdin/stdout for MCP clients that spawn the server as a subprocess. Reads
+//! previously collected telemetry from `--output-dir`.
+//!
+//! Logs go to stderr; stdout is reserved for the MCP protocol.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use quent_query_engine_server::{initialize_tracing, mcp::serve_stdio};
+use quent_simulator_analyzer::SimulatorUiAnalyzer;
+use quent_simulator_server::{build_importer, build_lister, parse_format};
+
+#[derive(Parser)]
+struct Args {
+    /// Log level filter (e.g. "debug", "info", "warn", "error").
+    /// Overridden by the RUST_LOG environment variable if set.
+    #[arg(long, default_value = "info")]
+    log_level: String,
+
+    /// Exporter format of the collected event data (ndjson, msgpack, postcard).
+    #[arg(long, default_value = "ndjson", env = "QUENT_COLLECTOR_EXPORTER")]
+    exporter: String,
+
+    /// Directory holding the collected event data.
+    #[arg(long, default_value = "data", env = "QUENT_COLLECTOR_OUTPUT_DIR")]
+    output_dir: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let Args {
+        log_level,
+        exporter,
+        output_dir,
+    } = Args::parse();
+
+    initialize_tracing(&log_level);
+
+    let format = parse_format(&exporter)?;
+    let importer = build_importer(format, output_dir.clone());
+    let lister = build_lister(output_dir);
+
+    tracing::info!("serving MCP over stdio");
+    serve_stdio::<SimulatorUiAnalyzer>(importer, lister).await
+}

--- a/examples/simulator/server/src/lib.rs
+++ b/examples/simulator/server/src/lib.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared setup for the simulator server binaries.
+//!
+//! Both the HTTP analyzer server (`main.rs`) and the stdio MCP server
+//! (`bin/mcp.rs`) read previously collected telemetry from a filesystem
+//! directory. The importer/lister callbacks and exporter-format parsing live
+//! here so both binaries stay in sync.
+
+use std::path::PathBuf;
+
+use quent_exporter::{
+    FileSystemFormat, FileSystemImporterOptions, ImporterOptions, create_importer,
+};
+use quent_query_engine_server::analyzer_cache::{ImporterFn, ListerFn};
+use quent_simulator_analyzer::SimulatorUiAnalyzer;
+use quent_simulator_instrumentation::SimulatorEvent;
+use uuid::Uuid;
+
+/// Parse an exporter-format CLI string into a [`FileSystemFormat`].
+pub fn parse_format(exporter: &str) -> Result<FileSystemFormat, Box<dyn std::error::Error>> {
+    match exporter {
+        "ndjson" => Ok(FileSystemFormat::Ndjson),
+        "msgpack" => Ok(FileSystemFormat::Msgpack),
+        "postcard" => Ok(FileSystemFormat::Postcard),
+        other => Err(format!("unknown exporter: {other}").into()),
+    }
+}
+
+/// Build a lister that enumerates engine ids from `output_dir`.
+///
+/// Each context exports to its own `output_dir/<context-id>/` subdirectory;
+/// this lists those subdirectories whose name parses as a UUID.
+pub fn build_lister(output_dir: PathBuf) -> Box<ListerFn> {
+    Box::new(move || {
+        let mut ids = Vec::new();
+        for entry in std::fs::read_dir(&output_dir)? {
+            let path = entry?.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if let Some(id) = path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .and_then(|s| Uuid::parse_str(s).ok())
+            {
+                ids.push(id);
+            }
+        }
+        Ok(ids)
+    })
+}
+
+/// Build an importer that reads an engine's events from its per-context
+/// `output_dir/<context-id>/` directory using the configured `format`.
+pub fn build_importer(
+    format: FileSystemFormat,
+    output_dir: PathBuf,
+) -> Box<ImporterFn<SimulatorUiAnalyzer>> {
+    Box::new(move |context_id| {
+        let dir = output_dir.join(format!("{context_id}"));
+        let kind = ImporterOptions::FileSystem(FileSystemImporterOptions { format, path: dir });
+        Ok(Box::new(create_importer::<SimulatorEvent>(&kind)?) as Box<dyn Iterator<Item = _>>)
+    })
+}

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -3,17 +3,13 @@
 
 use std::{net::ToSocketAddrs, path::PathBuf};
 
-use uuid::Uuid;
-
 use clap::Parser;
 use quent_collector::server::CollectorServiceOptions;
-use quent_exporter::{
-    ExporterOptions, FileSystemExporterOptions, FileSystemFormat, FileSystemImporterOptions,
-    ImporterOptions, create_importer,
-};
+use quent_exporter::{ExporterOptions, FileSystemExporterOptions};
 use quent_query_engine_server::{analyzer_service_router, collector_service, initialize_tracing};
 use quent_simulator_analyzer::SimulatorUiAnalyzer;
 use quent_simulator_instrumentation::SimulatorEvent;
+use quent_simulator_server::{build_importer, build_lister, parse_format};
 use tokio::net::TcpListener;
 
 mod defaults {
@@ -91,12 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let importer_output_dir = output_dir.clone();
     let lister_output_dir = output_dir.clone();
 
-    let format = match exporter.as_str() {
-        "ndjson" => FileSystemFormat::Ndjson,
-        "msgpack" => FileSystemFormat::Msgpack,
-        "postcard" => FileSystemFormat::Postcard,
-        other => return Err(format!("unknown exporter: {other}").into()),
-    };
+    let format = parse_format(&exporter)?;
     let exporter_kind = ExporterOptions::FileSystem(FileSystemExporterOptions {
         format,
         root: output_dir,
@@ -117,43 +108,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .next()
         .ok_or_else(|| format!("unable to resolve socket address: {analyzer_address}"))?;
 
-    // Each context exports to its own `output_dir/<context-id>/` subdirectory;
-    // list those subdirectories whose name is a uuid.
-    let lister = move || {
-        let mut ids = Vec::new();
-        for entry in std::fs::read_dir(&lister_output_dir)? {
-            let path = entry?.path();
-            if !path.is_dir() {
-                continue;
-            }
-            if let Some(id) = path
-                .file_name()
-                .and_then(|s| s.to_str())
-                .and_then(|s| Uuid::parse_str(s).ok())
-            {
-                ids.push(id);
-            }
-        }
-        Ok(ids)
-    };
-
-    // Hand the importer the per-context directory; it locates the event file by
-    // the configured format's extension.
-    let importer = move |context_id| {
-        let dir = importer_output_dir.join(format!("{context_id}"));
-        let kind = ImporterOptions::FileSystem(FileSystemImporterOptions { format, path: dir });
-        Ok(Box::new(create_importer::<SimulatorEvent>(&kind)?) as Box<dyn Iterator<Item = _>>)
-    };
+    let lister = build_lister(lister_output_dir);
+    let importer = build_importer(format, importer_output_dir);
 
     let analyzer = async {
         axum::serve(
             TcpListener::bind(analyzer_addr).await?,
-            analyzer_service_router::<SimulatorUiAnalyzer>(
-                Box::new(importer),
-                Box::new(lister),
-                cors_address,
-            )?
-            .into_make_service(),
+            analyzer_service_router::<SimulatorUiAnalyzer>(importer, lister, cors_address)?
+                .into_make_service(),
         )
         .await?;
         Ok::<(), Box<dyn std::error::Error>>(())


### PR DESCRIPTION
Expose the query-engine analyzer surface over the Model Context Protocol so agents can connect to a running quent server and explore telemetry.

The MCP server is generic over `UiAnalyzer` and reuses the existing `ServiceState` (analyzer + timeline caches), so out-of-repo analyzers get it for free. It is gated behind a new `mcp` feature on `quent-query-engine-server`, alongside the existing `swagger`/`ui` features.

Two transports:
- HTTP: a streamable-HTTP service mounted at `/mcp` on the Axum analyzer router. rmcp's loopback-only Host allowlist (a DNS-rebinding guard) is kept by default; non-local deployments opt in via `QUENT_MCP_ALLOWED_HOSTS` (comma-separated hosts, or `*` to disable). When CORS is enabled the layer also allows the MCP session/protocol and SSE-resume headers.
- stdio: `serve_stdio` plus a `quent-simulator-mcp` example binary.

Tools mirror the REST endpoints (list_engines, get_engine, list_query_groups, list_queries, get_query, single_timeline) and add agent-friendly summaries (engine_overview, plan_tree, slowest_operators).

The simulator example shares importer/lister setup between its HTTP and stdio binaries via a new `lib.rs`; `default-run` keeps `cargo run` on the HTTP server when the `mcp` feature adds a second binary.
