### PR TITLE
feat!: give each observer its own exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tarpaulin-report.html
 *.tsbuildinfo
 docs/agents/
 .cursor
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 target/
+data/
+events/
 .DS_Store
 .pnpm-store/
 .rumdl_cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,20 +601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,12 +919,6 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1865,7 +1845,6 @@ name = "quent-collector"
 version = "0.1.0"
 dependencies = [
  "ciborium",
- "dashmap",
  "quent-build-info",
  "quent-collector-proto",
  "quent-events",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,11 +1845,10 @@ name = "quent-collector"
 version = "0.1.0"
 dependencies = [
  "ciborium",
- "quent-build-info",
  "quent-collector-proto",
  "quent-events",
  "quent-exporter",
- "quent-exporter-types",
+ "quent-instrumentation",
  "serde",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "quent-time",
  "serde",
  "serde_json",
+ "tokio",
  "trybuild",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
 name = "quent-instrumentation"
 version = "0.1.0"
 dependencies = [
+ "ciborium",
  "criterion",
  "pprof",
  "quent-attributes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "quent-collector",
  "quent-collector-proto",
  "quent-events",
+ "quent-exporter",
  "quent-exporter-types",
  "quent-query-engine-analyzer",
  "quent-query-engine-model",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,12 +1844,9 @@ dependencies = [
 name = "quent-collector"
 version = "0.1.0"
 dependencies = [
- "ciborium",
  "quent-collector-proto",
- "quent-events",
  "quent-exporter",
  "quent-instrumentation",
- "serde",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2047,6 +2044,7 @@ dependencies = [
 name = "quent-model"
 version = "0.1.0"
 dependencies = [
+ "ciborium",
  "quent-attributes",
  "quent-build-info",
  "quent-events",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,6 +1868,7 @@ dependencies = [
  "dashmap",
  "quent-build-info",
  "quent-collector-proto",
+ "quent-events",
  "quent-exporter",
  "quent-exporter-types",
  "serde",
@@ -1928,6 +1929,7 @@ dependencies = [
 name = "quent-exporter"
 version = "0.1.0"
 dependencies = [
+ "quent-events",
  "quent-exporter-collector",
  "quent-exporter-msgpack",
  "quent-exporter-ndjson",
@@ -1960,6 +1962,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1973,6 +1976,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1986,6 +1990,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,6 +1858,7 @@ name = "quent-collector-client"
 version = "0.1.0"
 dependencies = [
  "ciborium",
+ "http",
  "quent-collector-proto",
  "quent-events",
  "serde",
@@ -1903,6 +1904,7 @@ dependencies = [
 name = "quent-exporter"
 version = "0.1.0"
 dependencies = [
+ "http",
  "quent-events",
  "quent-exporter-collector",
  "quent-exporter-msgpack",
@@ -1918,6 +1920,7 @@ name = "quent-exporter-collector"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "http",
  "quent-collector-client",
  "quent-events",
  "quent-exporter-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,9 +1844,8 @@ dependencies = [
 name = "quent-collector"
 version = "0.1.0"
 dependencies = [
+ "quent-collector-client",
  "quent-collector-proto",
- "quent-exporter",
- "quent-instrumentation",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2047,6 +2046,7 @@ dependencies = [
  "ciborium",
  "quent-attributes",
  "quent-build-info",
+ "quent-collector-client",
  "quent-events",
  "quent-exporter",
  "quent-instrumentation",
@@ -2306,7 +2306,6 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "clap",
- "quent-collector",
  "quent-exporter",
  "quent-query-engine-server",
  "quent-query-engine-ui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ publish = false
 
 [workspace.dependencies]
 async-trait = "0.1.89"
+http = "1"
 indexmap = "2"
 log = {version = "0.4.28", features = ["kv"]}
 petgraph = "0.8.3"

--- a/crates/build-info/src/lib.rs
+++ b/crates/build-info/src/lib.rs
@@ -85,6 +85,19 @@ impl BuildInfo {
     }
 }
 
+impl ModelInfo {
+    /// A [`ModelInfo`] with no provenance, for placeholders (e.g. tests) where
+    /// the model identity is irrelevant.
+    pub fn unknown() -> Self {
+        Self {
+            name: "unknown".to_string(),
+            package: "unknown".to_string(),
+            type_path: "unknown".to_string(),
+            source: BuildInfo::unknown(),
+        }
+    }
+}
+
 /// The provenance written into the `model.qmi` sidecar of each context directory.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ArtifactInfo {

--- a/crates/codegen/src/common.rs
+++ b/crates/codegen/src/common.rs
@@ -52,6 +52,12 @@ pub(crate) fn event_type_path(model_name: &str, options: &impl HasInstrumentatio
     format!("{}::{}Event", options.instrumentation_crate(), model_name)
 }
 
+/// Fully qualified model marker path for a generated model. This is the bare
+/// model name (e.g. `Simulator`), the marker `Context` is parameterized by.
+pub(crate) fn model_type_path(model_name: &str, options: &impl HasInstrumentationCrate) -> String {
+    format!("{}::{}", options.instrumentation_crate(), model_name)
+}
+
 /// Remap a `module_path!()` value to be relative to the instrumentation crate.
 ///
 /// `module_path!()` returns paths like `quent_query_engine_model::engine`.

--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -206,7 +206,7 @@ pub fn emit(model: &ModelBuilder, options: &CxxOptions) -> Vec<GeneratedFile> {
     }
 
     // Generate context bridge
-    files.push(emit_context_bridge(&model.name, options));
+    files.push(emit_context_bridge(model, &model.name, options));
 
     // Generate entity bridges
     for entity in &model.entities {
@@ -397,28 +397,121 @@ fn emit_uuid_bridge(model: &ModelBuilder, model_name: &str, options: &CxxOptions
     }
 }
 
+/// Deterministic name of the per-entity/per-fsm observer accessor on `Context`,
+/// shared between the context bridge (definition) and the entity/fsm bridges
+/// (call site).
+fn observer_handle_method(name: &str) -> syn::Ident {
+    format_ident!("{}_observer_handle", name)
+}
+
 /// Generate the context bridge module.
 ///
-/// The `Context` owns the inner quent context and exposes a sender accessor.
-/// C++ callers retain the returned `Box<Context>` and pass a reference to
-/// each observer/FSM factory, which extracts the sender from it.
-fn emit_context_bridge(model_name: &str, options: &CxxOptions) -> GeneratedFile {
+/// The `Context` owns the inner quent context and one observer per entity/FSM.
+/// C++ callers retain the returned `Box<Context>` and pass a reference to each
+/// observer/FSM factory, which clones the relevant observer from it.
+fn emit_context_bridge(
+    model: &ModelBuilder,
+    model_name: &str,
+    options: &CxxOptions,
+) -> GeneratedFile {
     let ns = &options.namespace;
     let q = quent_path(model_name, options);
     let event_type: syn::Type = syn::parse_str(&options.event_type(model_name)).unwrap();
     let uuid_include = format!("{}/{}/uuid.rs.h", options.crate_name, options.bridge_path);
     let context_type_id = format!("{ns}::Context");
 
+    struct ObserverField {
+        field: syn::Ident,
+        method: syn::Ident,
+        stored_ty: TokenStream,
+        build: TokenStream,
+    }
+
+    let observer_fields: Vec<ObserverField> = model
+        .entities
+        .iter()
+        .map(|entity| {
+            let field = format_ident!("{}", entity.name);
+            let method = observer_handle_method(&entity.name);
+            let component_mod: syn::Path =
+                syn::parse_str(&remap_module_path(&entity.module_path, options)).unwrap();
+            let entity_event_enum = format_ident!("{}Event", to_pascal_case(&entity.name));
+            let stored_ty = quote! { Arc<#q::Observer<#component_mod::#entity_event_enum>> };
+            let build = quote! {
+                let #field = Arc::new(
+                    inner
+                        .observer::<#component_mod::#entity_event_enum>()
+                        .map_err(|e| e.to_string())?,
+                );
+            };
+            ObserverField {
+                field,
+                method,
+                stored_ty,
+                build,
+            }
+        })
+        .chain(model.fsms.iter().map(|fsm| {
+            let field = format_ident!("{}", fsm.name);
+            let method = observer_handle_method(&fsm.name);
+            let component_mod: syn::Path =
+                syn::parse_str(&remap_module_path(&fsm.module_path, options)).unwrap();
+            let pascal = to_pascal_case(&fsm.name);
+            let facade = format_ident!("{}Observer", pascal);
+            let fsm_event = format_ident!("{}Event", pascal);
+            let stored_ty = quote! { #component_mod::#facade<#component_mod::#fsm_event> };
+            let build = quote! {
+                let #field = #component_mod::#facade::new(
+                    inner
+                        .observer::<#component_mod::#fsm_event>()
+                        .map_err(|e| e.to_string())?,
+                );
+            };
+            ObserverField {
+                field,
+                method,
+                stored_ty,
+                build,
+            }
+        }))
+        .collect();
+
+    let struct_fields: Vec<TokenStream> = observer_fields
+        .iter()
+        .map(|o| {
+            let field = &o.field;
+            let stored_ty = &o.stored_ty;
+            quote! { #field: #stored_ty }
+        })
+        .collect();
+
+    let field_builds: Vec<TokenStream> = observer_fields.iter().map(|o| o.build.clone()).collect();
+    let field_inits: Vec<syn::Ident> = observer_fields.iter().map(|o| o.field.clone()).collect();
+
+    let accessors: Vec<TokenStream> = observer_fields
+        .iter()
+        .map(|o| {
+            let field = &o.field;
+            let method = &o.method;
+            let stored_ty = &o.stored_ty;
+            quote! {
+                pub fn #method(&self) -> #stored_ty {
+                    self.#field.clone()
+                }
+            }
+        })
+        .collect();
+
     // Rust impl part — formatted via prettyplease.
     let impl_tokens = quote! {
+        use std::sync::Arc;
+
         pub struct Context {
-            inner: #q::Context<#event_type>,
+            #(#struct_fields,)*
         }
 
         impl Context {
-            pub fn events_sender(&self) -> #q::EventSender<#event_type> {
-                self.inner.events_sender()
-            }
+            #(#accessors)*
         }
 
         // Shared across bridges: other bridge modules declare `type Context;`
@@ -439,9 +532,12 @@ fn emit_context_bridge(model_name: &str, options: &CxxOptions) -> GeneratedFile 
                 )),
                 _ => None,
             };
-            let inner = #q::Context::try_new(opts)
+            let inner = #q::Context::<#event_type>::try_new(opts)
                 .map_err(|e| e.to_string())?;
-            Ok(Box::new(Context { inner }))
+            #(#field_builds)*
+            Ok(Box::new(Context {
+                #(#field_inits,)*
+            }))
         }
     };
 
@@ -773,11 +869,11 @@ fn emit_entity_bridge(
     let q = quent_path(model_name, options);
     let remapped = remap_module_path(&entity.module_path, options);
     let component_mod: syn::Path = syn::parse_str(&remapped).unwrap();
-    let event_type: syn::Type = syn::parse_str(&options.event_type(model_name)).unwrap();
     let include_path = format!("{}/{}/uuid.rs.h", options.crate_name, options.bridge_path);
 
     // Derive the entity event enum name: e.g., "Job" -> "JobEvent"
     let entity_event_enum = format_ident!("{}Event", pascal_name);
+    let observer_accessor = observer_handle_method(entity_name);
 
     // Strings for ffi module (CXX-specific syntax)
     let mut shared_structs_str = String::new();
@@ -801,9 +897,9 @@ fn emit_entity_bridge(
             observer_impl_methods.push(quote! {
                 pub fn #event_method(&self, id: ffi::UUID) {
                     let model_event = #component_mod::#event_pascal;
-                    self.tx.send(#q::Event::new_now(
+                    self.inner.send(#q::Event::new_now(
                         #q::uuid::Uuid::from(id),
-                        #component_mod::#entity_event_enum::from(model_event).into(),
+                        #component_mod::#entity_event_enum::from(model_event),
                     ));
                 }
             });
@@ -832,9 +928,9 @@ fn emit_entity_bridge(
                     let model_event = #component_mod::#event_pascal {
                         #(#field_conversions)*
                     };
-                    self.tx.send(#q::Event::new_now(
+                    self.inner.send(#q::Event::new_now(
                         #q::uuid::Uuid::from(id),
-                        #component_mod::#entity_event_enum::from(model_event).into(),
+                        #component_mod::#entity_event_enum::from(model_event),
                     ));
                 }
             });
@@ -856,8 +952,10 @@ fn emit_entity_bridge(
 
     // Build impl code via quote! + prettyplease
     let impl_tokens = quote! {
+        use std::sync::Arc;
+
         pub struct #observer_name {
-            tx: #q::EventSender<#event_type>,
+            inner: Arc<#q::Observer<#component_mod::#entity_event_enum>>,
         }
 
         impl #observer_name {
@@ -866,7 +964,7 @@ fn emit_entity_bridge(
 
         pub fn create_observer(ctx: &super::context::Context) -> Box<#observer_name> {
             Box::new(#observer_name {
-                tx: ctx.events_sender(),
+                inner: ctx.#observer_accessor(),
             })
         }
     };
@@ -1068,16 +1166,11 @@ fn emit_fsm_bridge(
     let handle_name = format_ident!("{}", handle_name_str);
     let q = quent_path(model_name, options);
     let remapped = remap_module_path(&fsm.module_path, options);
-    let component_mod: syn::Path = syn::parse_str(&remapped).unwrap();
     let include_path = format!("{}/{}/uuid.rs.h", options.crate_name, options.bridge_path);
 
+    let observer_accessor = observer_handle_method(fsm_name);
     let model_handle: syn::Type = {
-        let s = format!(
-            "{}::{}Handle<{}>",
-            remapped,
-            pascal_name,
-            options.event_type(model_name),
-        );
+        let s = format!("{remapped}::{pascal_name}Handle<{remapped}::{pascal_name}Event>");
         syn::parse_str(&s).unwrap()
     };
 
@@ -1209,13 +1302,12 @@ fn emit_fsm_bridge(
         })
         .collect();
 
-    let observer_name = format_ident!("{}Observer", pascal_name);
     let factory_fn = if has_entry_data {
         let (stmts, args) = emit_state_flat_args(model, entry_state, &q, &remapped, options);
         quote! {
             pub fn create(ctx: &super::context::Context, data: ffi::#entry_pascal) -> Box<#handle_name> {
                 #stmts
-                let obs = #component_mod::#observer_name::new(&ctx.events_sender());
+                let obs = ctx.#observer_accessor();
                 let id = #q::uuid::Uuid::now_v7();
                 Box::new(#handle_name {
                     inner: obs.#entry_name(id, #(#args),*),
@@ -1225,7 +1317,7 @@ fn emit_fsm_bridge(
     } else {
         quote! {
             pub fn create(ctx: &super::context::Context) -> Box<#handle_name> {
-                let obs = #component_mod::#observer_name::new(&ctx.events_sender());
+                let obs = ctx.#observer_accessor();
                 let id = #q::uuid::Uuid::now_v7();
                 Box::new(#handle_name {
                     inner: obs.#entry_name(id),

--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -424,7 +424,11 @@ fn emit_context_bridge(
         field: syn::Ident,
         method: syn::Ident,
         stored_ty: TokenStream,
-        build: TokenStream,
+        /// The entity event type for `Context::observer::<_>()`.
+        event_ty: TokenStream,
+        /// Constructor applied to the freshly built `Observer` to produce the
+        /// stored value (`Arc::new` or an FSM observer facade's `new`).
+        wrap: TokenStream,
     }
 
     let observer_fields: Vec<ObserverField> = model
@@ -436,19 +440,12 @@ fn emit_context_bridge(
             let component_mod: syn::Path =
                 syn::parse_str(&remap_module_path(&entity.module_path, options)).unwrap();
             let entity_event_enum = format_ident!("{}Event", to_pascal_case(&entity.name));
-            let stored_ty = quote! { Arc<#q::Observer<#component_mod::#entity_event_enum>> };
-            let build = quote! {
-                let #field = Arc::new(
-                    inner
-                        .observer::<#component_mod::#entity_event_enum>()
-                        .map_err(|e| e.to_string())?,
-                );
-            };
             ObserverField {
                 field,
                 method,
-                stored_ty,
-                build,
+                stored_ty: quote! { Arc<#q::Observer<#component_mod::#entity_event_enum>> },
+                event_ty: quote! { #component_mod::#entity_event_enum },
+                wrap: quote! { Arc::new },
             }
         })
         .chain(model.fsms.iter().map(|fsm| {
@@ -459,19 +456,12 @@ fn emit_context_bridge(
             let pascal = to_pascal_case(&fsm.name);
             let facade = format_ident!("{}Observer", pascal);
             let fsm_event = format_ident!("{}Event", pascal);
-            let stored_ty = quote! { #component_mod::#facade<#component_mod::#fsm_event> };
-            let build = quote! {
-                let #field = #component_mod::#facade::new(
-                    inner
-                        .observer::<#component_mod::#fsm_event>()
-                        .map_err(|e| e.to_string())?,
-                );
-            };
             ObserverField {
                 field,
                 method,
-                stored_ty,
-                build,
+                stored_ty: quote! { #component_mod::#facade },
+                event_ty: quote! { #component_mod::#fsm_event },
+                wrap: quote! { #component_mod::#facade::new },
             }
         }))
         .collect();
@@ -485,7 +475,9 @@ fn emit_context_bridge(
         })
         .collect();
 
-    let field_builds: Vec<TokenStream> = observer_fields.iter().map(|o| o.build.clone()).collect();
+    let build_fields: Vec<&syn::Ident> = observer_fields.iter().map(|o| &o.field).collect();
+    let build_event_tys: Vec<&TokenStream> = observer_fields.iter().map(|o| &o.event_ty).collect();
+    let build_wraps: Vec<&TokenStream> = observer_fields.iter().map(|o| &o.wrap).collect();
     let field_inits: Vec<syn::Ident> = observer_fields.iter().map(|o| o.field.clone()).collect();
 
     let accessors: Vec<TokenStream> = observer_fields
@@ -532,9 +524,25 @@ fn emit_context_bridge(
                 )),
                 _ => None,
             };
-            let inner = #q::Context::<#model_type>::try_new(opts)
+            let inner = #q::Context::try_new(opts)
                 .map_err(|e| e.to_string())?;
-            #(#field_builds)*
+            // Single sync/async bridge: build the sidecar and every observer
+            // concurrently on the context's runtime, then block until done.
+            let (#(#build_fields,)*) = inner.block_on(async {
+                let (_sidecar, #(#build_fields,)*) = #q::tokio::try_join!(
+                    async {
+                        inner
+                            .write_sidecar(
+                                <#model_type as #q::build_info::ModelSource>::model_info(),
+                            )
+                            .await;
+                        Ok::<(), Box<dyn std::error::Error>>(())
+                    },
+                    #(inner.observer::<#build_event_tys>(),)*
+                )
+                .map_err(|e| e.to_string())?;
+                Ok::<_, String>((#(#build_wraps(#build_fields),)*))
+            })?;
             Ok(Box::new(Context {
                 #(#field_inits,)*
             }))
@@ -1170,7 +1178,7 @@ fn emit_fsm_bridge(
 
     let observer_accessor = observer_handle_method(fsm_name);
     let model_handle: syn::Type = {
-        let s = format!("{remapped}::{pascal_name}Handle<{remapped}::{pascal_name}Event>");
+        let s = format!("{remapped}::{pascal_name}Handle");
         syn::parse_str(&s).unwrap()
     };
 

--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -406,9 +406,11 @@ fn observer_handle_method(name: &str) -> syn::Ident {
 
 /// Generate the context bridge module.
 ///
-/// The `Context` owns the inner quent context and one observer per entity/FSM.
-/// C++ callers retain the returned `Box<Context>` and pass a reference to each
-/// observer/FSM factory, which clones the relevant observer from it.
+/// The cxx `Context` holds one observer per entity/FSM; the inner quent context
+/// is used only to build them and is dropped after construction. C++ callers
+/// retain the returned `Box<Context>` and pass a reference to each observer/FSM
+/// factory, which clones the relevant observer from it. A stream flushes when
+/// its last clone drops — the field stored here, plus any the caller still holds.
 fn emit_context_bridge(
     model: &ModelBuilder,
     model_name: &str,

--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -526,20 +526,15 @@ fn emit_context_bridge(
                 )),
                 _ => None,
             };
-            let inner = #q::Context::try_new(opts)
-                .map_err(|e| e.to_string())?;
-            // Single sync/async bridge: build the sidecar and every observer
-            // concurrently on the context's runtime, then block until done.
+            let inner = #q::Context::try_new(
+                <#model_type as #q::build_info::ModelSource>::model_info(),
+                opts,
+            )
+            .map_err(|e| e.to_string())?;
+            // Single sync/async bridge: build every observer concurrently on the
+            // context's runtime, then block until done.
             let (#(#build_fields,)*) = inner.block_on(async {
-                let (_sidecar, #(#build_fields,)*) = #q::tokio::try_join!(
-                    async {
-                        inner
-                            .write_sidecar(
-                                <#model_type as #q::build_info::ModelSource>::model_info(),
-                            )
-                            .await;
-                        Ok::<(), Box<dyn std::error::Error>>(())
-                    },
+                let (#(#build_fields,)*) = #q::tokio::try_join!(
                     #(inner.observer::<#build_event_tys>(),)*
                 )
                 .map_err(|e| e.to_string())?;

--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -416,7 +416,7 @@ fn emit_context_bridge(
 ) -> GeneratedFile {
     let ns = &options.namespace;
     let q = quent_path(model_name, options);
-    let event_type: syn::Type = syn::parse_str(&options.event_type(model_name)).unwrap();
+    let model_type: syn::Type = syn::parse_str(&options.model_type(model_name)).unwrap();
     let uuid_include = format!("{}/{}/uuid.rs.h", options.crate_name, options.bridge_path);
     let context_type_id = format!("{ns}::Context");
 
@@ -532,7 +532,7 @@ fn emit_context_bridge(
                 )),
                 _ => None,
             };
-            let inner = #q::Context::<#event_type>::try_new(opts)
+            let inner = #q::Context::<#model_type>::try_new(opts)
                 .map_err(|e| e.to_string())?;
             #(#field_builds)*
             Ok(Box::new(Context {

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -31,6 +31,11 @@ impl CxxOptions {
     pub fn event_type(&self, model_name: &str) -> String {
         common::event_type_path(model_name, self)
     }
+
+    /// The fully qualified model marker path. Requires the model name.
+    pub fn model_type(&self, model_name: &str) -> String {
+        common::model_type_path(model_name, self)
+    }
 }
 
 impl Default for CxxOptions {
@@ -63,6 +68,11 @@ impl PyO3Options {
     /// The fully qualified event type path. Requires the model name.
     pub fn event_type(&self, model_name: &str) -> String {
         common::event_type_path(model_name, self)
+    }
+
+    /// The fully qualified model marker path. Requires the model name.
+    pub fn model_type(&self, model_name: &str) -> String {
+        common::model_type_path(model_name, self)
     }
 }
 

--- a/crates/codegen/src/pyo3_bridge.rs
+++ b/crates/codegen/src/pyo3_bridge.rs
@@ -570,7 +570,7 @@ fn emit_helpers(q: &syn::Path) -> TokenStream {
 fn emit_context(
     model: &ModelBuilder,
     q: &syn::Path,
-    event_type: &syn::Type,
+    model_type: &syn::Type,
     options: &PyO3Options,
 ) -> TokenStream {
     struct ObserverField {
@@ -691,7 +691,7 @@ fn emit_context(
     quote! {
         #[pyclass(name = "Context")]
         pub struct PyContext {
-            inner: Option<#q::Context<#event_type>>,
+            inner: Option<#q::Context<#model_type>>,
             #(#struct_fields,)*
             id: #q::uuid::Uuid,
         }
@@ -1018,12 +1018,12 @@ fn emit_fsm_bridge(
 /// Generate PyO3 bridge source code from a model.
 pub fn emit(model: &ModelBuilder, options: &PyO3Options) -> Vec<GeneratedFile> {
     let q = quent_path(&model.name, options);
-    let event_type: syn::Type = syn::parse_str(&options.event_type(&model.name)).unwrap();
+    let model_type: syn::Type = syn::parse_str(&options.model_type(&model.name)).unwrap();
     let module_fn = module_ident(&options.module_name);
     let module_name = syn::LitStr::new(module_export_name(&options.module_name), Span::call_site());
 
     let helpers = emit_helpers(&q);
-    let context = emit_context(model, &q, &event_type, options);
+    let context = emit_context(model, &q, &model_type, options);
     let entity_bridges: Vec<TokenStream> = model
         .entities
         .iter()

--- a/crates/codegen/src/pyo3_bridge.rs
+++ b/crates/codegen/src/pyo3_bridge.rs
@@ -434,6 +434,7 @@ fn emit_state_args(
 fn emit_helpers(q: &syn::Path) -> TokenStream {
     quote! {
         use pyo3::prelude::*;
+        use std::sync::Arc;
         use pyo3::types::{
             PyAny, PyBool, PyBoolMethods, PyDict, PyFloat, PyFloatMethods, PyInt, PyModule,
             PyString, PyStringMethods, PyTuple,
@@ -572,46 +573,126 @@ fn emit_context(
     event_type: &syn::Type,
     options: &PyO3Options,
 ) -> TokenStream {
-    let observer_methods: Vec<TokenStream> = model
+    struct ObserverField {
+        field: syn::Ident,
+        method: syn::Ident,
+        class: syn::Ident,
+        stored_ty: TokenStream,
+        build: TokenStream,
+    }
+
+    let observer_fields: Vec<ObserverField> = model
         .entities
         .iter()
         .map(|entity| {
+            let field = format_ident!("{}", entity.name);
             let method = format_ident!("{}", py_export_name(&format!("{}_observer", entity.name)));
             let class = py_class_ident(&py_export_name(&format!(
                 "{}Observer",
                 to_pascal_case(&entity.name)
             )));
-            quote! {
-                pub fn #method(&self) -> PyResult<#class> {
-                    Ok(#class {
-                        tx: self.events_sender()?,
-                    })
-                }
+            let component_mod: syn::Path =
+                syn::parse_str(&remap_module_path(&entity.module_path, options)).unwrap();
+            let entity_event_enum = event_enum_ident(&entity.name);
+            let stored_ty = quote! { Arc<#q::Observer<#component_mod::#entity_event_enum>> };
+            let build = quote! {
+                let #field = Arc::new(
+                    inner
+                        .observer::<#component_mod::#entity_event_enum>()
+                        .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?,
+                );
+            };
+            ObserverField {
+                field,
+                method,
+                class,
+                stored_ty,
+                build,
             }
         })
         .chain(model.fsms.iter().map(|fsm| {
+            let field = format_ident!("{}", fsm.name);
             let method = format_ident!("{}", py_export_name(&format!("{}_observer", fsm.name)));
             let class = py_class_ident(&py_export_name(&format!(
                 "{}Observer",
                 to_pascal_case(&fsm.name)
             )));
-            quote! {
-                pub fn #method(&self) -> PyResult<#class> {
-                    Ok(#class {
-                        tx: self.events_sender()?,
-                    })
-                }
+            let component_mod: syn::Path =
+                syn::parse_str(&remap_module_path(&fsm.module_path, options)).unwrap();
+            let pascal = to_pascal_case(&fsm.name);
+            let facade = format_ident!("{}Observer", pascal);
+            let fsm_event = format_ident!("{}Event", pascal);
+            let stored_ty = quote! { #component_mod::#facade<#component_mod::#fsm_event> };
+            let build = quote! {
+                let #field = #component_mod::#facade::new(
+                    inner
+                        .observer::<#component_mod::#fsm_event>()
+                        .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?,
+                );
+            };
+            ObserverField {
+                field,
+                method,
+                class,
+                stored_ty,
+                build,
             }
         }))
         .collect();
 
+    let struct_fields: Vec<TokenStream> = observer_fields
+        .iter()
+        .map(|o| {
+            let field = &o.field;
+            let stored_ty = &o.stored_ty;
+            quote! { #field: Option<#stored_ty> }
+        })
+        .collect();
+
+    let field_builds: Vec<TokenStream> = observer_fields.iter().map(|o| o.build.clone()).collect();
+
+    let field_inits: Vec<TokenStream> = observer_fields
+        .iter()
+        .map(|o| {
+            let field = &o.field;
+            quote! { #field: Some(#field) }
+        })
+        .collect();
+
+    let field_closes: Vec<TokenStream> = observer_fields
+        .iter()
+        .map(|o| {
+            let field = &o.field;
+            quote! { self.#field.take(); }
+        })
+        .collect();
+
     let module_name = &options.module_name;
+
+    let observer_methods: Vec<TokenStream> = observer_fields
+        .iter()
+        .map(|o| {
+            let field = &o.field;
+            let method = &o.method;
+            let class = &o.class;
+            quote! {
+                pub fn #method(&self) -> PyResult<#class> {
+                    let inner = self.#field.clone().ok_or_else(|| {
+                        pyo3::exceptions::PyRuntimeError::new_err(
+                            format!("`{}` context is closed", #module_name),
+                        )
+                    })?;
+                    Ok(#class { inner })
+                }
+            }
+        })
+        .collect();
 
     quote! {
         #[pyclass(name = "Context")]
         pub struct PyContext {
             inner: Option<#q::Context<#event_type>>,
-            tx: #q::EventSender<#event_type>,
+            #(#struct_fields,)*
             id: #q::uuid::Uuid,
         }
 
@@ -641,10 +722,10 @@ fn emit_context(
                 let inner = #q::Context::try_new(opts)
                     .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;
                 let id = inner.id();
-                let tx = inner.events_sender();
+                #(#field_builds)*
                 Ok(Self {
                     inner: Some(inner),
-                    tx,
+                    #(#field_inits,)*
                     id,
                 })
             }
@@ -655,6 +736,7 @@ fn emit_context(
             }
 
             pub fn close(&mut self) {
+                #(#field_closes)*
                 self.inner.take();
             }
 
@@ -673,24 +755,12 @@ fn emit_context(
 
             #(#observer_methods)*
         }
-
-        impl PyContext {
-            fn events_sender(&self) -> PyResult<#q::EventSender<#event_type>> {
-                if self.inner.is_none() {
-                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
-                        format!("`{}` context is closed", #module_name),
-                    ));
-                }
-                Ok(self.tx.clone())
-            }
-        }
     }
 }
 
 fn emit_entity_bridge(
     entity: &quent_model::EntityDef,
     q: &syn::Path,
-    event_type: &syn::Type,
     options: &PyO3Options,
 ) -> TokenStream {
     let multi_event = entity.events.len() > 1;
@@ -780,9 +850,9 @@ fn emit_entity_bridge(
                 pub fn #method(&self, #(#params,)*) -> PyResult<#ret_ty> {
                     #(#bindings)*
                     let model_event = #model_event;
-                    self.tx.send(#q::Event::new_now(
+                    self.inner.send(#q::Event::new_now(
                         #id_expr,
-                        #component_mod::#entity_event_enum::from(model_event).into(),
+                        #component_mod::#entity_event_enum::from(model_event),
                     ));
                     Ok(#ret_expr)
                 }
@@ -794,7 +864,7 @@ fn emit_entity_bridge(
         quote! {
             #[pyclass(name = #observer_py_name)]
             pub struct #observer {
-                tx: #q::EventSender<#event_type>,
+                inner: Arc<#q::Observer<#component_mod::#entity_event_enum>>,
             }
 
             #[pymethods]
@@ -802,7 +872,7 @@ fn emit_entity_bridge(
                 pub fn create(&self, id: PyRef<'_, PyUuid>) -> PyResult<#handle> {
                     Ok(#handle {
                         id: id.inner,
-                        tx: self.tx.clone(),
+                        inner: self.inner.clone(),
                     })
                 }
             }
@@ -810,7 +880,7 @@ fn emit_entity_bridge(
             #[pyclass(name = #handle_py_name)]
             pub struct #handle {
                 id: #q::uuid::Uuid,
-                tx: #q::EventSender<#event_type>,
+                inner: Arc<#q::Observer<#component_mod::#entity_event_enum>>,
             }
 
             #[pymethods]
@@ -827,7 +897,7 @@ fn emit_entity_bridge(
         quote! {
         #[pyclass(name = #observer_py_name)]
         pub struct #observer {
-            tx: #q::EventSender<#event_type>,
+            inner: Arc<#q::Observer<#component_mod::#entity_event_enum>>,
         }
 
         #[pymethods]
@@ -842,7 +912,6 @@ fn emit_fsm_bridge(
     model: &ModelBuilder,
     fsm: &FsmDef,
     q: &syn::Path,
-    event_type: &syn::Type,
     options: &PyO3Options,
 ) -> TokenStream {
     let pascal_name = to_pascal_case(&fsm.name);
@@ -852,11 +921,9 @@ fn emit_fsm_bridge(
     let handle = py_class_ident(&handle_py_name);
     let component_mod_str = remap_module_path(&fsm.module_path, options);
     let component_mod: syn::Path = syn::parse_str(&component_mod_str).unwrap();
+    let fsm_event = format_ident!("{}Event", pascal_name);
     let model_handle: syn::Type = syn::parse_str(&format!(
-        "{}::{}Handle<{}>",
-        component_mod_str,
-        pascal_name,
-        quote!(#event_type)
+        "{component_mod_str}::{pascal_name}Handle<{component_mod_str}::{pascal_name}Event>",
     ))
     .unwrap();
 
@@ -906,7 +973,7 @@ fn emit_fsm_bridge(
     quote! {
         #[pyclass(name = #observer_py_name)]
         pub struct #observer {
-            tx: #q::EventSender<#event_type>,
+            inner: #component_mod::#observer_name<#component_mod::#fsm_event>,
         }
 
         #[pymethods]
@@ -918,7 +985,7 @@ fn emit_fsm_bridge(
             ) -> PyResult<#handle> {
                 let id = id.inner;
                 #entry_bindings
-                let obs = #component_mod::#observer_name::new(&self.tx);
+                let obs = self.inner.clone();
                 Ok(#handle {
                     inner: obs.#model_entry_method(id, #(#entry_args),*),
                 })
@@ -960,12 +1027,12 @@ pub fn emit(model: &ModelBuilder, options: &PyO3Options) -> Vec<GeneratedFile> {
     let entity_bridges: Vec<TokenStream> = model
         .entities
         .iter()
-        .map(|entity| emit_entity_bridge(entity, &q, &event_type, options))
+        .map(|entity| emit_entity_bridge(entity, &q, options))
         .collect();
     let fsm_bridges: Vec<TokenStream> = model
         .fsms
         .iter()
-        .map(|fsm| emit_fsm_bridge(model, fsm, &q, &event_type, options))
+        .map(|fsm| emit_fsm_bridge(model, fsm, &q, options))
         .collect();
 
     let observer_classes: Vec<syn::Ident> = model

--- a/crates/codegen/src/pyo3_bridge.rs
+++ b/crates/codegen/src/pyo3_bridge.rs
@@ -713,21 +713,16 @@ fn emit_context(
                         )));
                     }
                 };
-                let inner = #q::Context::try_new(opts)
-                    .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;
+                let inner = #q::Context::try_new(
+                    <#model_type as #q::build_info::ModelSource>::model_info(),
+                    opts,
+                )
+                .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;
                 let id = inner.id();
-                // Single sync/async bridge: build the sidecar and every observer
-                // concurrently on the context's runtime, then block until done.
+                // Single sync/async bridge: build every observer concurrently on
+                // the context's runtime, then block until done.
                 let (#(#build_fields,)*) = inner.block_on(async {
-                    let (_sidecar, #(#build_fields,)*) = #q::tokio::try_join!(
-                        async {
-                            inner
-                                .write_sidecar(
-                                    <#model_type as #q::build_info::ModelSource>::model_info(),
-                                )
-                                .await;
-                            Ok::<(), Box<dyn std::error::Error>>(())
-                        },
+                    let (#(#build_fields,)*) = #q::tokio::try_join!(
                         #(inner.observer::<#build_event_tys>(),)*
                     )
                     .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;

--- a/crates/codegen/src/pyo3_bridge.rs
+++ b/crates/codegen/src/pyo3_bridge.rs
@@ -578,7 +578,11 @@ fn emit_context(
         method: syn::Ident,
         class: syn::Ident,
         stored_ty: TokenStream,
-        build: TokenStream,
+        /// The entity event type for `Context::observer::<_>()`.
+        event_ty: TokenStream,
+        /// Constructor applied to the freshly built `Observer` to produce the
+        /// stored value (e.g. `Arc::new` or an FSM observer facade's `new`).
+        wrap: TokenStream,
     }
 
     let observer_fields: Vec<ObserverField> = model
@@ -595,19 +599,13 @@ fn emit_context(
                 syn::parse_str(&remap_module_path(&entity.module_path, options)).unwrap();
             let entity_event_enum = event_enum_ident(&entity.name);
             let stored_ty = quote! { Arc<#q::Observer<#component_mod::#entity_event_enum>> };
-            let build = quote! {
-                let #field = Arc::new(
-                    inner
-                        .observer::<#component_mod::#entity_event_enum>()
-                        .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?,
-                );
-            };
             ObserverField {
                 field,
                 method,
                 class,
                 stored_ty,
-                build,
+                event_ty: quote! { #component_mod::#entity_event_enum },
+                wrap: quote! { Arc::new },
             }
         })
         .chain(model.fsms.iter().map(|fsm| {
@@ -623,19 +621,13 @@ fn emit_context(
             let facade = format_ident!("{}Observer", pascal);
             let fsm_event = format_ident!("{}Event", pascal);
             let stored_ty = quote! { #component_mod::#facade<#component_mod::#fsm_event> };
-            let build = quote! {
-                let #field = #component_mod::#facade::new(
-                    inner
-                        .observer::<#component_mod::#fsm_event>()
-                        .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?,
-                );
-            };
             ObserverField {
                 field,
                 method,
                 class,
                 stored_ty,
-                build,
+                event_ty: quote! { #component_mod::#fsm_event },
+                wrap: quote! { #component_mod::#facade::new },
             }
         }))
         .collect();
@@ -649,7 +641,9 @@ fn emit_context(
         })
         .collect();
 
-    let field_builds: Vec<TokenStream> = observer_fields.iter().map(|o| o.build.clone()).collect();
+    let build_fields: Vec<&syn::Ident> = observer_fields.iter().map(|o| &o.field).collect();
+    let build_event_tys: Vec<&TokenStream> = observer_fields.iter().map(|o| &o.event_ty).collect();
+    let build_wraps: Vec<&TokenStream> = observer_fields.iter().map(|o| &o.wrap).collect();
 
     let field_inits: Vec<TokenStream> = observer_fields
         .iter()
@@ -719,10 +713,26 @@ fn emit_context(
                         )));
                     }
                 };
-                let inner = #q::Context::try_new::<#model_type>(opts)
+                let inner = #q::Context::try_new(opts)
                     .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;
                 let id = inner.id();
-                #(#field_builds)*
+                // Single sync/async bridge: build the sidecar and every observer
+                // concurrently on the context's runtime, then block until done.
+                let (#(#build_fields,)*) = inner.block_on(async {
+                    let (_sidecar, #(#build_fields,)*) = #q::tokio::try_join!(
+                        async {
+                            inner
+                                .write_sidecar(
+                                    <#model_type as #q::build_info::ModelSource>::model_info(),
+                                )
+                                .await;
+                            Ok::<(), Box<dyn std::error::Error>>(())
+                        },
+                        #(inner.observer::<#build_event_tys>(),)*
+                    )
+                    .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;
+                    Ok::<_, pyo3::PyErr>((#(#build_wraps(#build_fields),)*))
+                })?;
                 Ok(Self {
                     inner: Some(inner),
                     #(#field_inits,)*

--- a/crates/codegen/src/pyo3_bridge.rs
+++ b/crates/codegen/src/pyo3_bridge.rs
@@ -620,7 +620,7 @@ fn emit_context(
             let pascal = to_pascal_case(&fsm.name);
             let facade = format_ident!("{}Observer", pascal);
             let fsm_event = format_ident!("{}Event", pascal);
-            let stored_ty = quote! { #component_mod::#facade<#component_mod::#fsm_event> };
+            let stored_ty = quote! { #component_mod::#facade };
             ObserverField {
                 field,
                 method,
@@ -931,11 +931,8 @@ fn emit_fsm_bridge(
     let handle = py_class_ident(&handle_py_name);
     let component_mod_str = remap_module_path(&fsm.module_path, options);
     let component_mod: syn::Path = syn::parse_str(&component_mod_str).unwrap();
-    let fsm_event = format_ident!("{}Event", pascal_name);
-    let model_handle: syn::Type = syn::parse_str(&format!(
-        "{component_mod_str}::{pascal_name}Handle<{component_mod_str}::{pascal_name}Event>",
-    ))
-    .unwrap();
+    let model_handle: syn::Type =
+        syn::parse_str(&format!("{component_mod_str}::{pascal_name}Handle",)).unwrap();
 
     let entry_state = fsm
         .states
@@ -983,7 +980,7 @@ fn emit_fsm_bridge(
     quote! {
         #[pyclass(name = #observer_py_name)]
         pub struct #observer {
-            inner: #component_mod::#observer_name<#component_mod::#fsm_event>,
+            inner: #component_mod::#observer_name,
         }
 
         #[pymethods]

--- a/crates/codegen/src/pyo3_bridge.rs
+++ b/crates/codegen/src/pyo3_bridge.rs
@@ -691,7 +691,7 @@ fn emit_context(
     quote! {
         #[pyclass(name = "Context")]
         pub struct PyContext {
-            inner: Option<#q::Context<#model_type>>,
+            inner: Option<#q::Context>,
             #(#struct_fields,)*
             id: #q::uuid::Uuid,
         }
@@ -719,7 +719,7 @@ fn emit_context(
                         )));
                     }
                 };
-                let inner = #q::Context::try_new(opts)
+                let inner = #q::Context::try_new::<#model_type>(opts)
                     .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;
                 let id = inner.id();
                 #(#field_builds)*

--- a/crates/collector/client/Cargo.toml
+++ b/crates/collector/client/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish.workspace = true
 [dependencies]
 ciborium = "0.2.2"
+http.workspace = true
 quent-collector-proto = { path = "../proto" }
 quent-events = { path = "../../events" }
 serde.workspace = true

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -52,7 +52,11 @@ impl<T> Client<T>
 where
     T: Serialize + Send + 'static,
 {
-    pub async fn new(source_context_id: Uuid, address: String) -> CollectorResult<Client<T>> {
+    pub async fn new(
+        source_context_id: Uuid,
+        entity_type: &str,
+        address: String,
+    ) -> CollectorResult<Client<T>> {
         debug!("connecting to {address}");
         // Try to connect.
         // TODO(johanpel): figure out whether this can also go through health check
@@ -175,7 +179,9 @@ where
 
         debug!("opening stream ...");
 
-        // Identify this stream so the collector reproduces its events under the id.
+        // Identify this stream so the collector reproduces its events under the
+        // id, and tag it with the entity type so the collector routes the batch
+        // to the matching entity observer.
         let mut req = Request::new(ReceiverStream::new(grpc_receiver));
         req.metadata_mut().insert(
             "source-context-id",
@@ -183,6 +189,10 @@ where
                 .to_string()
                 .parse()
                 .expect("valid metadata value"),
+        );
+        req.metadata_mut().insert(
+            "entity-type",
+            entity_type.parse().expect("valid metadata value"),
         );
 
         let mut cloned_client = client.clone();

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -25,8 +25,8 @@ use quent_collector_proto::{CollectEventRequest, collector_client::CollectorClie
 
 /// A sink for serialized per-entity event streams.
 pub trait CollectorSink {
-    /// Decode the serialized `event` belonging to the entity stream named
-    /// `entity`, and record it.
+    /// Ingest a serialized `event` belonging to the entity event stream named
+    /// `entity`.
     fn ingest(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>>;
 }
 

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -3,12 +3,12 @@
 
 //! A gRPC-based client that can send [`Event`]s to a collector.
 
+use std::sync::Mutex;
 use std::time::Duration;
 
 use quent_events::Event;
 use serde::Serialize;
 use tokio::{
-    runtime::Handle,
     select,
     sync::mpsc::{self, Receiver, Sender},
     task::JoinHandle,
@@ -40,6 +40,12 @@ pub enum CollectorError {
     Tonic(#[from] tonic::transport::Error),
     #[error("RPC error: {0}")]
     GRPC(#[from] Status),
+    #[error("invalid `{key}` metadata value: {source}")]
+    Metadata {
+        key: &'static str,
+        #[source]
+        source: tonic::metadata::errors::InvalidMetadataValue,
+    },
 }
 
 pub type CollectorResult<T> = std::result::Result<T, CollectorError>;
@@ -50,9 +56,10 @@ pub struct Client<T> {
     _grpc_client: CollectorClient<Channel>,
     event_sender: Sender<Event<T>>,
     cancellation_token: CancellationToken,
-    events_sender_handle: Option<JoinHandle<()>>,
-    events_collector_handle: Option<JoinHandle<()>>,
-    runtime_handle: Handle,
+    // `Mutex<Option<..>>` so the join handles can be taken from `&self` in
+    // `shutdown`; awaited there, never under the lock.
+    events_sender_handle: Mutex<Option<JoinHandle<()>>>,
+    events_collector_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl<T> Client<T>
@@ -195,11 +202,19 @@ where
             source_context_id
                 .to_string()
                 .parse()
-                .expect("valid metadata value"),
+                .map_err(|source| CollectorError::Metadata {
+                    key: "source-context-id",
+                    source,
+                })?,
         );
         req.metadata_mut().insert(
             "entity-type",
-            entity_type.parse().expect("valid metadata value"),
+            entity_type
+                .parse()
+                .map_err(|source| CollectorError::Metadata {
+                    key: "entity-type",
+                    source,
+                })?,
         );
 
         let mut cloned_client = client.clone();
@@ -212,10 +227,8 @@ where
             _grpc_client: client,
             event_sender,
             cancellation_token,
-            // Safety: this fn must be called from a tokio runtime.
-            runtime_handle: Handle::current(),
-            events_sender_handle: Some(events_sender_handle),
-            events_collector_handle: Some(events_collector_handle),
+            events_sender_handle: Mutex::new(Some(events_sender_handle)),
+            events_collector_handle: Mutex::new(Some(events_collector_handle)),
         })
     }
 
@@ -227,27 +240,34 @@ where
             .await
             .map_err(|e| CollectorError::SendError(e.to_string()))
     }
-}
 
-impl<T> Drop for Client<T> {
-    fn drop(&mut self) {
+    /// Drain and deliver all buffered events, then wait for both background
+    /// tasks to finish. Async so it can be awaited from the forwarder rather
+    /// than blocking in `Drop` (which would run on a runtime worker thread).
+    /// Idempotent; subsequent calls are no-ops.
+    pub async fn shutdown(&self) {
         self.cancellation_token.cancel();
-
-        // Wait for the sender to finish sending the remaining events
-        if let Some(join_handle) = self.events_sender_handle.take()
-            && let Err(e) = self.runtime_handle.block_on(join_handle)
+        let sender = self.events_sender_handle.lock().unwrap().take();
+        if let Some(handle) = sender
+            && let Err(e) = handle.await
         {
             warn!("grpc sender task failed: {e}");
         }
-
-        debug!("events_sender_handle completed");
-
-        // Wait for the collector to finish processing the remaining events
-        if let Some(join_handle) = self.events_collector_handle.take()
-            && let Err(e) = self.runtime_handle.block_on(join_handle)
+        let collector = self.events_collector_handle.lock().unwrap().take();
+        if let Some(handle) = collector
+            && let Err(e) = handle.await
         {
             warn!("grpc collector task failed: {e}");
         }
         info!("client shut down, all gRPC messages flushed");
+    }
+}
+
+impl<T> Drop for Client<T> {
+    fn drop(&mut self) {
+        // The forwarder awaits `shutdown` before dropping the exporter, so the
+        // tasks are normally already joined. Cancel as a backstop; any handle
+        // still present is detached (no blocking — `Drop` may run on a worker).
+        self.cancellation_token.cancel();
     }
 }

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -23,6 +23,13 @@ use uuid::Uuid;
 
 use quent_collector_proto::{CollectEventRequest, collector_client::CollectorClient};
 
+/// A sink for serialized per-entity event streams.
+pub trait CollectorSink {
+    /// Decode the serialized `event` belonging to the entity stream named
+    /// `entity`, and record it.
+    fn ingest(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>>;
+}
+
 #[derive(Debug, Error)]
 pub enum CollectorError {
     #[error("Unable to connect: {0}")]

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -69,7 +69,7 @@ where
     pub async fn new(
         source_context_id: Uuid,
         entity_type: &str,
-        address: String,
+        address: http::Uri,
     ) -> CollectorResult<Client<T>> {
         debug!("connecting to {address}");
         // Try to connect.

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -52,7 +52,7 @@ impl<T> Client<T>
 where
     T: Serialize + Send + 'static,
 {
-    pub async fn new(application_id: Uuid, address: String) -> CollectorResult<Client<T>> {
+    pub async fn new(source_context_id: Uuid, address: String) -> CollectorResult<Client<T>> {
         debug!("connecting to {address}");
         // Try to connect.
         // TODO(johanpel): figure out whether this can also go through health check
@@ -175,11 +175,11 @@ where
 
         debug!("opening stream ...");
 
-        // Identify this stream so the collector groups its events under the id.
+        // Identify this stream so the collector reproduces its events under the id.
         let mut req = Request::new(ReceiverStream::new(grpc_receiver));
         req.metadata_mut().insert(
-            "application-id",
-            application_id
+            "source-context-id",
+            source_context_id
                 .to_string()
                 .parse()
                 .expect("valid metadata value"),

--- a/crates/collector/server/Cargo.toml
+++ b/crates/collector/server/Cargo.toml
@@ -6,11 +6,10 @@ version.workspace = true
 
 [dependencies]
 ciborium = "0.2.2"
-quent-build-info = { path = "../../build-info" }
 quent-collector-proto = { path = "../proto" }
 quent-events = { path = "../../events" }
-quent-exporter-types = { path = "../../exporter/types" }
 quent-exporter = { path = "../../exporter" }
+quent-instrumentation = { path = "../../instrumentation" }
 serde.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true

--- a/crates/collector/server/Cargo.toml
+++ b/crates/collector/server/Cargo.toml
@@ -6,8 +6,7 @@ version.workspace = true
 
 [dependencies]
 quent-collector-proto = { path = "../proto" }
-quent-exporter = { path = "../../exporter" }
-quent-instrumentation = { path = "../../instrumentation" }
+quent-collector-client = { path = "../client" }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tonic.workspace = true

--- a/crates/collector/server/Cargo.toml
+++ b/crates/collector/server/Cargo.toml
@@ -5,12 +5,9 @@ publish.workspace = true
 version.workspace = true
 
 [dependencies]
-ciborium = "0.2.2"
 quent-collector-proto = { path = "../proto" }
-quent-events = { path = "../../events" }
 quent-exporter = { path = "../../exporter" }
 quent-instrumentation = { path = "../../instrumentation" }
-serde.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tonic.workspace = true

--- a/crates/collector/server/Cargo.toml
+++ b/crates/collector/server/Cargo.toml
@@ -9,6 +9,7 @@ ciborium = "0.2.2"
 dashmap = "6.1.0"
 quent-build-info = { path = "../../build-info" }
 quent-collector-proto = { path = "../proto" }
+quent-events = { path = "../../events" }
 quent-exporter-types = { path = "../../exporter/types" }
 quent-exporter = { path = "../../exporter" }
 serde.workspace = true

--- a/crates/collector/server/Cargo.toml
+++ b/crates/collector/server/Cargo.toml
@@ -6,7 +6,6 @@ version.workspace = true
 
 [dependencies]
 ciborium = "0.2.2"
-dashmap = "6.1.0"
 quent-build-info = { path = "../../build-info" }
 quent-collector-proto = { path = "../proto" }
 quent-events = { path = "../../events" }

--- a/crates/collector/server/src/lib.rs
+++ b/crates/collector/server/src/lib.rs
@@ -9,5 +9,5 @@ pub mod server;
 
 /// Re-exported so callers constructing a [`server::CollectorService`] over a
 /// generic context type can bound it without depending on
-/// `quent-instrumentation` directly.
-pub use quent_instrumentation::CollectorContext;
+/// `quent-collector-client` directly.
+pub use quent_collector_client::CollectorSink;

--- a/crates/collector/server/src/lib.rs
+++ b/crates/collector/server/src/lib.rs
@@ -8,6 +8,6 @@
 pub mod server;
 
 /// Re-exported so callers constructing a [`server::CollectorService`] over a
-/// generic event type can bound it without depending on `quent-build-info`
-/// directly.
-pub use quent_build_info::ModelSource;
+/// generic context type can bound it without depending on
+/// `quent-instrumentation` directly.
+pub use quent_instrumentation::CollectorContext;

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -3,9 +3,9 @@
 
 //! A gRPC-based server that collects `Event`s from multiple sources and exports them.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
-use dashmap::DashMap;
 use quent_build_info::{ArtifactInfo, ModelSource};
 use quent_events::EntityEvent;
 use quent_exporter::{ExporterOptions, create_exporter};
@@ -23,13 +23,16 @@ pub struct CollectorServiceOptions {
     pub exporter: ExporterOptions,
 }
 
+/// Exporters shared across streams, keyed by `application-id`.
+type Exporters<T> = Arc<RwLock<HashMap<Uuid, Arc<dyn Exporter<T>>>>>;
+
 // Simple service to centralize telemetry from distributed clients
 //
 // TODO(johanpel): clean up exporter after timeout or application end.
 pub struct CollectorService<T> {
     // Exporters shared across streams, keyed by `application-id` so concurrent
     // sources of the same application consolidate into one exporter.
-    exporters: Arc<DashMap<Uuid, Arc<dyn Exporter<T>>>>,
+    exporters: Exporters<T>,
     exporter: ExporterOptions,
 }
 
@@ -82,16 +85,22 @@ where
                     Ok(request) => {
                         // Reuse this application's exporter, or create it lazily
                         // on the first batch (so an empty stream writes nothing).
-                        let exporter = if let Some(exporter) = exporters.get(&application_id) {
-                            Arc::clone(&exporter)
+                        // The read guard is dropped before any `.await`.
+                        let cached = exporters.read().unwrap().get(&application_id).cloned();
+                        let exporter = if let Some(exporter) = cached {
+                            exporter
                         } else {
-                            let exporter = match create_exporter::<T>(exporter_kind.clone()).await {
-                                Ok(exporter) => exporter,
-                                Err(e) => {
-                                    error!("unable to construct exporter: {e}");
-                                    break;
-                                }
-                            };
+                            // The server shares one exporter per application across
+                            // its stream handlers, so wrap the owned exporter in an
+                            // `Arc` here — that sharing is local to the collector.
+                            let exporter: Arc<dyn Exporter<T>> =
+                                match create_exporter::<T>(exporter_kind.clone()).await {
+                                    Ok(exporter) => Arc::from(exporter),
+                                    Err(e) => {
+                                        error!("unable to construct exporter: {e}");
+                                        break;
+                                    }
+                                };
                             // Write the provenance sidecar once per application,
                             // alongside the events this exporter just created
                             // the directory for (filesystem exporters only).
@@ -101,7 +110,10 @@ where
                                     warn!("failed to write provenance sidecar: {e}");
                                 }
                             }
-                            exporters.insert(application_id, Arc::clone(&exporter));
+                            exporters
+                                .write()
+                                .unwrap()
+                                .insert(application_id, Arc::clone(&exporter));
                             exporter
                         };
 
@@ -135,11 +147,12 @@ where
                         warn!("collector: stream error: {err:?}");
                         // TODO(johanpel): a client disconnecting (abruptly?) may result in entering this branch.
                         // We should clean up here, but the todo is to figure out what else can go wrong.
-                        if let Some(exporter) = exporters.get(&application_id) {
+                        let exporter = exporters.read().unwrap().get(&application_id).cloned();
+                        if let Some(exporter) = exporter {
                             if let Err(e) = exporter.force_flush().await {
                                 warn!("unable to flush exporter: {e}");
                             }
-                            exporters.remove(&application_id);
+                            exporters.write().unwrap().remove(&application_id);
                         }
                         break;
                     }
@@ -147,7 +160,8 @@ where
             }
 
             // Flush the exporter when stream ends normally
-            if let Some(exporter) = exporters.get(&application_id)
+            let exporter = exporters.read().unwrap().get(&application_id).cloned();
+            if let Some(exporter) = exporter
                 && let Err(e) = exporter.force_flush().await
             {
                 warn!("unable to flush exporter after stream completion: {e}");

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use quent_collector_proto as proto;
 
-/// Local contexts keyed by source context id; one per remote source.
+/// Local contexts keyed by remote source context id.
 type Contexts<C> = Arc<RwLock<HashMap<Uuid, Arc<C>>>>;
 
 /// Builds a per-source local sink from its source context id.

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -1,13 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! A gRPC-based server that reproduces each remote source's local output.
+//! A gRPC server that reproduces each remote source's local output.
 //!
-//! Each source streams its umbrella events tagged with a `source-context-id`.
-//! The server runs one local `{App}Context` (a [`CollectorContext`]) per source
-//! id, feeding it the received events so it reproduces, on the server's own
-//! filesystem, exactly what the source produced locally (including the
-//! provenance sidecar the local context writes itself).
+//! Each source streams its events tagged with a `source-context-id`; the server
+//! runs one local [`CollectorContext`] per source id and feeds it those events,
+//! so it writes the same output the source would write locally.
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use quent_collector_client::CollectorSink;
+use tokio::sync::OnceCell;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{error, warn};
@@ -18,16 +19,58 @@ use uuid::Uuid;
 
 use quent_collector_proto as proto;
 
-/// Local contexts keyed by remote source context id.
-type Contexts<C> = Arc<RwLock<HashMap<Uuid, Arc<C>>>>;
+/// A remote source's locally mirrored context. `cell` builds it exactly once
+/// even when several of that source's entity streams reach the service
+/// together; `open_streams` counts the source's currently open streams so the
+/// context can be dropped when the last one closes.
+struct MirroredContext<C> {
+    cell: Arc<OnceCell<C>>,
+    open_streams: usize,
+}
 
-/// Builds a per-source local sink from its source context id.
+/// Mirrored contexts keyed by remote source context id.
+type Contexts<C> = RwLock<HashMap<Uuid, MirroredContext<C>>>;
+
+/// Builds a per-source mirrored context (with its observers ready) from its
+/// source context id. Injected by the caller because the generic server can't
+/// construct a model-specific context. The build is synchronous from here — the
+/// context bridges its own async work internally.
 type MakeFn<C> = Arc<dyn Fn(Uuid) -> Result<C, String> + Send + Sync>;
 
-// Centralizes telemetry from distributed sources by reproducing each source's
-// local production through a per-source local sink built by `make`.
-//
-// TODO(johanpel): clean up contexts after timeout or source end.
+/// Decrements a source's open-stream count when a stream ends, including on
+/// cancellation (the handler future being dropped mid-stream). When the last
+/// stream of a source closes, removes its context and drops it.
+struct StreamGuard<'a, C: Send + Sync + 'static> {
+    contexts: &'a Contexts<C>,
+    source_context_id: Uuid,
+}
+
+impl<C: Send + Sync + 'static> Drop for StreamGuard<'_, C> {
+    fn drop(&mut self) {
+        let mut map = self.contexts.write().unwrap();
+        let Some(entry) = map.get_mut(&self.source_context_id) else {
+            return;
+        };
+        entry.open_streams -= 1;
+        if entry.open_streams > 0 {
+            return;
+        }
+        let entry = map.remove(&self.source_context_id).expect("entry present");
+        drop(map);
+        // Dropping the context blocks to flush its observers; that block must
+        // not happen on a runtime worker. Drop it on a plain OS thread so the
+        // observers take the off-runtime `block_on` path. `entry.cell` is the
+        // sole remaining handle here (no other stream is open), so this also
+        // drops the context itself.
+        std::thread::spawn(move || drop(entry.cell));
+    }
+}
+
+/// Centralizes telemetry from distributed sources by reproducing each source's
+/// local production through a per-source local sink built by `make`.
+///
+/// `C` is the generated per-model context (implementing [`CollectorSink`] so it
+/// can route serialized events into the right observer).
 pub struct CollectorService<C> {
     contexts: Contexts<C>,
     make: MakeFn<C>,
@@ -40,8 +83,9 @@ impl<C> std::fmt::Debug for CollectorService<C> {
 }
 
 impl<C> CollectorService<C> {
-    /// `make` builds a per-source local sink from its source context id; it is
-    /// invoked once per source on the first received batch.
+    /// `make` builds a per-source local sink (with its observers ready) from its
+    /// source context id; it is invoked once per source on the first received
+    /// batch.
     pub fn new(make: impl Fn(Uuid) -> Result<C, String> + Send + Sync + 'static) -> Self {
         Self {
             contexts: Default::default(),
@@ -82,73 +126,69 @@ where
             .map_err(|_| Status::invalid_argument("`entity-type` metadata is not valid UTF-8"))?
             .to_owned();
 
-        let mut stream = request.into_inner();
-        let contexts = Arc::clone(&self.contexts);
-        let make = Arc::clone(&self.make);
-        let export_join_handle = tokio::spawn(async move {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(request) => {
-                        // Reuse this source's context, or create it lazily on the
-                        // first batch. The read guard is dropped before any work
-                        // that could block; neither guard is held across `.await`.
-                        let cached = contexts.read().unwrap().get(&source_context_id).cloned();
-                        let context = if let Some(context) = cached {
-                            context
-                        } else {
-                            // The context builds its observers with `block_on`,
-                            // which would panic on a runtime worker thread, so
-                            // construct it on a blocking thread.
-                            let make = Arc::clone(&make);
-                            let built =
-                                tokio::task::spawn_blocking(move || (make)(source_context_id))
-                                    .await;
-                            let context = match built {
-                                Ok(Ok(context)) => Arc::new(context),
-                                Ok(Err(e)) => {
-                                    error!("unable to construct local context: {e}");
-                                    break;
-                                }
-                                Err(e) => {
-                                    error!("local context construction panicked: {e}");
-                                    break;
-                                }
-                            };
-                            contexts
-                                .write()
-                                .unwrap()
-                                .insert(source_context_id, Arc::clone(&context));
-                            context
-                        };
+        // Register this stream against its source, creating the entry on the
+        // first stream of the source.
+        {
+            let mut map = self.contexts.write().unwrap();
+            map.entry(source_context_id)
+                .or_insert_with(|| MirroredContext {
+                    cell: Arc::new(OnceCell::new()),
+                    open_streams: 0,
+                })
+                .open_streams += 1;
+        }
+        // Drops the source's context once its last stream closes; runs on
+        // normal completion and on cancellation alike.
+        let _guard = StreamGuard {
+            contexts: &self.contexts,
+            source_context_id,
+        };
 
-                        tracing::trace_span!("ingesting", num_events = request.event.len())
-                            .in_scope(|| {
-                                for serialized_event in request.event {
-                                    if let Err(e) =
-                                        context.ingest(&entity_type, &serialized_event[..])
-                                    {
-                                        warn!("collector: ingest error: {e}");
-                                    }
-                                }
-                            });
-                    }
-                    Err(err) => {
-                        warn!("collector: stream error: {err:?}");
-                        // TODO(johanpel): a source disconnecting (abruptly?) may result in entering this branch.
-                        // The context's observers flush on drop (via `block_on`),
-                        // so drop it on a blocking thread, not a runtime worker.
-                        let removed = contexts.write().unwrap().remove(&source_context_id);
-                        if let Some(context) = removed {
-                            let _ = tokio::task::spawn_blocking(move || drop(context)).await;
+        // Run the loop inline (not in a spawned task) so it is cancelled when
+        // this RPC's future is dropped, e.g. when the client disconnects.
+        let mut stream = request.into_inner();
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(request) => {
+                    // Vend this source's build-once cell; its entry is present
+                    // for as long as this stream is open. The lock is held only
+                    // for the lookup, never across construction.
+                    let cell = {
+                        let map = self.contexts.read().unwrap();
+                        Arc::clone(&map.get(&source_context_id).expect("entry registered").cell)
+                    };
+
+                    // Built exactly once across this source's streams; concurrent
+                    // first-touchers await the same construction. `make` is sync
+                    // and bridges its own async observer builds internally.
+                    let built = cell
+                        .get_or_try_init(|| async { (self.make)(source_context_id) })
+                        .await;
+                    let context = match built {
+                        Ok(context) => context,
+                        Err(e) => {
+                            error!("unable to construct local context: {e}");
+                            break;
                         }
-                        break;
-                    }
+                    };
+
+                    tracing::trace_span!("ingesting", num_events = request.event.len()).in_scope(
+                        || {
+                            for serialized_event in request.event {
+                                if let Err(e) = context.ingest(&entity_type, &serialized_event[..])
+                                {
+                                    warn!("collector: ingest error: {e}");
+                                }
+                            }
+                        },
+                    );
+                }
+                Err(err) => {
+                    warn!("collector: stream error: {err:?}");
+                    break;
                 }
             }
-            // On normal stream completion the context stays cached; its
-            // observers flush when the context is eventually dropped.
-        });
-        let _ = export_join_handle.await;
+        }
         Ok(Response::new(proto::CollectEventResponse {}))
     }
 }

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use quent_build_info::{ArtifactInfo, ModelSource};
+use quent_events::EntityEvent;
 use quent_exporter::{ExporterOptions, create_exporter};
 use quent_exporter_types::Exporter;
 use serde::{Deserialize, Serialize};
@@ -52,7 +53,7 @@ impl<T> CollectorService<T> {
 #[tonic::async_trait]
 impl<T> proto::collector_server::Collector for CollectorService<T>
 where
-    for<'de> T: Serialize + Deserialize<'de> + Send + ModelSource + 'static,
+    for<'de> T: Serialize + Deserialize<'de> + Send + ModelSource + EntityEvent + 'static,
 {
     #[tracing::instrument]
     async fn collect_events(

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -1,16 +1,21 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! A gRPC-based server that collects `Event`s from multiple sources and exports them.
+//! A gRPC-based server that reproduces each remote source's local output.
+//!
+//! Each source streams its umbrella events tagged with a `source-context-id`.
+//! The server runs one local `{App}Context` (a [`CollectorContext`]) per source
+//! id, feeding it the received events so it reproduces, on the server's own
+//! filesystem, exactly what the source produced locally (including the
+//! provenance sidecar the local context writes itself).
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use quent_build_info::{ArtifactInfo, ModelSource};
-use quent_events::EntityEvent;
-use quent_exporter::{ExporterOptions, create_exporter};
-use quent_exporter_types::Exporter;
-use serde::{Deserialize, Serialize};
+use quent_events::Event;
+use quent_exporter::ExporterOptions;
+use quent_instrumentation::CollectorContext;
+use serde::Deserialize;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{error, warn};
@@ -23,20 +28,19 @@ pub struct CollectorServiceOptions {
     pub exporter: ExporterOptions,
 }
 
-/// Exporters shared across streams, keyed by `application-id`.
-type Exporters<T> = Arc<RwLock<HashMap<Uuid, Arc<dyn Exporter<T>>>>>;
+/// Local contexts keyed by source context id; one per remote source.
+type Contexts<C> = Arc<RwLock<HashMap<Uuid, Arc<C>>>>;
 
-// Simple service to centralize telemetry from distributed clients
+// Centralizes telemetry from distributed sources by reproducing each source's
+// local production through a per-source local context.
 //
-// TODO(johanpel): clean up exporter after timeout or application end.
-pub struct CollectorService<T> {
-    // Exporters shared across streams, keyed by `application-id` so concurrent
-    // sources of the same application consolidate into one exporter.
-    exporters: Exporters<T>,
+// TODO(johanpel): clean up contexts after timeout or source end.
+pub struct CollectorService<C> {
+    contexts: Contexts<C>,
     exporter: ExporterOptions,
 }
 
-impl<T> std::fmt::Debug for CollectorService<T> {
+impl<C> std::fmt::Debug for CollectorService<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CollectorService")
             .field("exporter", &self.exporter)
@@ -44,128 +48,110 @@ impl<T> std::fmt::Debug for CollectorService<T> {
     }
 }
 
-impl<T> CollectorService<T> {
+impl<C> CollectorService<C> {
     pub fn new(options: CollectorServiceOptions) -> Self {
         Self {
-            exporters: Default::default(),
+            contexts: Default::default(),
             exporter: options.exporter,
         }
     }
 }
 
 #[tonic::async_trait]
-impl<T> proto::collector_server::Collector for CollectorService<T>
+impl<C> proto::collector_server::Collector for CollectorService<C>
 where
-    for<'de> T: Serialize + Deserialize<'de> + Send + ModelSource + EntityEvent + 'static,
+    C: CollectorContext + Send + Sync + 'static,
+    for<'de> C::Event: Deserialize<'de>,
 {
     #[tracing::instrument]
     async fn collect_events(
         &self,
         request: Request<Streaming<proto::CollectEventRequest>>,
     ) -> Result<Response<proto::CollectEventResponse>, Status> {
-        // The client identifies its stream with the `application-id` metadata.
-        let application_id = request
+        // The source identifies its stream with the `source-context-id` metadata.
+        let source_context_id = request
             .metadata()
-            .get("application-id")
-            .ok_or_else(|| Status::invalid_argument("missing `application-id` metadata"))?
+            .get("source-context-id")
+            .ok_or_else(|| Status::invalid_argument("missing `source-context-id` metadata"))?
             .to_str()
             .ok()
             .and_then(|s| Uuid::parse_str(s).ok())
             .ok_or_else(|| {
-                Status::invalid_argument("`application-id` metadata is not a valid UUID")
+                Status::invalid_argument("`source-context-id` metadata is not a valid UUID")
             })?;
 
         let mut stream = request.into_inner();
-        let exporters = Arc::clone(&self.exporters);
-        // Group each application's events under its own subdirectory.
-        let exporter_kind = self.exporter.clone().in_context_dir(application_id);
+        let contexts = Arc::clone(&self.contexts);
+        let exporter = self.exporter.clone();
         let export_join_handle = tokio::spawn(async move {
             while let Some(item) = stream.next().await {
                 match item {
                     Ok(request) => {
-                        // Reuse this application's exporter, or create it lazily
-                        // on the first batch (so an empty stream writes nothing).
-                        // The read guard is dropped before any `.await`.
-                        let cached = exporters.read().unwrap().get(&application_id).cloned();
-                        let exporter = if let Some(exporter) = cached {
-                            exporter
+                        // Reuse this source's context, or create it lazily on the
+                        // first batch. The read guard is dropped before any work
+                        // that could block; neither guard is held across `.await`.
+                        let cached = contexts.read().unwrap().get(&source_context_id).cloned();
+                        let context = if let Some(context) = cached {
+                            context
                         } else {
-                            // The server shares one exporter per application across
-                            // its stream handlers, so wrap the owned exporter in an
-                            // `Arc` here — that sharing is local to the collector.
-                            let exporter: Arc<dyn Exporter<T>> =
-                                match create_exporter::<T>(exporter_kind.clone()).await {
-                                    Ok(exporter) => Arc::from(exporter),
-                                    Err(e) => {
-                                        error!("unable to construct exporter: {e}");
-                                        break;
-                                    }
-                                };
-                            // Write the provenance sidecar once per application,
-                            // alongside the events this exporter just created
-                            // the directory for (filesystem exporters only).
-                            if let Some(dir) = exporter_kind.filesystem_root() {
-                                let info = ArtifactInfo::new(T::model_info());
-                                if let Err(e) = info.write_sidecar(dir) {
-                                    warn!("failed to write provenance sidecar: {e}");
+                            // The context builds its observers with `block_on`,
+                            // which would panic on a runtime worker thread, so
+                            // construct it on a blocking thread.
+                            let exporter = exporter.clone();
+                            // The error type is not `Send`, so stringify it on
+                            // the blocking thread before crossing the boundary.
+                            let built = tokio::task::spawn_blocking(move || {
+                                C::with_source_id(source_context_id, Some(exporter))
+                                    .map_err(|e| e.to_string())
+                            })
+                            .await;
+                            let context = match built {
+                                Ok(Ok(context)) => Arc::new(context),
+                                Ok(Err(e)) => {
+                                    error!("unable to construct local context: {e}");
+                                    break;
                                 }
-                            }
-                            exporters
+                                Err(e) => {
+                                    error!("local context construction panicked: {e}");
+                                    break;
+                                }
+                            };
+                            contexts
                                 .write()
                                 .unwrap()
-                                .insert(application_id, Arc::clone(&exporter));
-                            exporter
+                                .insert(source_context_id, Arc::clone(&context));
+                            context
                         };
 
-                        let mut events = Vec::with_capacity(request.event.len());
                         tracing::trace_span!("deserializing", num_events = request.event.len())
                             .in_scope(|| {
                                 for serialized_event in request.event {
-                                    match ciborium::from_reader(&serialized_event[..]) {
-                                        Ok(event) => events.push(event),
+                                    match ciborium::from_reader::<Event<C::Event>, _>(
+                                        &serialized_event[..],
+                                    ) {
+                                        Ok(event) => context.feed(event),
                                         Err(e) => {
                                             warn!("collector: deserialization error: {e}")
                                         }
                                     }
                                 }
                             });
-
-                        tracing::trace_span!("exporting")
-                            .in_scope(async || {
-                                for event in events {
-                                    match exporter.push(event).await {
-                                        Ok(_) => (), // successfully exported
-                                        Err(e) => {
-                                            warn!("collector: unable to export: {e}")
-                                        }
-                                    }
-                                }
-                            })
-                            .await;
                     }
                     Err(err) => {
                         warn!("collector: stream error: {err:?}");
-                        // TODO(johanpel): a client disconnecting (abruptly?) may result in entering this branch.
-                        // We should clean up here, but the todo is to figure out what else can go wrong.
-                        let exporter = exporters.read().unwrap().get(&application_id).cloned();
-                        if let Some(exporter) = exporter {
-                            if let Err(e) = exporter.force_flush().await {
-                                warn!("unable to flush exporter: {e}");
-                            }
-                            exporters.write().unwrap().remove(&application_id);
+                        // TODO(johanpel): a source disconnecting (abruptly?) may result in entering this branch.
+                        // The context's observers flush on drop (via `block_on`),
+                        // so drop it on a blocking thread, not a runtime worker.
+                        let removed = contexts.write().unwrap().remove(&source_context_id);
+                        if let Some(context) = removed {
+                            let _ = tokio::task::spawn_blocking(move || drop(context)).await;
                         }
                         break;
                     }
                 }
             }
-
-            // Flush the exporter when stream ends normally
-            let exporter = exporters.read().unwrap().get(&application_id).cloned();
-            if let Some(exporter) = exporter
-                && let Err(e) = exporter.force_flush().await
-            {
-                warn!("unable to flush exporter after stream completion: {e}");
-            }
+            // On normal stream completion the context stays cached; its
+            // observers flush when the context is eventually dropped.
         });
         let _ = export_join_handle.await;
         Ok(Response::new(proto::CollectEventResponse {}))

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -10,10 +10,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use quent_events::Event;
 use quent_exporter::ExporterOptions;
 use quent_instrumentation::CollectorContext;
-use serde::Deserialize;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{error, warn};
@@ -59,7 +57,6 @@ impl<C> CollectorService<C> {
 impl<C> proto::collector_server::Collector for CollectorService<C>
 where
     C: CollectorContext + Send + Sync + 'static,
-    for<'de> C::Event: Deserialize<'de>,
 {
     #[tracing::instrument]
     async fn collect_events(
@@ -77,6 +74,16 @@ where
             .ok_or_else(|| {
                 Status::invalid_argument("`source-context-id` metadata is not a valid UUID")
             })?;
+
+        // The source tags its stream with the entity type so the local context
+        // routes each batch to the matching entity observer.
+        let entity_type = request
+            .metadata()
+            .get("entity-type")
+            .ok_or_else(|| Status::invalid_argument("missing `entity-type` metadata"))?
+            .to_str()
+            .map_err(|_| Status::invalid_argument("`entity-type` metadata is not valid UTF-8"))?
+            .to_owned();
 
         let mut stream = request.into_inner();
         let contexts = Arc::clone(&self.contexts);
@@ -121,19 +128,17 @@ where
                             context
                         };
 
-                        tracing::trace_span!("deserializing", num_events = request.event.len())
-                            .in_scope(|| {
+                        tracing::trace_span!("feeding", num_events = request.event.len()).in_scope(
+                            || {
                                 for serialized_event in request.event {
-                                    match ciborium::from_reader::<Event<C::Event>, _>(
-                                        &serialized_event[..],
-                                    ) {
-                                        Ok(event) => context.feed(event),
-                                        Err(e) => {
-                                            warn!("collector: deserialization error: {e}")
-                                        }
+                                    if let Err(e) =
+                                        context.feed(&entity_type, &serialized_event[..])
+                                    {
+                                        warn!("collector: feed error: {e}");
                                     }
                                 }
-                            });
+                            },
+                        );
                     }
                     Err(err) => {
                         warn!("collector: stream error: {err:?}");

--- a/crates/collector/server/src/server.rs
+++ b/crates/collector/server/src/server.rs
@@ -4,14 +4,13 @@
 //! A gRPC server that reproduces each remote source's local output.
 //!
 //! Each source streams its events tagged with a `source-context-id`; the server
-//! runs one local [`CollectorContext`] per source id and feeds it those events,
-//! so it writes the same output the source would write locally.
+//! runs one local sink per source id and routes those events into it, so it
+//! writes the same output the source would write locally.
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use quent_exporter::ExporterOptions;
-use quent_instrumentation::CollectorContext;
+use quent_collector_client::CollectorSink;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{error, warn};
@@ -19,36 +18,34 @@ use uuid::Uuid;
 
 use quent_collector_proto as proto;
 
-#[derive(Debug, Clone)]
-pub struct CollectorServiceOptions {
-    pub exporter: ExporterOptions,
-}
-
 /// Local contexts keyed by source context id; one per remote source.
 type Contexts<C> = Arc<RwLock<HashMap<Uuid, Arc<C>>>>;
 
+/// Builds a per-source local sink from its source context id.
+type MakeFn<C> = Arc<dyn Fn(Uuid) -> Result<C, String> + Send + Sync>;
+
 // Centralizes telemetry from distributed sources by reproducing each source's
-// local production through a per-source local context.
+// local production through a per-source local sink built by `make`.
 //
 // TODO(johanpel): clean up contexts after timeout or source end.
 pub struct CollectorService<C> {
     contexts: Contexts<C>,
-    exporter: ExporterOptions,
+    make: MakeFn<C>,
 }
 
 impl<C> std::fmt::Debug for CollectorService<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CollectorService")
-            .field("exporter", &self.exporter)
-            .finish()
+        f.debug_struct("CollectorService").finish_non_exhaustive()
     }
 }
 
 impl<C> CollectorService<C> {
-    pub fn new(options: CollectorServiceOptions) -> Self {
+    /// `make` builds a per-source local sink from its source context id; it is
+    /// invoked once per source on the first received batch.
+    pub fn new(make: impl Fn(Uuid) -> Result<C, String> + Send + Sync + 'static) -> Self {
         Self {
             contexts: Default::default(),
-            exporter: options.exporter,
+            make: Arc::new(make),
         }
     }
 }
@@ -56,7 +53,7 @@ impl<C> CollectorService<C> {
 #[tonic::async_trait]
 impl<C> proto::collector_server::Collector for CollectorService<C>
 where
-    C: CollectorContext + Send + Sync + 'static,
+    C: CollectorSink + Send + Sync + 'static,
 {
     #[tracing::instrument]
     async fn collect_events(
@@ -87,7 +84,7 @@ where
 
         let mut stream = request.into_inner();
         let contexts = Arc::clone(&self.contexts);
-        let exporter = self.exporter.clone();
+        let make = Arc::clone(&self.make);
         let export_join_handle = tokio::spawn(async move {
             while let Some(item) = stream.next().await {
                 match item {
@@ -102,14 +99,10 @@ where
                             // The context builds its observers with `block_on`,
                             // which would panic on a runtime worker thread, so
                             // construct it on a blocking thread.
-                            let exporter = exporter.clone();
-                            // The error type is not `Send`, so stringify it on
-                            // the blocking thread before crossing the boundary.
-                            let built = tokio::task::spawn_blocking(move || {
-                                C::with_source_id(source_context_id, Some(exporter))
-                                    .map_err(|e| e.to_string())
-                            })
-                            .await;
+                            let make = Arc::clone(&make);
+                            let built =
+                                tokio::task::spawn_blocking(move || (make)(source_context_id))
+                                    .await;
                             let context = match built {
                                 Ok(Ok(context)) => Arc::new(context),
                                 Ok(Err(e)) => {
@@ -128,17 +121,16 @@ where
                             context
                         };
 
-                        tracing::trace_span!("feeding", num_events = request.event.len()).in_scope(
-                            || {
+                        tracing::trace_span!("ingesting", num_events = request.event.len())
+                            .in_scope(|| {
                                 for serialized_event in request.event {
                                     if let Err(e) =
-                                        context.feed(&entity_type, &serialized_event[..])
+                                        context.ingest(&entity_type, &serialized_event[..])
                                     {
-                                        warn!("collector: feed error: {e}");
+                                        warn!("collector: ingest error: {e}");
                                     }
                                 }
-                            },
-                        );
+                            });
                     }
                     Err(err) => {
                         warn!("collector: stream error: {err:?}");

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -9,6 +9,12 @@ use uuid::Uuid;
 
 pub mod trace;
 
+/// Trait for the event type of an entity.
+pub trait EntityEvent {
+    /// The name of the entity.
+    const NAME: &'static str;
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct Event<T> {
     /// The ID of the entity producing this event.

--- a/crates/exporter/Cargo.toml
+++ b/crates/exporter/Cargo.toml
@@ -11,6 +11,7 @@ postcard = ["dep:quent-exporter-postcard"]
 collector = ["dep:quent-exporter-collector"]
 
 [dependencies]
+quent-events = { path = "../events" }
 quent-exporter-types = { path = "types" }
 quent-exporter-collector = { path = "collector", optional = true }
 quent-exporter-msgpack = { path = "msgpack", optional = true }

--- a/crates/exporter/Cargo.toml
+++ b/crates/exporter/Cargo.toml
@@ -8,9 +8,10 @@ default = ["ndjson", "msgpack", "postcard", "collector"]
 ndjson = ["dep:quent-exporter-ndjson"]
 msgpack = ["dep:quent-exporter-msgpack"]
 postcard = ["dep:quent-exporter-postcard"]
-collector = ["dep:quent-exporter-collector"]
+collector = ["dep:quent-exporter-collector", "dep:http"]
 
 [dependencies]
+http = { workspace = true, optional = true }
 quent-events = { path = "../events" }
 quent-exporter-types = { path = "types" }
 quent-exporter-collector = { path = "collector", optional = true }

--- a/crates/exporter/collector/Cargo.toml
+++ b/crates/exporter/collector/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace =  true
 publish.workspace = true
 [dependencies]
 async-trait.workspace = true
+http.workspace = true
 serde.workspace = true
 quent-collector-client = { path = "../../collector/client" }
 quent-events = { path = "../../events" }

--- a/crates/exporter/collector/src/lib.rs
+++ b/crates/exporter/collector/src/lib.rs
@@ -35,7 +35,7 @@ where
     /// `source_context_id` identifies this stream to the collector, which
     /// reproduces the source's output under that id.
     pub async fn try_new(
-        address: String,
+        address: http::Uri,
         source_context_id: Uuid,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let client = Client::new(source_context_id, T::NAME, address).await?;

--- a/crates/exporter/collector/src/lib.rs
+++ b/crates/exporter/collector/src/lib.rs
@@ -9,16 +9,15 @@ use quent_exporter_types::{Exporter, ExporterError, ExporterResult};
 use serde::Serialize;
 use uuid::Uuid;
 
-/// Options for the collector exporter.
+/// User-facing options for the collector exporter.
 ///
 /// Streams events over gRPC to a remote collector service. Use this for
-/// distributed deployments where events are centralized for analysis.
-/// `source_context_id` identifies this stream to the collector, which
-/// reproduces the source's output under that id.
+/// distributed deployments where events are centralized for analysis. The
+/// source context id the collector reproduces under is supplied separately by
+/// the context when it builds the exporter (see [`CollectorExporter::try_new`]).
 #[derive(Debug, Default, Clone)]
 pub struct CollectorExporterOptions {
     pub address: String,
-    pub source_context_id: Uuid,
 }
 
 /// Streams one entity's events to a collector. The stream is tagged with the
@@ -33,10 +32,13 @@ impl<T> CollectorExporter<T>
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
+    /// `source_context_id` identifies this stream to the collector, which
+    /// reproduces the source's output under that id.
     pub async fn try_new(
-        options: CollectorExporterOptions,
+        address: String,
+        source_context_id: Uuid,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let client = Client::new(options.source_context_id, T::NAME, options.address).await?;
+        let client = Client::new(source_context_id, T::NAME, address).await?;
         Ok(Self { client })
     }
 }

--- a/crates/exporter/collector/src/lib.rs
+++ b/crates/exporter/collector/src/lib.rs
@@ -21,35 +21,34 @@ pub struct CollectorExporterOptions {
     pub source_context_id: Uuid,
 }
 
-/// Streams a model's entity events to a collector, wrapping each entity event
-/// into the umbrella wire type `U` so the serde variant tag identifies the
-/// entity (no separate event-type field is sent).
+/// Streams one entity's events to a collector. The stream is tagged with the
+/// entity name (`T::NAME`) so the collector routes each batch to the matching
+/// entity observer.
 #[derive(Debug)]
-pub struct CollectorExporter<U> {
-    client: Client<U>,
+pub struct CollectorExporter<T> {
+    client: Client<T>,
 }
 
-impl<U> CollectorExporter<U>
+impl<T> CollectorExporter<T>
 where
-    U: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     pub async fn try_new(
         options: CollectorExporterOptions,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let client = Client::new(options.source_context_id, options.address).await?;
+        let client = Client::new(options.source_context_id, T::NAME, options.address).await?;
         Ok(Self { client })
     }
 }
 
 #[async_trait::async_trait]
-impl<T, U> Exporter<T> for CollectorExporter<U>
+impl<T> Exporter<T> for CollectorExporter<T>
 where
-    T: Serialize + Send + EntityEvent + Into<U> + 'static,
-    U: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     async fn push(&self, event: Event<T>) -> ExporterResult<()> {
         self.client
-            .send(Event::new(event.id, event.timestamp, event.data.into()))
+            .send(event)
             .await
             .map_err(|e| ExporterError::Collector(format!("{e:?}")))?;
         Ok(())

--- a/crates/exporter/collector/src/lib.rs
+++ b/crates/exporter/collector/src/lib.rs
@@ -54,7 +54,11 @@ where
         Ok(())
     }
     async fn force_flush(&self) -> ExporterResult<()> {
-        // TODO(johanpel): figure this out, it may be that we don't need this trait fn
+        // Drain buffered events and wait for delivery. The forwarder awaits this
+        // on shutdown, so the client's tasks are joined here rather than in
+        // `Client::drop` (which may run on a runtime worker, where blocking
+        // panics).
+        self.client.shutdown().await;
         Ok(())
     }
 }

--- a/crates/exporter/collector/src/lib.rs
+++ b/crates/exporter/collector/src/lib.rs
@@ -4,7 +4,7 @@
 //! Exporter sending events to a Collector service
 
 use quent_collector_client::Client;
-use quent_events::Event;
+use quent_events::{EntityEvent, Event};
 use quent_exporter_types::{Exporter, ExporterError, ExporterResult};
 use serde::Serialize;
 use uuid::Uuid;
@@ -41,7 +41,7 @@ where
 #[async_trait::async_trait]
 impl<T> Exporter<T> for CollectorExporter<T>
 where
-    T: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     async fn push(&self, event: Event<T>) -> ExporterResult<()> {
         self.client

--- a/crates/exporter/collector/src/lib.rs
+++ b/crates/exporter/collector/src/lib.rs
@@ -13,39 +13,43 @@ use uuid::Uuid;
 ///
 /// Streams events over gRPC to a remote collector service. Use this for
 /// distributed deployments where events are centralized for analysis.
-/// `application_id` identifies this stream to the collector, which groups its
-/// events under that id.
+/// `source_context_id` identifies this stream to the collector, which
+/// reproduces the source's output under that id.
 #[derive(Debug, Default, Clone)]
 pub struct CollectorExporterOptions {
     pub address: String,
-    pub application_id: Uuid,
+    pub source_context_id: Uuid,
 }
 
+/// Streams a model's entity events to a collector, wrapping each entity event
+/// into the umbrella wire type `U` so the serde variant tag identifies the
+/// entity (no separate event-type field is sent).
 #[derive(Debug)]
-pub struct CollectorExporter<T> {
-    client: Client<T>,
+pub struct CollectorExporter<U> {
+    client: Client<U>,
 }
 
-impl<T> CollectorExporter<T>
+impl<U> CollectorExporter<U>
 where
-    T: Serialize + Send + 'static,
+    U: Serialize + Send + 'static,
 {
     pub async fn try_new(
         options: CollectorExporterOptions,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let client = Client::new(options.application_id, options.address).await?;
+        let client = Client::new(options.source_context_id, options.address).await?;
         Ok(Self { client })
     }
 }
 
 #[async_trait::async_trait]
-impl<T> Exporter<T> for CollectorExporter<T>
+impl<T, U> Exporter<T> for CollectorExporter<U>
 where
-    T: Serialize + Send + EntityEvent + 'static,
+    T: Serialize + Send + EntityEvent + Into<U> + 'static,
+    U: Serialize + Send + 'static,
 {
     async fn push(&self, event: Event<T>) -> ExporterResult<()> {
         self.client
-            .send(event)
+            .send(Event::new(event.id, event.timestamp, event.data.into()))
             .await
             .map_err(|e| ExporterError::Collector(format!("{e:?}")))?;
         Ok(())

--- a/crates/exporter/msgpack/Cargo.toml
+++ b/crates/exporter/msgpack/Cargo.toml
@@ -11,3 +11,4 @@ rmp-serde.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["sync", "fs", "io-util"]}
 tracing.workspace = true
+uuid.workspace = true

--- a/crates/exporter/msgpack/src/lib.rs
+++ b/crates/exporter/msgpack/src/lib.rs
@@ -26,7 +26,7 @@ const EXTENSION: &str = "msgpack";
 /// A compact row-oriented binary format, which is self-describing.
 ///
 /// Writes events in MessagePack binary format under `dir`, in a per-entity
-/// subdirectory holding a UUIDv7-named file with extension [`EXTENSION`].
+/// subdirectory holding a UUIDv7-named `.msgpack` file.
 #[derive(Debug, Clone)]
 pub struct MsgpackExporterOptions {
     pub dir: PathBuf,

--- a/crates/exporter/msgpack/src/lib.rs
+++ b/crates/exporter/msgpack/src/lib.rs
@@ -7,7 +7,7 @@
 //! Each record: `[4 bytes: payload length as u32 BE][payload: msgpack-encoded Event<T>]`
 use std::{io::BufReader, marker::PhantomData, path::PathBuf};
 
-use quent_events::Event;
+use quent_events::{EntityEvent, Event};
 use quent_exporter_types::{Exporter, ExporterError, ExporterResult, Importer, ImporterResult};
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -16,14 +16,20 @@ use tokio::{
     sync::Mutex,
 };
 use tracing::{debug, error};
+use uuid::Uuid;
+
+/// File extension for MessagePack event files.
+const EXTENSION: &str = "msgpack";
 
 /// Options for the MessagePack exporter.
 ///
-/// Writes events in MessagePack binary format to the file at `path`. Compact
-/// and fast to serialize/deserialize.
+/// A compact row-oriented binary format, which is self-describing.
+///
+/// Writes events in MessagePack binary format under `dir`, in a per-entity
+/// subdirectory holding a UUIDv7-named file with extension [`EXTENSION`].
 #[derive(Debug, Clone)]
 pub struct MsgpackExporterOptions {
-    pub path: PathBuf,
+    pub dir: PathBuf,
 }
 
 #[derive(Debug)]
@@ -32,15 +38,15 @@ pub struct MsgpackExporter {
 }
 
 impl MsgpackExporter {
-    pub async fn try_new(options: MsgpackExporterOptions) -> ExporterResult<Self> {
-        if let Some(parent) = options.path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        debug!("exporting to \"{}\"", options.path.display());
+    pub async fn try_new<T: EntityEvent>(options: MsgpackExporterOptions) -> ExporterResult<Self> {
+        let dir = options.dir.join(T::NAME);
+        tokio::fs::create_dir_all(&dir).await?;
+        let path = dir.join(format!("{}.{EXTENSION}", Uuid::now_v7()));
+        debug!("exporting to \"{}\"", path.display());
         let file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&options.path)
+            .open(&path)
             .await?;
         Ok(Self {
             writer: Mutex::new(BufWriter::new(file)),
@@ -51,7 +57,7 @@ impl MsgpackExporter {
 #[async_trait::async_trait]
 impl<T> Exporter<T> for MsgpackExporter
 where
-    T: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     async fn push(&self, event: Event<T>) -> ExporterResult<()> {
         let payload =

--- a/crates/exporter/ndjson/Cargo.toml
+++ b/crates/exporter/ndjson/Cargo.toml
@@ -11,3 +11,4 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync", "fs", "io-util"]}
 tracing.workspace = true
+uuid.workspace = true

--- a/crates/exporter/ndjson/src/lib.rs
+++ b/crates/exporter/ndjson/src/lib.rs
@@ -28,8 +28,7 @@ const EXTENSION: &str = "ndjson";
 /// inspection.
 ///
 /// Writes events as newline-delimited JSON (one JSON object per line) under
-/// `dir`, in a per-entity subdirectory holding a UUIDv7-named file with
-/// extension [`EXTENSION`].
+/// `dir`, in a per-entity subdirectory holding a UUIDv7-named `.ndjson` file.
 #[derive(Debug, Clone)]
 pub struct NdjsonExporterOptions {
     pub dir: PathBuf,

--- a/crates/exporter/ndjson/src/lib.rs
+++ b/crates/exporter/ndjson/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     path::PathBuf,
 };
 
-use quent_events::Event;
+use quent_events::{EntityEvent, Event};
 use quent_exporter_types::{Exporter, ExporterError, ExporterResult, Importer, ImporterResult};
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -17,13 +17,22 @@ use tokio::{
     sync::Mutex,
 };
 use tracing::{debug, error};
+use uuid::Uuid;
+
+/// File extension for ndjson event files.
+const EXTENSION: &str = "ndjson";
+
 /// Options for the ndjson exporter.
 ///
-/// Writes events as newline-delimited JSON (one JSON object per line) to the
-/// file at `path`. Human-readable, useful for debugging and manual inspection.
+/// A human-readable format useful for debugging and manual / LLM-based
+/// inspection.
+///
+/// Writes events as newline-delimited JSON (one JSON object per line) under
+/// `dir`, in a per-entity subdirectory holding a UUIDv7-named file with
+/// extension [`EXTENSION`].
 #[derive(Debug, Clone)]
 pub struct NdjsonExporterOptions {
-    pub path: PathBuf,
+    pub dir: PathBuf,
 }
 
 #[derive(Debug)]
@@ -32,15 +41,15 @@ pub struct NdjsonExporter {
 }
 
 impl NdjsonExporter {
-    pub async fn try_new(options: NdjsonExporterOptions) -> ExporterResult<Self> {
-        if let Some(parent) = options.path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        debug!("exporting to \"{}\"", options.path.display());
+    pub async fn try_new<T: EntityEvent>(options: NdjsonExporterOptions) -> ExporterResult<Self> {
+        let dir = options.dir.join(T::NAME);
+        tokio::fs::create_dir_all(&dir).await?;
+        let path = dir.join(format!("{}.{EXTENSION}", Uuid::now_v7()));
+        debug!("exporting to \"{}\"", path.display());
         let file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&options.path)
+            .open(&path)
             .await?;
 
         Ok(Self {
@@ -52,7 +61,7 @@ impl NdjsonExporter {
 #[async_trait::async_trait]
 impl<T> Exporter<T> for NdjsonExporter
 where
-    T: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     async fn push(&self, event: Event<T>) -> ExporterResult<()> {
         let line = format!(

--- a/crates/exporter/postcard/Cargo.toml
+++ b/crates/exporter/postcard/Cargo.toml
@@ -11,3 +11,4 @@ quent-exporter-types = { path = "../types" }
 serde.workspace = true
 tokio = { workspace = true, features = ["sync", "fs", "io-util"]}
 tracing.workspace = true
+uuid.workspace = true

--- a/crates/exporter/postcard/src/lib.rs
+++ b/crates/exporter/postcard/src/lib.rs
@@ -26,7 +26,7 @@ const EXTENSION: &str = "postcard";
 /// A compact row-oriented binary format, which is not self-describing.
 ///
 /// Writes events in Postcard format under `dir`, in a per-entity subdirectory
-/// holding a UUIDv7-named file with extension [`EXTENSION`].
+/// holding a UUIDv7-named `.postcard` file.
 #[derive(Debug, Clone)]
 pub struct PostcardExporterOptions {
     pub dir: PathBuf,

--- a/crates/exporter/postcard/src/lib.rs
+++ b/crates/exporter/postcard/src/lib.rs
@@ -7,7 +7,7 @@
 //! Each record: `[4 bytes: payload length as u32 BE][payload: postcard-encoded Event<T>]`
 use std::{io::BufReader, marker::PhantomData, path::PathBuf};
 
-use quent_events::Event;
+use quent_events::{EntityEvent, Event};
 use quent_exporter_types::{Exporter, ExporterError, ExporterResult, Importer, ImporterResult};
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -16,14 +16,20 @@ use tokio::{
     sync::Mutex,
 };
 use tracing::{debug, error};
+use uuid::Uuid;
+
+/// File extension for Postcard event files.
+const EXTENSION: &str = "postcard";
 
 /// Options for the Postcard exporter.
 ///
-/// Writes events in Postcard format (a compact, no_std-friendly binary
-/// encoding) to the file at `path`.
+/// A compact row-oriented binary format, which is not self-describing.
+///
+/// Writes events in Postcard format under `dir`, in a per-entity subdirectory
+/// holding a UUIDv7-named file with extension [`EXTENSION`].
 #[derive(Debug, Clone)]
 pub struct PostcardExporterOptions {
-    pub path: PathBuf,
+    pub dir: PathBuf,
 }
 
 #[derive(Debug)]
@@ -32,15 +38,15 @@ pub struct PostcardExporter {
 }
 
 impl PostcardExporter {
-    pub async fn try_new(options: PostcardExporterOptions) -> ExporterResult<Self> {
-        if let Some(parent) = options.path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        debug!("exporting to \"{}\"", options.path.display());
+    pub async fn try_new<T: EntityEvent>(options: PostcardExporterOptions) -> ExporterResult<Self> {
+        let dir = options.dir.join(T::NAME);
+        tokio::fs::create_dir_all(&dir).await?;
+        let path = dir.join(format!("{}.{EXTENSION}", Uuid::now_v7()));
+        debug!("exporting to \"{}\"", path.display());
         let file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&options.path)
+            .open(&path)
             .await?;
         Ok(Self {
             writer: Mutex::new(BufWriter::new(file)),
@@ -51,7 +57,7 @@ impl PostcardExporter {
 #[async_trait::async_trait]
 impl<T> Exporter<T> for PostcardExporter
 where
-    T: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     async fn push(&self, event: Event<T>) -> ExporterResult<()> {
         let payload =

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -21,7 +21,8 @@ compile_error!("at least one exporter feature must be enabled");
 #[cfg(feature = "collector")]
 pub use quent_exporter_collector::CollectorExporterOptions;
 
-/// Selects an exporter and its options.
+/// Selects where a context's events go: local files (filesystem) or a collector
+/// service. A context created without any options discards its events.
 #[derive(Debug, Clone)]
 pub enum ExporterOptions {
     FileSystem(FileSystemExporterOptions),
@@ -41,7 +42,7 @@ pub enum FileSystemFormat {
 }
 
 /// Options for exporting events to the filesystem in the given `format`, under
-/// the directory `root`.
+/// the directory `root`, together with a `model.qmi` provenance sidecar.
 #[derive(Debug, Clone)]
 pub struct FileSystemExporterOptions {
     pub format: FileSystemFormat,

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 compile_error!("at least one exporter feature must be enabled");
 
 #[cfg(feature = "collector")]
-pub use quent_exporter_collector::{CollectorExporter, CollectorExporterOptions};
+pub use quent_exporter_collector::CollectorExporterOptions;
 
 /// Selects an exporter and its options.
 #[derive(Debug, Clone)]
@@ -121,10 +121,13 @@ where
     }
 }
 
-/// Construct an exporter from [`ExporterOptions`].
-pub async fn create_exporter<T>(kind: ExporterOptions) -> ExporterResult<Box<dyn Exporter<T>>>
+/// Construct an exporter from [`ExporterOptions`]. `U` is the type events are
+/// sent as on the wire; the collector wraps each `T` into it. It is irrelevant
+/// for filesystem output.
+pub async fn create_exporter<T, U>(kind: ExporterOptions) -> ExporterResult<Box<dyn Exporter<T>>>
 where
-    T: Serialize + Send + EntityEvent + 'static,
+    T: Serialize + Send + EntityEvent + Into<U> + 'static,
+    U: Serialize + Send + 'static,
 {
     match kind {
         ExporterOptions::FileSystem(FileSystemExporterOptions { format, root }) => match format {
@@ -150,11 +153,11 @@ where
                 .await?,
             ) as Box<dyn Exporter<T>>),
         },
-        // The collector exporter is built by the instrumentation context, which
-        // knows the umbrella wire type; it cannot be constructed from `T` alone.
         #[cfg(feature = "collector")]
-        ExporterOptions::Collector(_) => Err(ExporterError::Collector(
-            "collector exporter is constructed by the instrumentation context".into(),
-        )),
+        ExporterOptions::Collector(options) => Ok(Box::new(
+            quent_exporter_collector::CollectorExporter::<U>::try_new(options)
+                .await
+                .map_err(|e| ExporterError::Collector(e.to_string()))?,
+        ) as Box<dyn Exporter<T>>),
     }
 }

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -6,8 +6,12 @@
 use std::path::PathBuf;
 
 use quent_events::EntityEvent;
-use quent_exporter_types::{Exporter, ExporterError, ExporterResult, Importer, ImporterResult};
+use quent_exporter_types::{Exporter, ExporterError, ExporterResult, Importer};
 use serde::{Deserialize, Serialize};
+
+// Part of the public API: `create_importer` returns `ImporterResult`, so callers
+// must be able to name it (and its error).
+pub use quent_exporter_types::{ImporterError, ImporterResult};
 use uuid::Uuid;
 
 #[cfg(not(any(

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 compile_error!("at least one exporter feature must be enabled");
 
 #[cfg(feature = "collector")]
-pub use quent_exporter_collector::CollectorExporterOptions;
+pub use quent_exporter_collector::{CollectorExporter, CollectorExporterOptions};
 
 /// Selects an exporter and its options.
 #[derive(Debug, Clone)]
@@ -60,7 +60,10 @@ impl ExporterOptions {
                 ExporterOptions::FileSystem(options)
             }
             #[cfg(feature = "collector")]
-            ExporterOptions::Collector(options) => ExporterOptions::Collector(options),
+            ExporterOptions::Collector(mut options) => {
+                options.source_context_id = id;
+                ExporterOptions::Collector(options)
+            }
         }
     }
 
@@ -150,11 +153,11 @@ where
                 .await?,
             ) as Box<dyn Exporter<T>>),
         },
+        // The collector exporter is built by the instrumentation context, which
+        // knows the umbrella wire type; it cannot be constructed from `T` alone.
         #[cfg(feature = "collector")]
-        ExporterOptions::Collector(options) => Ok(Box::new(
-            quent_exporter_collector::CollectorExporter::try_new(options)
-                .await
-                .map_err(|e| ExporterError::Collector(e.to_string()))?,
-        ) as Box<dyn Exporter<T>>),
+        ExporterOptions::Collector(_) => Err(ExporterError::Collector(
+            "collector exporter is constructed by the instrumentation context".into(),
+        )),
     }
 }

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Umbrella crate providing unified exporter/importer creation.
 
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use quent_events::EntityEvent;
 use quent_exporter_types::{Exporter, ExporterError, ExporterResult, Importer, ImporterResult};
@@ -120,40 +120,41 @@ where
     }
 }
 
-/// Construct an exporter from [`ExporterOptions`].
-pub async fn create_exporter<T>(kind: ExporterOptions) -> ExporterResult<Arc<dyn Exporter<T>>>
+/// Construct an exporter from [`ExporterOptions`]. The caller owns the returned
+/// exporter; wrap it in an [`std::sync::Arc`] if it needs to be shared.
+pub async fn create_exporter<T>(kind: ExporterOptions) -> ExporterResult<Box<dyn Exporter<T>>>
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
     match kind {
         ExporterOptions::FileSystem(FileSystemExporterOptions { format, root }) => match format {
             #[cfg(feature = "ndjson")]
-            FileSystemFormat::Ndjson => Ok(Arc::new(
+            FileSystemFormat::Ndjson => Ok(Box::new(
                 quent_exporter_ndjson::NdjsonExporter::try_new::<T>(
                     quent_exporter_ndjson::NdjsonExporterOptions { dir: root },
                 )
                 .await?,
-            ) as Arc<dyn Exporter<T>>),
+            ) as Box<dyn Exporter<T>>),
             #[cfg(feature = "msgpack")]
-            FileSystemFormat::Msgpack => Ok(Arc::new(
+            FileSystemFormat::Msgpack => Ok(Box::new(
                 quent_exporter_msgpack::MsgpackExporter::try_new::<T>(
                     quent_exporter_msgpack::MsgpackExporterOptions { dir: root },
                 )
                 .await?,
-            ) as Arc<dyn Exporter<T>>),
+            ) as Box<dyn Exporter<T>>),
             #[cfg(feature = "postcard")]
-            FileSystemFormat::Postcard => Ok(Arc::new(
+            FileSystemFormat::Postcard => Ok(Box::new(
                 quent_exporter_postcard::PostcardExporter::try_new::<T>(
                     quent_exporter_postcard::PostcardExporterOptions { dir: root },
                 )
                 .await?,
-            ) as Arc<dyn Exporter<T>>),
+            ) as Box<dyn Exporter<T>>),
         },
         #[cfg(feature = "collector")]
-        ExporterOptions::Collector(options) => Ok(Arc::new(
+        ExporterOptions::Collector(options) => Ok(Box::new(
             quent_exporter_collector::CollectorExporter::try_new(options)
                 .await
                 .map_err(|e| ExporterError::Collector(e.to_string()))?,
-        ) as Arc<dyn Exporter<T>>),
+        ) as Box<dyn Exporter<T>>),
     }
 }

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -122,13 +122,10 @@ where
     }
 }
 
-/// Construct an exporter from [`ExporterOptions`]. `U` is the type events are
-/// sent as on the wire; the collector wraps each `T` into it. It is irrelevant
-/// for filesystem output.
-pub async fn create_exporter<T, U>(kind: ExporterOptions) -> ExporterResult<Box<dyn Exporter<T>>>
+/// Construct an exporter from [`ExporterOptions`].
+pub async fn create_exporter<T>(kind: ExporterOptions) -> ExporterResult<Box<dyn Exporter<T>>>
 where
-    T: Serialize + Send + EntityEvent + Into<U> + 'static,
-    U: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     match kind {
         ExporterOptions::FileSystem(FileSystemExporterOptions { format, root }) => match format {
@@ -156,7 +153,7 @@ where
         },
         #[cfg(feature = "collector")]
         ExporterOptions::Collector(options) => Ok(Box::new(
-            quent_exporter_collector::CollectorExporter::<U>::try_new(options)
+            quent_exporter_collector::CollectorExporter::<T>::try_new(options)
                 .await
                 .map_err(|e| ExporterError::Collector(e.to_string()))?,
         ) as Box<dyn Exporter<T>>),

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -25,13 +25,37 @@ compile_error!("at least one exporter feature must be enabled");
 #[cfg(feature = "collector")]
 pub use quent_exporter_collector::CollectorExporterOptions;
 
-/// Selects where a context's events go: local files (filesystem) or a collector
-/// service. A context created without any options discards its events.
+/// Where events go: local files (filesystem) or a collector service.
 #[derive(Debug, Clone)]
 pub enum ExporterOptions {
     FileSystem(FileSystemExporterOptions),
     #[cfg(feature = "collector")]
     Collector(CollectorExporterOptions),
+}
+
+/// Like [`ExporterOptions`], but the collector variant also carries the source
+/// context id and a filesystem `root` is the per-context directory.
+#[derive(Debug, Clone)]
+pub enum ResolvedExporterOptions {
+    FileSystem(FileSystemExporterOptions),
+    #[cfg(feature = "collector")]
+    Collector {
+        address: String,
+        source_context_id: Uuid,
+    },
+}
+
+impl ResolvedExporterOptions {
+    /// Filesystem output directory for filesystem exporters; `None` for
+    /// exporters (e.g. the collector) that do not write a local directory.
+    /// Used to locate where a provenance sidecar should be written.
+    pub fn filesystem_root(&self) -> Option<&std::path::Path> {
+        match self {
+            ResolvedExporterOptions::FileSystem(options) => Some(&options.root),
+            #[cfg(feature = "collector")]
+            ResolvedExporterOptions::Collector { .. } => None,
+        }
+    }
 }
 
 /// Serialization format for the filesystem exporter and importer.
@@ -54,30 +78,19 @@ pub struct FileSystemExporterOptions {
 }
 
 impl ExporterOptions {
-    /// Returns these options scoped to the context `id`, so each context's
-    /// output is kept separate.
-    pub fn in_context_dir(self, id: Uuid) -> Self {
+    /// Bind these options to the context `id`: scope a filesystem `root` to the
+    /// context directory, or set the collector's source context id.
+    pub fn resolve(self, id: Uuid) -> ResolvedExporterOptions {
         match self {
             ExporterOptions::FileSystem(mut options) => {
                 options.root = options.root.join(id.to_string());
-                ExporterOptions::FileSystem(options)
+                ResolvedExporterOptions::FileSystem(options)
             }
             #[cfg(feature = "collector")]
-            ExporterOptions::Collector(mut options) => {
-                options.source_context_id = id;
-                ExporterOptions::Collector(options)
-            }
-        }
-    }
-
-    /// Filesystem output directory for filesystem exporters; `None` for
-    /// exporters (e.g. the collector) that do not write a local directory.
-    /// Used to locate where a provenance sidecar should be written.
-    pub fn filesystem_root(&self) -> Option<&std::path::Path> {
-        match self {
-            ExporterOptions::FileSystem(options) => Some(&options.root),
-            #[cfg(feature = "collector")]
-            ExporterOptions::Collector(_) => None,
+            ExporterOptions::Collector(options) => ResolvedExporterOptions::Collector {
+                address: options.address,
+                source_context_id: id,
+            },
         }
     }
 }
@@ -126,38 +139,45 @@ where
     }
 }
 
-/// Construct an exporter from [`ExporterOptions`].
-pub async fn create_exporter<T>(kind: ExporterOptions) -> ExporterResult<Box<dyn Exporter<T>>>
+/// Construct an exporter from [`ResolvedExporterOptions`].
+pub async fn create_exporter<T>(
+    kind: ResolvedExporterOptions,
+) -> ExporterResult<Box<dyn Exporter<T>>>
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
     match kind {
-        ExporterOptions::FileSystem(FileSystemExporterOptions { format, root }) => match format {
-            #[cfg(feature = "ndjson")]
-            FileSystemFormat::Ndjson => Ok(Box::new(
-                quent_exporter_ndjson::NdjsonExporter::try_new::<T>(
-                    quent_exporter_ndjson::NdjsonExporterOptions { dir: root },
-                )
-                .await?,
-            ) as Box<dyn Exporter<T>>),
-            #[cfg(feature = "msgpack")]
-            FileSystemFormat::Msgpack => Ok(Box::new(
-                quent_exporter_msgpack::MsgpackExporter::try_new::<T>(
-                    quent_exporter_msgpack::MsgpackExporterOptions { dir: root },
-                )
-                .await?,
-            ) as Box<dyn Exporter<T>>),
-            #[cfg(feature = "postcard")]
-            FileSystemFormat::Postcard => Ok(Box::new(
-                quent_exporter_postcard::PostcardExporter::try_new::<T>(
-                    quent_exporter_postcard::PostcardExporterOptions { dir: root },
-                )
-                .await?,
-            ) as Box<dyn Exporter<T>>),
-        },
+        ResolvedExporterOptions::FileSystem(FileSystemExporterOptions { format, root }) => {
+            match format {
+                #[cfg(feature = "ndjson")]
+                FileSystemFormat::Ndjson => Ok(Box::new(
+                    quent_exporter_ndjson::NdjsonExporter::try_new::<T>(
+                        quent_exporter_ndjson::NdjsonExporterOptions { dir: root },
+                    )
+                    .await?,
+                ) as Box<dyn Exporter<T>>),
+                #[cfg(feature = "msgpack")]
+                FileSystemFormat::Msgpack => Ok(Box::new(
+                    quent_exporter_msgpack::MsgpackExporter::try_new::<T>(
+                        quent_exporter_msgpack::MsgpackExporterOptions { dir: root },
+                    )
+                    .await?,
+                ) as Box<dyn Exporter<T>>),
+                #[cfg(feature = "postcard")]
+                FileSystemFormat::Postcard => Ok(Box::new(
+                    quent_exporter_postcard::PostcardExporter::try_new::<T>(
+                        quent_exporter_postcard::PostcardExporterOptions { dir: root },
+                    )
+                    .await?,
+                ) as Box<dyn Exporter<T>>),
+            }
+        }
         #[cfg(feature = "collector")]
-        ExporterOptions::Collector(options) => Ok(Box::new(
-            quent_exporter_collector::CollectorExporter::<T>::try_new(options)
+        ResolvedExporterOptions::Collector {
+            address,
+            source_context_id,
+        } => Ok(Box::new(
+            quent_exporter_collector::CollectorExporter::<T>::try_new(address, source_context_id)
                 .await
                 .map_err(|e| ExporterError::Collector(e.to_string()))?,
         ) as Box<dyn Exporter<T>>),

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -176,10 +176,18 @@ where
         ResolvedExporterOptions::Collector {
             address,
             source_context_id,
-        } => Ok(Box::new(
-            quent_exporter_collector::CollectorExporter::<T>::try_new(address, source_context_id)
+        } => {
+            let address: http::Uri = address
+                .parse()
+                .map_err(|e: http::uri::InvalidUri| ExporterError::Collector(e.to_string()))?;
+            Ok(Box::new(
+                quent_exporter_collector::CollectorExporter::<T>::try_new(
+                    address,
+                    source_context_id,
+                )
                 .await
                 .map_err(|e| ExporterError::Collector(e.to_string()))?,
-        ) as Box<dyn Exporter<T>>),
+            ) as Box<dyn Exporter<T>>)
+        }
     }
 }

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -40,9 +40,8 @@ pub enum FileSystemFormat {
     Postcard,
 }
 
-/// Options for exporting events to the filesystem in the given `format`. Events
-/// are written to `root/<entity>/events.<ext>`, one subdirectory per entity
-/// event stream (see [`create_exporter`]).
+/// Options for exporting events to the filesystem in the given `format`, under
+/// the directory `root`.
 #[derive(Debug, Clone)]
 pub struct FileSystemExporterOptions {
     pub format: FileSystemFormat,
@@ -50,9 +49,8 @@ pub struct FileSystemExporterOptions {
 }
 
 impl ExporterOptions {
-    /// Returns these options with filesystem output relocated into a
-    /// per-context subdirectory `root/<id>/`. Non-filesystem exporters are
-    /// returned unchanged.
+    /// Returns these options scoped to the context `id`, so each context's
+    /// output is kept separate.
     pub fn in_context_dir(self, id: Uuid) -> Self {
         match self {
             ExporterOptions::FileSystem(mut options) => {
@@ -123,8 +121,7 @@ where
     }
 }
 
-/// Construct an exporter from [`ExporterOptions`]. The caller owns the returned
-/// exporter; wrap it in an [`std::sync::Arc`] if it needs to be shared.
+/// Construct an exporter from [`ExporterOptions`].
 pub async fn create_exporter<T>(kind: ExporterOptions) -> ExporterResult<Box<dyn Exporter<T>>>
 where
     T: Serialize + Send + EntityEvent + 'static,

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
+use quent_events::EntityEvent;
 use quent_exporter_types::{Exporter, ExporterError, ExporterResult, Importer, ImporterResult};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -40,7 +41,8 @@ pub enum FileSystemFormat {
 }
 
 /// Options for exporting events to the filesystem in the given `format`. Events
-/// are written to `root/events.<ext>`.
+/// are written to `root/<entity>/events.<ext>`, one subdirectory per entity
+/// event stream (see [`create_exporter`]).
 #[derive(Debug, Clone)]
 pub struct FileSystemExporterOptions {
     pub format: FileSystemFormat,
@@ -118,38 +120,31 @@ where
     }
 }
 
-/// Construct an exporter from [`ExporterOptions`]. Filesystem exporters write to
-/// `root/events.<ext>`.
+/// Construct an exporter from [`ExporterOptions`].
 pub async fn create_exporter<T>(kind: ExporterOptions) -> ExporterResult<Arc<dyn Exporter<T>>>
 where
-    T: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     match kind {
         ExporterOptions::FileSystem(FileSystemExporterOptions { format, root }) => match format {
             #[cfg(feature = "ndjson")]
             FileSystemFormat::Ndjson => Ok(Arc::new(
-                quent_exporter_ndjson::NdjsonExporter::try_new(
-                    quent_exporter_ndjson::NdjsonExporterOptions {
-                        path: root.join("events.ndjson"),
-                    },
+                quent_exporter_ndjson::NdjsonExporter::try_new::<T>(
+                    quent_exporter_ndjson::NdjsonExporterOptions { dir: root },
                 )
                 .await?,
             ) as Arc<dyn Exporter<T>>),
             #[cfg(feature = "msgpack")]
             FileSystemFormat::Msgpack => Ok(Arc::new(
-                quent_exporter_msgpack::MsgpackExporter::try_new(
-                    quent_exporter_msgpack::MsgpackExporterOptions {
-                        path: root.join("events.msgpack"),
-                    },
+                quent_exporter_msgpack::MsgpackExporter::try_new::<T>(
+                    quent_exporter_msgpack::MsgpackExporterOptions { dir: root },
                 )
                 .await?,
             ) as Arc<dyn Exporter<T>>),
             #[cfg(feature = "postcard")]
             FileSystemFormat::Postcard => Ok(Arc::new(
-                quent_exporter_postcard::PostcardExporter::try_new(
-                    quent_exporter_postcard::PostcardExporterOptions {
-                        path: root.join("events.postcard"),
-                    },
+                quent_exporter_postcard::PostcardExporter::try_new::<T>(
+                    quent_exporter_postcard::PostcardExporterOptions { dir: root },
                 )
                 .await?,
             ) as Arc<dyn Exporter<T>>),

--- a/crates/exporter/types/src/lib.rs
+++ b/crates/exporter/types/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Basic traits for exporter / importer implementations
 
-use quent_events::Event;
+use quent_events::{EntityEvent, Event};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -57,7 +57,7 @@ pub fn resolve_import_path(
 #[async_trait::async_trait]
 pub trait Exporter<T>: Send + Sync
 where
-    T: Serialize + Send,
+    T: Serialize + Send + EntityEvent,
 {
     async fn push(&self, event: Event<T>) -> ExporterResult<()>;
     async fn force_flush(&self) -> ExporterResult<()>;

--- a/crates/instrumentation/Cargo.toml
+++ b/crates/instrumentation/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+ciborium = "0.2.2"
 criterion = { version = "0.5", features = ["html_reports"] }
 pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
 quent-collector = { path = "../collector/server" }

--- a/crates/instrumentation/Cargo.toml
+++ b/crates/instrumentation/Cargo.toml
@@ -3,6 +3,11 @@ name = "quent-instrumentation"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
+[features]
+default = ["collector"]
+# Build collector-routed observers; forwards to quent-exporter's `collector`
+# feature, which gates the `ExporterOptions::Collector` variant matched here.
+collector = ["quent-exporter/collector"]
 [dependencies]
 quent-attributes = { path = "../attributes" }
 quent-build-info = { path = "../build-info" }

--- a/crates/instrumentation/Cargo.toml
+++ b/crates/instrumentation/Cargo.toml
@@ -28,6 +28,7 @@ quent-collector = { path = "../collector/server" }
 quent-collector-proto = { path = "../collector/proto" }
 serde = { workspace = true, features = ["derive"] }
 tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-stream.workspace = true
 tonic.workspace = true
 

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 
 use criterion::{BenchmarkGroup, Criterion, Throughput, black_box, measurement::WallTime};
 use pprof::criterion::{Output, PProfProfiler};
+use quent_build_info::{BuildInfo, ModelSource};
 use quent_collector::{CollectorSink, server::CollectorService};
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_events::{EntityEvent, Event};
@@ -43,6 +44,18 @@ impl EntityEvent for BenchEvent {
     const NAME: &'static str = "BenchEvent";
 }
 
+// Provenance for the context's sidecar, written at construction.
+struct BenchModel;
+
+impl ModelSource for BenchModel {
+    fn package() -> &'static str {
+        "quent-instrumentation-bench"
+    }
+    fn source() -> BuildInfo {
+        BuildInfo::unknown()
+    }
+}
+
 // The in-process collector server runs this sink per source: it decodes received
 // `BenchEvent`s and records them through a local ndjson observer, built up front.
 struct BenchSink {
@@ -51,7 +64,7 @@ struct BenchSink {
 
 impl BenchSink {
     fn new(id: Uuid, exporter: Option<ExporterOptions>) -> BenchResult<Self> {
-        let context = Context::try_with_id(id, exporter)?;
+        let context = Context::try_with_id(id, BenchModel::model_info(), exporter)?;
         let observer = context.block_on(context.observer::<BenchEvent>())?;
         Ok(Self { observer })
     }
@@ -117,7 +130,7 @@ fn bench_emit_variant(
     label: &str,
     exporter: Option<ExporterOptions>,
 ) -> BenchResult {
-    let context = Context::try_new(exporter)?;
+    let context = Context::try_new(BenchModel::model_info(), exporter)?;
     let observer = context.block_on(context.observer::<BenchEvent>())?;
     let event_id = Uuid::now_v7();
 

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -36,18 +36,6 @@ use uuid::Uuid;
 
 type BenchResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
-/// Model marker for the benchmark context.
-struct Bench;
-
-impl quent_build_info::ModelSource for Bench {
-    fn package() -> &'static str {
-        "quent-instrumentation"
-    }
-    fn source() -> quent_build_info::BuildInfo {
-        quent_build_info::BuildInfo::unknown()
-    }
-}
-
 #[derive(Serialize, Deserialize)]
 struct BenchEvent;
 
@@ -56,14 +44,15 @@ impl EntityEvent for BenchEvent {
 }
 
 // The in-process collector server runs this sink per source: it decodes received
-// `BenchEvent`s and records them through a local ndjson observer.
+// `BenchEvent`s and records them through a local ndjson observer, built up front.
 struct BenchSink {
     observer: Observer<BenchEvent>,
 }
 
 impl BenchSink {
     fn new(id: Uuid, exporter: Option<ExporterOptions>) -> BenchResult<Self> {
-        let observer = Context::try_with_id::<Bench>(id, exporter)?.observer::<BenchEvent>()?;
+        let context = Context::try_with_id(id, exporter)?;
+        let observer = context.block_on(context.observer::<BenchEvent>())?;
         Ok(Self { observer })
     }
 }
@@ -128,7 +117,8 @@ fn bench_emit_variant(
     label: &str,
     exporter: Option<ExporterOptions>,
 ) -> BenchResult {
-    let observer = Context::try_new::<Bench>(exporter)?.observer::<BenchEvent>()?;
+    let context = Context::try_new(exporter)?;
+    let observer = context.block_on(context.observer::<BenchEvent>())?;
     let event_id = Uuid::now_v7();
 
     group.bench_function(label, |b| {

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 
 use criterion::{BenchmarkGroup, Criterion, Throughput, black_box, measurement::WallTime};
 use pprof::criterion::{Output, PProfProfiler};
-use quent_build_info::{BuildInfo, ModelSource};
+use quent_build_info::ModelInfo;
 use quent_collector::{CollectorSink, server::CollectorService};
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_events::{EntityEvent, Event};
@@ -44,18 +44,6 @@ impl EntityEvent for BenchEvent {
     const NAME: &'static str = "BenchEvent";
 }
 
-// Provenance for the context's sidecar, written at construction.
-struct BenchModel;
-
-impl ModelSource for BenchModel {
-    fn package() -> &'static str {
-        "quent-instrumentation-bench"
-    }
-    fn source() -> BuildInfo {
-        BuildInfo::unknown()
-    }
-}
-
 // The in-process collector server runs this sink per source: it decodes received
 // `BenchEvent`s and records them through a local ndjson observer, built up front.
 struct BenchSink {
@@ -64,7 +52,7 @@ struct BenchSink {
 
 impl BenchSink {
     fn new(id: Uuid, exporter: Option<ExporterOptions>) -> BenchResult<Self> {
-        let context = Context::try_with_id(id, BenchModel::model_info(), exporter)?;
+        let context = Context::try_with_id(id, ModelInfo::unknown(), exporter)?;
         let observer = context.block_on(context.observer::<BenchEvent>())?;
         Ok(Self { observer })
     }
@@ -130,7 +118,7 @@ fn bench_emit_variant(
     label: &str,
     exporter: Option<ExporterOptions>,
 ) -> BenchResult {
-    let context = Context::try_new(BenchModel::model_info(), exporter)?;
+    let context = Context::try_new(ModelInfo::unknown(), exporter)?;
     let observer = context.block_on(context.observer::<BenchEvent>())?;
     let event_id = Uuid::now_v7();
 

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -179,7 +179,6 @@ fn try_bench_emit(c: &mut Criterion) -> BenchResult {
         "collector",
         Some(ExporterOptions::Collector(CollectorExporterOptions {
             address: collector_address,
-            source_context_id: Uuid::nil(),
         })),
     )?;
 

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -21,12 +21,13 @@ use std::path::Path;
 
 use criterion::{BenchmarkGroup, Criterion, Throughput, black_box, measurement::WallTime};
 use pprof::criterion::{Output, PProfProfiler};
-use quent_collector::server::{CollectorService, CollectorServiceOptions};
+use quent_collector::{CollectorSink, server::CollectorService};
 use quent_collector_proto::collector_server::CollectorServer;
+use quent_events::{EntityEvent, Event};
 use quent_exporter::{
     CollectorExporterOptions, ExporterOptions, FileSystemExporterOptions, FileSystemFormat,
 };
-use quent_instrumentation::Context;
+use quent_instrumentation::{Context, Observer};
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -35,15 +36,47 @@ use uuid::Uuid;
 
 type BenchResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
-#[derive(Serialize, Deserialize)]
-struct BenchEvent;
+/// Model marker for the benchmark context.
+struct Bench;
 
-impl quent_build_info::ModelSource for BenchEvent {
+impl quent_build_info::ModelSource for Bench {
     fn package() -> &'static str {
         "quent-instrumentation"
     }
     fn source() -> quent_build_info::BuildInfo {
         quent_build_info::BuildInfo::unknown()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct BenchEvent;
+
+impl EntityEvent for BenchEvent {
+    const NAME: &'static str = "BenchEvent";
+}
+
+// The in-process collector server runs this sink per source: it decodes received
+// `BenchEvent`s and records them through a local ndjson observer.
+struct BenchSink {
+    observer: Observer<BenchEvent>,
+}
+
+impl BenchSink {
+    fn new(id: Uuid, exporter: Option<ExporterOptions>) -> BenchResult<Self> {
+        let observer = Context::try_with_id::<Bench>(id, exporter)?.observer::<BenchEvent>()?;
+        Ok(Self { observer })
+    }
+}
+
+impl CollectorSink for BenchSink {
+    fn ingest(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+        if entity == BenchEvent::NAME {
+            self.observer
+                .send(ciborium::from_reader::<Event<BenchEvent>, _>(event)?);
+            Ok(())
+        } else {
+            Err(format!("unknown entity stream `{entity}`").into())
+        }
     }
 }
 
@@ -67,7 +100,6 @@ fn start_collector_server(backing_dir: &Path) -> BenchResult<String> {
         format: FileSystemFormat::Ndjson,
         root: backing_dir.to_path_buf(),
     });
-    let opts = CollectorServiceOptions { exporter: backing };
 
     rt.spawn(async move {
         let listener = match tokio::net::TcpListener::from_std(std_listener) {
@@ -78,7 +110,9 @@ fn start_collector_server(backing_dir: &Path) -> BenchResult<String> {
             }
         };
         let incoming = TcpListenerStream::new(listener);
-        let service = CollectorService::<BenchEvent>::new(opts);
+        let service = CollectorService::new(move |id| {
+            BenchSink::new(id, Some(backing.clone())).map_err(|e| e.to_string())
+        });
         let _ = GrpcServer::builder()
             .add_service(CollectorServer::new(service))
             .serve_with_incoming(incoming)
@@ -94,13 +128,12 @@ fn bench_emit_variant(
     label: &str,
     exporter: Option<ExporterOptions>,
 ) -> BenchResult {
-    let ctx = Context::<BenchEvent>::try_new(exporter)?;
-    let sender = ctx.events_sender();
+    let observer = Context::try_new::<Bench>(exporter)?.observer::<BenchEvent>()?;
     let event_id = Uuid::now_v7();
 
     group.bench_function(label, |b| {
         b.iter(|| {
-            sender.emit(black_box(event_id), black_box(BenchEvent));
+            observer.emit(black_box(event_id), black_box(BenchEvent));
         });
     });
 
@@ -108,7 +141,7 @@ fn bench_emit_variant(
     // would dominate cleanup time and is not part of what we measure here.
     // The forwarder keeps its open file handles; writes continue to the
     // (eventually unlinked) inode until process exit.
-    std::mem::forget(ctx);
+    std::mem::forget(observer);
     Ok(())
 }
 

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -156,7 +156,7 @@ fn try_bench_emit(c: &mut Criterion) -> BenchResult {
         "collector",
         Some(ExporterOptions::Collector(CollectorExporterOptions {
             address: collector_address,
-            application_id: Uuid::now_v7(),
+            source_context_id: Uuid::nil(),
         })),
     )?;
 

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -145,6 +145,7 @@ enum Backend {
 ///
 /// The blocking sync/async crossings work off a runtime or on a multi-threaded
 /// one, but panic on a current-thread runtime.
+#[doc(hidden)]
 pub struct Context {
     /// Unique identifier of this context.
     id: Uuid,
@@ -314,8 +315,12 @@ impl Context {
 /// unless they have a very special reason. Instead, it interacts with the
 /// generated observer only.
 ///
-/// A generated observer deals out generated handles per entity instance that
-/// share ownership of this observer.
+/// Generated code constructs and shares this type. Instrumented application
+/// code uses the generated observer and its per-instance entity handles
+/// instead. Those manage the shared ownership and flush-on-last-drop this type
+/// relies on, so holding or dropping it directly can lose or prematurely flush
+/// events.
+#[doc(hidden)]
 pub struct Observer<T>
 where
     T: Serialize + Send + EntityEvent + 'static,

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -79,8 +79,8 @@ impl<T> EventSender<T> {
     }
 }
 
-/// Identity and runtime owner for a model's instrumentation. Generates the
-/// context id, owns (or locates) the async runtime, and mints one [`Observer`]
+/// Identity and runtime owner for an application's instrumentation: holds the
+/// context id, owns (or locates) the async runtime, and creates one [`Observer`]
 /// per entity event stream via [`Self::observer`].
 ///
 /// `M` is the model marker; its [`ModelSource`] impl supplies the provenance a
@@ -195,7 +195,7 @@ impl<M> Context<M> {
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().in_context_dir(self.id);
         // The forwarder task owns the exporter outright; no sharing, no `Arc`.
-        // `M` is the model's umbrella event, the collector's wire type.
+        // `M` is the wire type the collector wraps events into.
         let exporter = handle.block_on(create_exporter::<T, M>(kind))?;
 
         let cancellation_token = CancellationToken::new();
@@ -308,12 +308,11 @@ where
     }
 }
 
-/// A local model context that reproduces a remote source's output by feeding
-/// its observers with received umbrella events. Implemented by generated
-/// `{App}Context` types; the routing lives in this trait impl, keeping the
-/// context's inherent API a pure local-production type.
+/// Replays a remote source's events into a local context, reproducing that
+/// source's output. Implemented by generated application contexts; kept separate
+/// from the context's own API so the context stays a local-production type.
 pub trait CollectorContext {
-    /// The model's umbrella event type carried on the wire.
+    /// The event type carried on the wire.
     type Event;
 
     /// Build a context that reproduces the source identified by `id`.
@@ -324,7 +323,7 @@ pub trait CollectorContext {
     where
         Self: Sized;
 
-    /// Route one received umbrella event to the matching entity observer.
+    /// Route a received event to the matching entity observer.
     fn feed(&self, event: Event<Self::Event>);
 }
 

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -138,8 +138,9 @@ enum Backend {
 /// What it is responsible for:
 /// - Resolving the runtime its observers run on. It borrows an ambient one if
 ///   present, otherwise spawns its own (see [`BackendRuntime`]).
+/// - Writing the provenance sidecar at construction.
 /// - Being the single sync→async bridge for async observer + exporter
-///   construction, provenance sidecar write, and the drop-time flush.
+///   construction and the drop-time flush.
 ///
 /// # Panics
 ///
@@ -155,13 +156,17 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn try_new(exporter: Option<ExporterOptions>) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::try_with_id(Uuid::now_v7(), exporter)
+    pub fn try_new(
+        model: ModelInfo,
+        exporter: Option<ExporterOptions>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::try_with_id(Uuid::now_v7(), model, exporter)
     }
 
     /// Construct a new context with the supplied universally unique identifier.
     pub fn try_with_id(
         id: Uuid,
+        model: ModelInfo,
         exporter: Option<ExporterOptions>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let Some(config) = exporter else {
@@ -185,10 +190,31 @@ impl Context {
             }
         };
 
-        Ok(Context {
+        let context = Context {
             id,
             backend: Backend::Active { config, runtime },
-        })
+        };
+        context.write_sidecar(model);
+        Ok(context)
+    }
+
+    /// Write the model provenance sidecar file into the context's filesystem
+    /// exporter directory.
+    ///
+    /// If no filesystem exporter is configured, then this is a no-op.
+    fn write_sidecar(&self, model: ModelInfo) {
+        let Backend::Active { config, .. } = &self.backend else {
+            return;
+        };
+        let kind = config.clone().resolve(self.id);
+        let Some(root) = kind.filesystem_root() else {
+            return;
+        };
+        if let Err(e) = std::fs::create_dir_all(root)
+            .and_then(|()| ArtifactInfo::new(model).write_sidecar(root))
+        {
+            warn!("failed to write provenance sidecar: {e}");
+        }
     }
 
     /// Return the universally unique identifier of this context.
@@ -206,9 +232,9 @@ impl Context {
         match &self.backend {
             Backend::Active { runtime, .. } => drive(&runtime.handle(), fut),
             // A noop context has no runtime, but its async work is immediately
-            // ready, so poll once. Invariant: the noop `observer()`/
-            // `write_sidecar()` futures must never pend (they early-return
-            // before any `.await`); the `unreachable!` below enforces it.
+            // ready, so poll once. Invariant: the noop `observer()` future must
+            // never pend (it early-returns before any `.await`). The
+            // `unreachable!` below enforces it.
             Backend::Noop => {
                 let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
                 match std::pin::pin!(fut).poll(&mut cx) {
@@ -218,31 +244,6 @@ impl Context {
                     }
                 }
             }
-        }
-    }
-
-    /// Write the model provenance sidecar file into the context's filesystem
-    /// exporter directory.
-    ///
-    /// If no filesystem exporter is configured, then this is a no-op.
-    pub async fn write_sidecar(&self, model: ModelInfo) {
-        let Backend::Active { config, .. } = &self.backend else {
-            return;
-        };
-        let kind = config.clone().resolve(self.id);
-        let Some(root) = kind.filesystem_root() else {
-            return;
-        };
-        let dir = root.to_path_buf();
-        let result = tokio::task::spawn_blocking(move || {
-            std::fs::create_dir_all(&dir)
-                .and_then(|()| ArtifactInfo::new(model).write_sidecar(&dir))
-        })
-        .await;
-        match result {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => warn!("failed to write provenance sidecar: {e}"),
-            Err(e) => warn!("provenance sidecar task failed: {e}"),
         }
     }
 
@@ -429,7 +430,7 @@ mod tests {
 
     #[test]
     fn noop_context_creates_noop_observer() {
-        let ctx = Context::try_new(None).unwrap();
+        let ctx = Context::try_new(TestModel::model_info(), None).unwrap();
         assert!(matches!(ctx.backend, Backend::Noop));
 
         let observer = ctx.block_on(ctx.observer::<TestEvent>()).unwrap();
@@ -444,23 +445,19 @@ mod tests {
     #[test]
     fn filesystem_observer_writes_under_entity_subdir_with_sidecar() {
         let dir = tempfile::tempdir().unwrap();
-        let ctx = Context::try_new(Some(ExporterOptions::FileSystem(
-            FileSystemExporterOptions {
+        let ctx = Context::try_new(
+            TestModel::model_info(),
+            Some(ExporterOptions::FileSystem(FileSystemExporterOptions {
                 format: FileSystemFormat::Ndjson,
                 root: dir.path().to_path_buf(),
-            },
-        )))
+            })),
+        )
         .unwrap();
 
         let context_dir = dir.path().join(ctx.id().to_string());
 
         {
-            let observer = ctx
-                .block_on(async {
-                    ctx.write_sidecar(TestModel::model_info()).await;
-                    ctx.observer::<TestEvent>().await
-                })
-                .unwrap();
+            let observer = ctx.block_on(ctx.observer::<TestEvent>()).unwrap();
             observer.send(Event::new_now(Uuid::now_v7(), TestEvent));
             // Drop the observer to drain and flush before asserting.
         }

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -6,6 +6,7 @@
 use quent_build_info::{ArtifactInfo, ModelSource};
 use quent_events::{EntityEvent, Event};
 use quent_exporter::{ExporterOptions, create_exporter};
+use quent_exporter_types::Exporter;
 use serde::Serialize;
 use std::marker::PhantomData;
 use std::sync::{
@@ -114,8 +115,23 @@ impl<M> Context<M> {
     where
         M: ModelSource,
     {
-        let id = Uuid::now_v7();
+        Self::try_with_id(Uuid::now_v7(), exporter)
+    }
 
+    /// Like [`Self::try_new`] but adopts an existing `id` instead of generating
+    /// one — used when reproducing another context's output (e.g. the collector
+    /// writing a remote source's streams under that source's context id).
+    ///
+    /// # Errors
+    /// Returns an error if no runtime is available and one cannot be spawned. A
+    /// failure to write the sidecar is logged, not returned.
+    pub fn try_with_id(
+        id: Uuid,
+        exporter: Option<ExporterOptions>,
+    ) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        M: ModelSource,
+    {
         let Some(config) = exporter else {
             debug!("using noop exporter");
             return Ok(Context {
@@ -175,7 +191,8 @@ impl<M> Context<M> {
     /// Returns an error if the exporter cannot be constructed.
     pub fn observer<T>(&self) -> Result<Observer<T>, Box<dyn std::error::Error>>
     where
-        T: Serialize + Send + EntityEvent + 'static,
+        T: Serialize + Send + EntityEvent + Into<M> + 'static,
+        M: Serialize + Send + 'static,
     {
         let (Some(config), Some(handle)) = (&self.config, &self.handle) else {
             return Ok(Observer::noop());
@@ -184,7 +201,15 @@ impl<M> Context<M> {
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().in_context_dir(self.id);
         // The forwarder task owns the exporter outright; no sharing, no `Arc`.
-        let exporter = handle.block_on(create_exporter::<T>(kind))?;
+        // Filesystem exporters are built by `create_exporter`; the collector
+        // exporter is built here because it needs the umbrella wire type `M`.
+        let exporter: Box<dyn Exporter<T>> = match kind {
+            #[cfg(feature = "collector")]
+            ExporterOptions::Collector(options) => {
+                Box::new(handle.block_on(quent_exporter::CollectorExporter::<M>::try_new(options))?)
+            }
+            other => handle.block_on(create_exporter::<T>(other))?,
+        };
 
         let cancellation_token = CancellationToken::new();
         let cloned_token = cancellation_token.clone();
@@ -296,13 +321,37 @@ where
     }
 }
 
+/// A local model context that reproduces a remote source's output by feeding
+/// its observers with received umbrella events. Implemented by generated
+/// `{App}Context` types; the routing lives in this trait impl, keeping the
+/// context's inherent API a pure local-production type.
+pub trait CollectorContext: Sized {
+    /// The model's umbrella event type carried on the wire.
+    type Event;
+
+    /// Build a context that reproduces the source identified by `id`.
+    fn with_source_id(
+        id: Uuid,
+        exporter: Option<ExporterOptions>,
+    ) -> Result<Self, Box<dyn std::error::Error>>;
+
+    /// Route one received umbrella event to the matching entity observer.
+    fn feed(&self, event: Event<Self::Event>);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use quent_exporter::{FileSystemExporterOptions, FileSystemFormat};
 
-    #[derive(Debug)]
-    struct TestModel;
+    #[derive(Debug, serde::Serialize)]
+    struct TestModel(TestEvent);
+
+    impl From<TestEvent> for TestModel {
+        fn from(e: TestEvent) -> Self {
+            TestModel(e)
+        }
+    }
 
     impl ModelSource for TestModel {
         fn package() -> &'static str {

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -7,7 +7,6 @@ use quent_build_info::{ArtifactInfo, ModelSource};
 use quent_events::{EntityEvent, Event};
 use quent_exporter::{ExporterOptions, create_exporter};
 use serde::Serialize;
-use std::marker::PhantomData;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -49,12 +48,6 @@ impl<T> Clone for EventSender<T> {
     }
 }
 
-impl<T> Default for EventSender<T> {
-    fn default() -> Self {
-        Self::noop()
-    }
-}
-
 impl<T> EventSender<T> {
     /// Returns a noop sender that silently drops all events.
     pub fn noop() -> Self {
@@ -79,81 +72,83 @@ impl<T> EventSender<T> {
     }
 }
 
-/// Identity and runtime owner for an application's instrumentation: holds the
-/// context id, owns (or locates) the async runtime, and creates one [`Observer`]
-/// per entity event stream via [`Self::observer`].
-///
-/// `M` is the model marker; its [`ModelSource`] impl supplies the provenance a
-/// filesystem exporter records. It does not appear in the event streams, which
-/// are typed per entity by the [`Observer`]s.
-pub struct Context<M> {
-    /// Identity of this context, generated on construction.
-    id: Uuid,
-    /// Exporter configuration cloned into each observer it builds; `None` is a
-    /// no-op context that creates no runtime.
-    config: Option<ExporterOptions>,
-    handle: Option<Handle>,
-    /// Shared with every [`Observer`] this context builds so the runtime
-    /// outlives them regardless of drop order; `None` when running on a
-    /// caller-provided (ambient) runtime.
-    runtime: Option<Arc<Runtime>>,
-    _model: PhantomData<M>,
+/// The runtime an active context's observers run on. `Ambient` borrows a runtime
+/// that already existed (e.g. a `#[tokio::main]` or caller-managed one); `Owned`
+/// keeps alive the one this context spawned.
+#[derive(Clone)]
+enum ActiveRuntime {
+    Ambient(Handle),
+    Owned(Arc<Runtime>),
 }
 
-impl<M> Context<M> {
+impl ActiveRuntime {
+    /// The handle observers spawn and block on.
+    fn handle(&self) -> Handle {
+        match self {
+            Self::Ambient(h) => h.clone(),
+            Self::Owned(rt) => rt.handle().clone(),
+        }
+    }
+}
+
+/// What a context does with events. `Noop` drops them; `Active` carries the
+/// exporter configuration and the runtime its observers run on.
+enum Backend {
+    Noop,
+    Active {
+        config: ExporterOptions,
+        runtime: ActiveRuntime,
+    },
+}
+
+pub struct Context {
+    /// Identity of this context, generated on construction.
+    id: Uuid,
+    backend: Backend,
+}
+
+impl Context {
     /// Create a context for the given `exporter` configuration (see
     /// [`ExporterOptions`]).
     ///
-    /// # Errors
-    /// Returns an error only if an async runtime is needed but cannot be spawned.
-    pub fn try_new(exporter: Option<ExporterOptions>) -> Result<Self, Box<dyn std::error::Error>>
-    where
-        M: ModelSource,
-    {
-        Self::try_with_id(Uuid::now_v7(), exporter)
-    }
-
-    /// Like [`Self::try_new`] but adopts an existing `id` instead of generating
-    /// one — e.g. the collector reproducing a remote source's output under that
-    /// source's id.
+    /// `M` defines the model provenance, which is written into a sidecar file
+    /// alongside events when `exporter` is a filesystem exporter variant.
     ///
     /// # Errors
-    /// Returns an error only if an async runtime is needed but cannot be spawned.
-    pub fn try_with_id(
+    ///
+    /// Returns an error when an async runtime is needed but cannot be obtained.
+    pub fn try_new<M: ModelSource>(
+        exporter: Option<ExporterOptions>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::try_with_id::<M>(Uuid::now_v7(), exporter)
+    }
+
+    /// Like [`Self::try_new`], but adopts an existing `id`.
+    pub fn try_with_id<M: ModelSource>(
         id: Uuid,
         exporter: Option<ExporterOptions>,
-    ) -> Result<Self, Box<dyn std::error::Error>>
-    where
-        M: ModelSource,
-    {
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let Some(config) = exporter else {
             debug!("using noop exporter");
             return Ok(Context {
                 id,
-                config: None,
-                handle: None,
-                runtime: None,
-                _model: PhantomData,
+                backend: Backend::Noop,
             });
         };
 
-        let (runtime, handle) = if let Ok(handle) = Handle::try_current() {
+        let runtime = if let Ok(handle) = Handle::try_current() {
             debug!("using existing async runtime");
-            (None, handle)
+            ActiveRuntime::Ambient(handle)
         } else {
             debug!("spawning new async runtime");
-            if let Ok(runtime) = Runtime::new() {
-                let handle = runtime.handle().clone();
-                (Some(Arc::new(runtime)), handle)
-            } else {
-                return Err("unable to spawn async runtime")?;
-            }
+            let runtime =
+                Runtime::new().map_err(|e| format!("unable to spawn async runtime: {e}"))?;
+            ActiveRuntime::Owned(Arc::new(runtime))
         };
 
         // Write the provenance sidecar once per context, in the context
         // directory the per-entity observers nest their streams under.
-        // Filesystem exporters only; the collector server writes it for
-        // collector-routed events.
+        // Filesystem exporters only.
         if let Some(dir) = config.clone().in_context_dir(id).filesystem_root() {
             let dir = dir.to_path_buf();
             if let Err(e) = std::fs::create_dir_all(&dir)
@@ -165,34 +160,31 @@ impl<M> Context<M> {
 
         Ok(Context {
             id,
-            config: Some(config),
-            handle: Some(handle),
-            runtime,
-            _model: PhantomData,
+            backend: Backend::Active { config, runtime },
         })
     }
 
-    /// Identity of this context, generated on construction.
+    /// Identity of this context, generated or set on construction.
     pub fn id(&self) -> Uuid {
         self.id
     }
 
-    /// Create an [`Observer`] for one entity's event stream `T`. Returns a no-op
-    /// observer when the context has no exporter configured.
+    /// Create an [`Observer`] of events of one *type* of entity `T`.
     ///
     /// # Errors
+    ///
     /// Returns an error if the exporter cannot be constructed.
     pub fn observer<T>(&self) -> Result<Observer<T>, Box<dyn std::error::Error>>
     where
         T: Serialize + Send + EntityEvent + 'static,
     {
-        let (Some(config), Some(handle)) = (&self.config, &self.handle) else {
+        let Backend::Active { config, runtime } = &self.backend else {
             return Ok(Observer::noop());
         };
+        let handle = runtime.handle();
 
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().in_context_dir(self.id);
-        // The forwarder task owns the exporter outright; no sharing, no `Arc`.
         let exporter = handle.block_on(create_exporter::<T>(kind))?;
 
         let cancellation_token = CancellationToken::new();
@@ -234,19 +226,17 @@ impl<M> Context<M> {
             },
             cancellation_token,
             forwarder_handle: Some(forwarder_handle),
-            handle: Some(handle.clone()),
-            _runtime: self.runtime.clone(),
+            runtime: Some(runtime.clone()),
         })
     }
 }
 
-/// One entity's event stream. It owns the channel and the forwarder task (which
-/// in turn owns the exporter) plus a share of the runtime, so it operates
-/// independently of the [`Context`] that built it (typically held behind an
-/// `Arc` and shared across the application). Emit through [`Self::send`] /
-/// [`Self::emit`]. On drop it cancels and waits (via `block_on`) for the
-/// forwarder to drain buffered events and flush the exporter, so it must be
-/// dropped where [`Handle::block_on`] is valid (not on a runtime worker thread).
+/// Observes events of one *type* of entity `T`.
+///
+/// It does so by dealing out (generated) handles per entity. These handles have
+/// functions with names and signatures generated from an application event
+/// model. Upon calling these functions, events are sent to an exporter that is
+/// managed by this observer.
 pub struct Observer<T>
 where
     T: Serialize + Send + EntityEvent + 'static,
@@ -254,11 +244,10 @@ where
     events_sender: EventSender<T>,
     cancellation_token: CancellationToken,
     forwarder_handle: Option<JoinHandle<()>>,
-    handle: Option<Handle>,
-    /// Keeps the runtime alive for as long as this observer lives, so its drop
-    /// flush is valid even after the [`Context`] is gone. `None` for a no-op
-    /// observer or on an ambient runtime.
-    _runtime: Option<Arc<Runtime>>,
+    /// The runtime this observer's forwarder runs on; `None` for a no-op
+    /// observer. An `Owned` runtime is kept alive here for the observer's
+    /// lifetime, so its drop flush is valid even after the [`Context`] is gone.
+    runtime: Option<ActiveRuntime>,
 }
 
 impl<T> Observer<T>
@@ -271,8 +260,7 @@ where
             events_sender: EventSender::noop(),
             cancellation_token: CancellationToken::new(),
             forwarder_handle: None,
-            handle: None,
-            _runtime: None,
+            runtime: None,
         }
     }
 
@@ -294,12 +282,22 @@ where
     fn drop(&mut self) {
         self.cancellation_token.cancel();
 
-        // Wait for the forwarder to drain remaining events and flush the
-        // exporter (it owns the exporter and flushes on shutdown).
-        if let Some(handle) = &self.handle
-            && let Some(forwarder_handle) = self.forwarder_handle.take()
-            && let Err(e) = handle.block_on(forwarder_handle)
-        {
+        let (Some(runtime), Some(forwarder_handle)) = (&self.runtime, self.forwarder_handle.take())
+        else {
+            return;
+        };
+        let handle = runtime.handle();
+
+        // The forwarder drains remaining events and flushes the exporter on
+        // cancellation; joining only waits for that to finish. `block_on`
+        // panics on a runtime worker thread, so when dropped inside a runtime
+        // detach the join instead — the flush still runs, but drop no longer
+        // waits for it.
+        if Handle::try_current().is_ok() {
+            handle.spawn(async move {
+                let _ = forwarder_handle.await;
+            });
+        } else if let Err(e) = handle.block_on(forwarder_handle) {
             warn!("forwarder task failed: {e}");
         }
     }
@@ -337,9 +335,8 @@ mod tests {
 
     #[test]
     fn noop_context_creates_noop_observer() {
-        let ctx = Context::<TestModel>::try_new(None).unwrap();
-        assert!(ctx.handle.is_none());
-        assert!(ctx.runtime.is_none());
+        let ctx = Context::try_new::<TestModel>(None).unwrap();
+        assert!(matches!(ctx.backend, Backend::Noop));
 
         let observer = ctx.observer::<TestEvent>().unwrap();
         assert!(observer.events_sender.tx.is_none());
@@ -353,7 +350,7 @@ mod tests {
     #[test]
     fn filesystem_observer_writes_under_entity_subdir_with_sidecar() {
         let dir = tempfile::tempdir().unwrap();
-        let ctx = Context::<TestModel>::try_new(Some(ExporterOptions::FileSystem(
+        let ctx = Context::try_new::<TestModel>(Some(ExporterOptions::FileSystem(
             FileSystemExporterOptions {
                 format: FileSystemFormat::Ndjson,
                 root: dir.path().to_path_buf(),

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -177,9 +177,8 @@ impl<M> Context<M> {
         self.id
     }
 
-    /// Build the pipeline for one entity's event stream `T`. Filesystem events
-    /// are written to `<root>/<id>/<T::NAME>/`. Returns a no-op observer when
-    /// the context has no exporter configured.
+    /// Create an [`Observer`] for one entity's event stream `T`. Returns a no-op
+    /// observer when the context has no exporter configured.
     ///
     /// # Errors
     /// Returns an error if the exporter cannot be constructed.
@@ -304,27 +303,6 @@ where
             warn!("forwarder task failed: {e}");
         }
     }
-}
-
-/// Replays a remote source's events into a local context, reproducing that
-/// source's output. Implemented by generated application contexts; kept separate
-/// from the context's own API so the context stays a local-production type.
-pub trait CollectorContext {
-    /// Build a context that reproduces the source identified by `id`.
-    fn with_source_id(
-        id: Uuid,
-        exporter: Option<ExporterOptions>,
-    ) -> Result<Self, Box<dyn std::error::Error>>
-    where
-        Self: Sized;
-
-    /// Deserialize a received event for the named `entity` stream and route it
-    /// to that entity's observer.
-    ///
-    /// # Errors
-    /// Returns an error if `entity` names no known stream or the bytes fail to
-    /// deserialize.
-    fn feed(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>>;
 }
 
 #[cfg(test)]

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -185,8 +185,7 @@ impl<M> Context<M> {
     /// Returns an error if the exporter cannot be constructed.
     pub fn observer<T>(&self) -> Result<Observer<T>, Box<dyn std::error::Error>>
     where
-        T: Serialize + Send + EntityEvent + Into<M> + 'static,
-        M: Serialize + Send + 'static,
+        T: Serialize + Send + EntityEvent + 'static,
     {
         let (Some(config), Some(handle)) = (&self.config, &self.handle) else {
             return Ok(Observer::noop());
@@ -195,8 +194,7 @@ impl<M> Context<M> {
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().in_context_dir(self.id);
         // The forwarder task owns the exporter outright; no sharing, no `Arc`.
-        // `M` is the wire type the collector wraps events into.
-        let exporter = handle.block_on(create_exporter::<T, M>(kind))?;
+        let exporter = handle.block_on(create_exporter::<T>(kind))?;
 
         let cancellation_token = CancellationToken::new();
         let cloned_token = cancellation_token.clone();
@@ -312,9 +310,6 @@ where
 /// source's output. Implemented by generated application contexts; kept separate
 /// from the context's own API so the context stays a local-production type.
 pub trait CollectorContext {
-    /// The event type carried on the wire.
-    type Event;
-
     /// Build a context that reproduces the source identified by `id`.
     fn with_source_id(
         id: Uuid,
@@ -323,8 +318,13 @@ pub trait CollectorContext {
     where
         Self: Sized;
 
-    /// Route a received event to the matching entity observer.
-    fn feed(&self, event: Event<Self::Event>);
+    /// Deserialize a received event for the named `entity` stream and route it
+    /// to that entity's observer.
+    ///
+    /// # Errors
+    /// Returns an error if `entity` names no known stream or the bytes fail to
+    /// deserialize.
+    fn feed(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>>;
 }
 
 #[cfg(test)]

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -3,9 +3,10 @@
 
 //! Quent Instrumentation API
 //!
-//! Instrumented application code should not import features from this crate directly
-//! unless there is a very special reason. Instead, it should interact with the
+//! Instrumented application code should not import this crate directly unless
+//! there is a very special reason. Instead, it should interact with the
 //! generated instrumentation library only.
+
 use quent_build_info::{ArtifactInfo, ModelInfo};
 use quent_events::{EntityEvent, Event};
 use quent_exporter::{ExporterOptions, create_exporter};
@@ -157,7 +158,7 @@ impl Context {
         Self::try_with_id(Uuid::now_v7(), exporter)
     }
 
-    /// Construct a new context with the supplied ID.
+    /// Construct a new context with the supplied universally unique identifier.
     pub fn try_with_id(
         id: Uuid,
         exporter: Option<ExporterOptions>,
@@ -189,6 +190,7 @@ impl Context {
         })
     }
 
+    /// Return the universally unique identifier of this context.
     pub fn id(&self) -> Uuid {
         self.id
     }
@@ -312,7 +314,8 @@ impl Context {
 /// unless they have a very special reason. Instead, it interacts with the
 /// generated observer only.
 ///
-/// A generated observer deals out generated handles per entity instance.
+/// A generated observer deals out generated handles per entity instance that
+/// share ownership of this observer.
 pub struct Observer<T>
 where
     T: Serialize + Send + EntityEvent + 'static,
@@ -330,7 +333,8 @@ impl<T> Observer<T>
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
-    /// A no-op observer that discards events and holds no runtime resources.
+    /// Construct a no-op observer that discards events and holds no runtime
+    /// resources whatesoever.
     fn noop() -> Self {
         Self {
             events_sender: EventSender::noop(),
@@ -374,10 +378,11 @@ where
 
 /// Drive `fut` to completion on `handle`'s runtime, blocking the current thread.
 ///
-/// - Off a runtime, it blocks directly.
-/// - On a multi-threaded runtime worker it uses `block_in_place` so the
-/// scheduler keeps progressing.
-/// - On a current-thread runtime it panics.
+/// Off a runtime, it blocks directly. On a multi-threaded runtime worker it
+/// uses `block_in_place` so the scheduler keeps progressing.
+///
+/// # Panics
+/// On a current-thread runtime, this panics.
 fn drive<F: Future>(handle: &Handle, fut: F) -> F::Output {
     if Handle::try_current().is_ok() {
         tokio::task::block_in_place(|| handle.block_on(fut))

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -80,13 +80,12 @@ impl<T> EventSender<T> {
 }
 
 /// Identity and runtime owner for a model's instrumentation. Generates the
-/// context id, owns (or locates) the async runtime, and writes the model
-/// provenance sidecar once on construction. Mints one [`Observer`] per entity
-/// event stream via [`Self::observer`].
+/// context id, owns (or locates) the async runtime, and mints one [`Observer`]
+/// per entity event stream via [`Self::observer`].
 ///
-/// `M` is the model marker whose [`ModelSource`] impl supplies the `model.qmi`
-/// provenance. It does not appear in the event streams, which are typed per
-/// entity by the [`Observer`]s.
+/// `M` is the model marker; its [`ModelSource`] impl supplies the provenance a
+/// filesystem exporter records. It does not appear in the event streams, which
+/// are typed per entity by the [`Observer`]s.
 pub struct Context<M> {
     /// Identity of this context, generated on construction.
     id: Uuid,
@@ -102,14 +101,11 @@ pub struct Context<M> {
 }
 
 impl<M> Context<M> {
-    /// Create a context. With `Some(exporter)` this locates or spawns a runtime
-    /// and writes the `model.qmi` provenance sidecar into the context directory;
-    /// with `None` it is a no-op context that creates no runtime and whose
-    /// observers discard events.
+    /// Create a context for the given `exporter` configuration (see
+    /// [`ExporterOptions`]).
     ///
     /// # Errors
-    /// Returns an error if no runtime is available and one cannot be spawned. A
-    /// failure to write the sidecar is logged, not returned.
+    /// Returns an error only if an async runtime is needed but cannot be spawned.
     pub fn try_new(exporter: Option<ExporterOptions>) -> Result<Self, Box<dyn std::error::Error>>
     where
         M: ModelSource,
@@ -118,12 +114,11 @@ impl<M> Context<M> {
     }
 
     /// Like [`Self::try_new`] but adopts an existing `id` instead of generating
-    /// one — used when reproducing another context's output (e.g. the collector
-    /// writing a remote source's streams under that source's context id).
+    /// one — e.g. the collector reproducing a remote source's output under that
+    /// source's id.
     ///
     /// # Errors
-    /// Returns an error if no runtime is available and one cannot be spawned. A
-    /// failure to write the sidecar is logged, not returned.
+    /// Returns an error only if an async runtime is needed but cannot be spawned.
     pub fn try_with_id(
         id: Uuid,
         exporter: Option<ExporterOptions>,
@@ -317,7 +312,7 @@ where
 /// its observers with received umbrella events. Implemented by generated
 /// `{App}Context` types; the routing lives in this trait impl, keeping the
 /// context's inherent API a pure local-production type.
-pub trait CollectorContext: Sized {
+pub trait CollectorContext {
     /// The model's umbrella event type carried on the wire.
     type Event;
 
@@ -325,7 +320,9 @@ pub trait CollectorContext: Sized {
     fn with_source_id(
         id: Uuid,
         exporter: Option<ExporterOptions>,
-    ) -> Result<Self, Box<dyn std::error::Error>>;
+    ) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        Self: Sized;
 
     /// Route one received umbrella event to the matching entity observer.
     fn feed(&self, event: Event<Self::Event>);

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Quent Instrumentation API
+//! Backing structures for generated instrumentation libraries.
 //!
 //! Instrumented application code should not import this crate directly unless
 //! there is a very special reason. Instead, it should interact with the

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -228,7 +228,7 @@ impl Context {
         let Backend::Active { config, .. } = &self.backend else {
             return;
         };
-        let kind = config.clone().in_context_dir(self.id);
+        let kind = config.clone().resolve(self.id);
         let Some(root) = kind.filesystem_root() else {
             return;
         };
@@ -260,7 +260,7 @@ impl Context {
         let handle = runtime.handle();
 
         debug!("constructing exporter for stream `{}`", T::NAME);
-        let kind = config.clone().in_context_dir(self.id);
+        let kind = config.clone().resolve(self.id);
         let exporter = create_exporter::<T>(kind).await?;
 
         let cancellation_token = CancellationToken::new();

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -6,7 +6,6 @@
 use quent_build_info::{ArtifactInfo, ModelSource};
 use quent_events::{EntityEvent, Event};
 use quent_exporter::{ExporterOptions, create_exporter};
-use quent_exporter_types::Exporter;
 use serde::Serialize;
 use std::marker::PhantomData;
 use std::sync::{
@@ -201,15 +200,8 @@ impl<M> Context<M> {
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().in_context_dir(self.id);
         // The forwarder task owns the exporter outright; no sharing, no `Arc`.
-        // Filesystem exporters are built by `create_exporter`; the collector
-        // exporter is built here because it needs the umbrella wire type `M`.
-        let exporter: Box<dyn Exporter<T>> = match kind {
-            #[cfg(feature = "collector")]
-            ExporterOptions::Collector(options) => {
-                Box::new(handle.block_on(quent_exporter::CollectorExporter::<M>::try_new(options))?)
-            }
-            other => handle.block_on(create_exporter::<T>(other))?,
-        };
+        // `M` is the model's umbrella event, the collector's wire type.
+        let exporter = handle.block_on(create_exporter::<T, M>(kind))?;
 
         let cancellation_token = CancellationToken::new();
         let cloned_token = cancellation_token.clone();

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -6,7 +6,6 @@
 use quent_build_info::{ArtifactInfo, ModelSource};
 use quent_events::{EntityEvent, Event};
 use quent_exporter::{ExporterOptions, create_exporter};
-use quent_exporter_types::Exporter;
 use serde::Serialize;
 use std::marker::PhantomData;
 use std::sync::{
@@ -91,16 +90,15 @@ impl<T> EventSender<T> {
 pub struct Context<M> {
     /// Identity of this context, generated on construction.
     id: Uuid,
-    /// Exporter configuration cloned into each observer's pipeline; `None` is a
+    /// Exporter configuration cloned into each observer it builds; `None` is a
     /// no-op context that creates no runtime.
     config: Option<ExporterOptions>,
     handle: Option<Handle>,
+    /// Shared with every [`Observer`] this context builds so the runtime
+    /// outlives them regardless of drop order; `None` when running on a
+    /// caller-provided (ambient) runtime.
+    runtime: Option<Arc<Runtime>>,
     _model: PhantomData<M>,
-
-    // The runtime is the last field so it is dropped last (see
-    // https://doc.rust-lang.org/reference/destructors.html), after the
-    // observers it spawned forwarder tasks for have been dropped and drained.
-    _runtime: Option<Runtime>,
 }
 
 impl<M> Context<M> {
@@ -124,8 +122,8 @@ impl<M> Context<M> {
                 id,
                 config: None,
                 handle: None,
+                runtime: None,
                 _model: PhantomData,
-                _runtime: None,
             });
         };
 
@@ -136,7 +134,7 @@ impl<M> Context<M> {
             debug!("spawning new async runtime");
             if let Ok(runtime) = Runtime::new() {
                 let handle = runtime.handle().clone();
-                (Some(runtime), handle)
+                (Some(Arc::new(runtime)), handle)
             } else {
                 return Err("unable to spawn async runtime")?;
             }
@@ -159,8 +157,8 @@ impl<M> Context<M> {
             id,
             config: Some(config),
             handle: Some(handle),
+            runtime,
             _model: PhantomData,
-            _runtime: runtime,
         })
     }
 
@@ -185,36 +183,38 @@ impl<M> Context<M> {
 
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().in_context_dir(self.id);
-        let exporter: Arc<dyn Exporter<T>> = handle.block_on(create_exporter(kind))?;
+        // The forwarder task owns the exporter outright; no sharing, no `Arc`.
+        let exporter = handle.block_on(create_exporter::<T>(kind))?;
 
         let cancellation_token = CancellationToken::new();
         let cloned_token = cancellation_token.clone();
         let (events_sender, mut events_receiver) = unbounded_channel();
 
-        let forwarder_handle = handle.spawn({
-            let exporter: Arc<dyn Exporter<T>> = Arc::clone(&exporter);
-            async move {
-                loop {
-                    tokio::select! {
-                        Some(event) = events_receiver.recv() => {
+        let forwarder_handle = handle.spawn(async move {
+            loop {
+                tokio::select! {
+                    Some(event) = events_receiver.recv() => {
+                        if let Err(e) = exporter.push(event).await {
+                            warn!("unable to export event: {e}");
+                        }
+                    },
+                    () = cloned_token.cancelled() => {
+                        events_receiver.close();
+                        // drain events that are buffered
+                        while let Some(event) = events_receiver.recv().await {
                             if let Err(e) = exporter.push(event).await {
                                 warn!("unable to export event: {e}");
                             }
-                        },
-                        () = cloned_token.cancelled() => {
-                            events_receiver.close();
-                            // drain events that are buffered
-                            while let Some(event) = events_receiver.recv().await {
-                                if let Err(e) = exporter.push(event).await {
-                                    warn!("unable to export event: {e}");
-                                }
-                            }
-                            break
-                        },
-                        // the events channel has been closed: nothing left to forward.
-                        else => break,
-                    }
+                        }
+                        break
+                    },
+                    // the events channel has been closed: nothing left to forward.
+                    else => break,
                 }
+            }
+            // Flush once on shutdown, however the loop exited.
+            if let Err(e) = exporter.force_flush().await {
+                warn!("failed to flush exporter: {e}");
             }
         });
 
@@ -223,28 +223,33 @@ impl<M> Context<M> {
                 tx: Some(events_sender),
                 disable_error_log: Arc::new(AtomicBool::new(false)),
             },
-            exporter: Some(exporter),
             cancellation_token,
             forwarder_handle: Some(forwarder_handle),
             handle: Some(handle.clone()),
+            _runtime: self.runtime.clone(),
         })
     }
 }
 
-/// One entity's event pipeline: channel → forwarder task → exporter. Hand out
-/// cloned senders with [`Self::sender`] and emit through them concurrently. On
-/// drop, drains buffered events and flushes the exporter, using the runtime
-/// [`Handle`] it was built with — so an observer must be dropped where
-/// [`Handle::block_on`] is valid and while that runtime is still alive.
+/// One entity's event stream. It owns the channel and the forwarder task (which
+/// in turn owns the exporter) plus a share of the runtime, so it operates
+/// independently of the [`Context`] that built it (typically held behind an
+/// `Arc` and shared across the application). Emit through [`Self::send`] /
+/// [`Self::emit`]. On drop it cancels and waits (via `block_on`) for the
+/// forwarder to drain buffered events and flush the exporter, so it must be
+/// dropped where [`Handle::block_on`] is valid (not on a runtime worker thread).
 pub struct Observer<T>
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
     events_sender: EventSender<T>,
-    exporter: Option<Arc<dyn Exporter<T>>>,
     cancellation_token: CancellationToken,
     forwarder_handle: Option<JoinHandle<()>>,
     handle: Option<Handle>,
+    /// Keeps the runtime alive for as long as this observer lives, so its drop
+    /// flush is valid even after the [`Context`] is gone. `None` for a no-op
+    /// observer or on an ambient runtime.
+    _runtime: Option<Arc<Runtime>>,
 }
 
 impl<T> Observer<T>
@@ -255,16 +260,21 @@ where
     fn noop() -> Self {
         Self {
             events_sender: EventSender::noop(),
-            exporter: None,
             cancellation_token: CancellationToken::new(),
             forwarder_handle: None,
             handle: None,
+            _runtime: None,
         }
     }
 
-    /// A cloned [`EventSender`] for this stream; cheap and `Send + Sync + Clone`.
-    pub fn sender(&self) -> EventSender<T> {
-        self.events_sender.clone()
+    /// Send a pre-built event into this stream.
+    pub fn send(&self, event: Event<T>) {
+        self.events_sender.send(event);
+    }
+
+    /// Emit an event for entity `id`, converting it into the stream type.
+    pub fn emit(&self, id: Uuid, event: impl Into<T>) {
+        self.events_sender.emit(id, event);
     }
 }
 
@@ -275,20 +285,13 @@ where
     fn drop(&mut self) {
         self.cancellation_token.cancel();
 
-        if let Some(handle) = &self.handle {
-            // Wait for the forwarder to finish processing remaining events.
-            if let Some(forwarder_handle) = self.forwarder_handle.take()
-                && let Err(e) = handle.block_on(forwarder_handle)
-            {
-                warn!("forwarder task failed: {e}");
-            }
-
-            // Flush the exporter to ensure all events are sent.
-            if let Some(exporter) = &self.exporter
-                && let Err(e) = handle.block_on(exporter.force_flush())
-            {
-                warn!("failed to flush exporter: {e}");
-            }
+        // Wait for the forwarder to drain remaining events and flush the
+        // exporter (it owns the exporter and flushes on shutdown).
+        if let Some(handle) = &self.handle
+            && let Some(forwarder_handle) = self.forwarder_handle.take()
+            && let Err(e) = handle.block_on(forwarder_handle)
+        {
+            warn!("forwarder task failed: {e}");
         }
     }
 }
@@ -321,14 +324,13 @@ mod tests {
     fn noop_context_creates_noop_observer() {
         let ctx = Context::<TestModel>::try_new(None).unwrap();
         assert!(ctx.handle.is_none());
-        assert!(ctx._runtime.is_none());
+        assert!(ctx.runtime.is_none());
 
         let observer = ctx.observer::<TestEvent>().unwrap();
-        let sender = observer.sender();
-        assert!(sender.tx.is_none());
+        assert!(observer.events_sender.tx.is_none());
 
-        sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
-        sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
+        observer.send(Event::new_now(Uuid::now_v7(), TestEvent));
+        observer.emit(Uuid::now_v7(), TestEvent);
         drop(observer);
         drop(ctx);
     }
@@ -348,8 +350,7 @@ mod tests {
 
         {
             let observer = ctx.observer::<TestEvent>().unwrap();
-            let sender = observer.sender();
-            sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
+            observer.send(Event::new_now(Uuid::now_v7(), TestEvent));
             // Drop the observer to drain and flush before asserting.
         }
 

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -4,10 +4,11 @@
 //! Quent Instrumentation API
 //!
 use quent_build_info::{ArtifactInfo, ModelSource};
-use quent_events::Event;
+use quent_events::{EntityEvent, Event};
 use quent_exporter::{ExporterOptions, create_exporter};
 use quent_exporter_types::Exporter;
 use serde::Serialize;
+use std::marker::PhantomData;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -79,51 +80,53 @@ impl<T> EventSender<T> {
     }
 }
 
-pub struct Context<T>
-where
-    T: Serialize + Send + 'static,
-{
+/// Identity and runtime owner for a model's instrumentation. Generates the
+/// context id, owns (or locates) the async runtime, and writes the model
+/// provenance sidecar once on construction. Mints one [`Observer`] per entity
+/// event stream via [`Self::observer`].
+///
+/// `M` is the model marker whose [`ModelSource`] impl supplies the `model.qmi`
+/// provenance. It does not appear in the event streams, which are typed per
+/// entity by the [`Observer`]s.
+pub struct Context<M> {
     /// Identity of this context, generated on construction.
     id: Uuid,
+    /// Exporter configuration cloned into each observer's pipeline; `None` is a
+    /// no-op context that creates no runtime.
+    config: Option<ExporterOptions>,
     handle: Option<Handle>,
-    events_sender: EventSender<T>,
-    exporter: Option<Arc<dyn Exporter<T>>>,
-    cancellation_token: CancellationToken,
-    forwarder_handle: Option<JoinHandle<()>>,
+    _model: PhantomData<M>,
 
-    // The runtime should be the last field, so it is dropped the last
-    // (see https://doc.rust-lang.org/reference/destructors.html for
-    // drop order of structs) because other tasks for exporters and
-    // forwarders rely on this runtime.
-    _runtime: Option<tokio::runtime::Runtime>,
+    // The runtime is the last field so it is dropped last (see
+    // https://doc.rust-lang.org/reference/destructors.html), after the
+    // observers it spawned forwarder tasks for have been dropped and drained.
+    _runtime: Option<Runtime>,
 }
 
-impl<T> Context<T>
-where
-    T: Serialize + Send + 'static,
-{
+impl<M> Context<M> {
+    /// Create a context. With `Some(exporter)` this locates or spawns a runtime
+    /// and writes the `model.qmi` provenance sidecar into the context directory;
+    /// with `None` it is a no-op context that creates no runtime and whose
+    /// observers discard events.
+    ///
+    /// # Errors
+    /// Returns an error if no runtime is available and one cannot be spawned. A
+    /// failure to write the sidecar is logged, not returned.
     pub fn try_new(exporter: Option<ExporterOptions>) -> Result<Self, Box<dyn std::error::Error>>
     where
-        T: ModelSource,
+        M: ModelSource,
     {
         let id = Uuid::now_v7();
-        let kind = match exporter {
-            None => {
-                debug!("using noop exporter");
-                return Ok(Context {
-                    id,
-                    handle: None,
-                    events_sender: EventSender {
-                        tx: None,
-                        disable_error_log: Arc::new(AtomicBool::new(false)),
-                    },
-                    exporter: None,
-                    cancellation_token: CancellationToken::new(),
-                    forwarder_handle: None,
-                    _runtime: None,
-                });
-            }
-            Some(kind) => kind,
+
+        let Some(config) = exporter else {
+            debug!("using noop exporter");
+            return Ok(Context {
+                id,
+                config: None,
+                handle: None,
+                _model: PhantomData,
+                _runtime: None,
+            });
         };
 
         let (runtime, handle) = if let Ok(handle) = Handle::try_current() {
@@ -139,71 +142,24 @@ where
             }
         };
 
-        let (events_sender, mut events_receiver) = unbounded_channel();
-
-        debug!("constructing exporter");
-        let kind = kind.in_context_dir(id);
-        // Provenance sidecar destination, captured before `kind` is consumed.
-        let sidecar_dir = kind.filesystem_root().map(std::path::Path::to_path_buf);
-        let exporter: Arc<dyn Exporter<T>> = handle.block_on(create_exporter(kind))?;
-
-        // Write the provenance sidecar once per context, alongside the events
-        // the exporter just created the directory for. Filesystem exporters
-        // only; the collector server writes it for collector-routed events.
-        if let Some(dir) = sidecar_dir {
-            let info = ArtifactInfo::new(T::model_info());
-            if let Err(e) = info.write_sidecar(&dir) {
+        // Write the provenance sidecar once per context, in the context
+        // directory the per-entity observers nest their streams under.
+        // Filesystem exporters only; the collector server writes it for
+        // collector-routed events.
+        if let Some(dir) = config.clone().in_context_dir(id).filesystem_root() {
+            let dir = dir.to_path_buf();
+            if let Err(e) = std::fs::create_dir_all(&dir)
+                .and_then(|()| ArtifactInfo::new(M::model_info()).write_sidecar(&dir))
+            {
                 warn!("failed to write provenance sidecar: {e}");
             }
         }
 
-        let cancellation_token = CancellationToken::new();
-        let cloned_token = cancellation_token.clone();
-
-        let forwarder_handle = handle.spawn({
-            let exporter: Arc<dyn Exporter<T>> = Arc::clone(&exporter);
-            async move {
-                loop {
-                    tokio::select! {
-                        Some(event) = events_receiver.recv() => {
-                            match exporter.push(event).await {
-                                Ok(_) => (), // successfully pushed to exporter,
-                                Err(e) => warn!("unable to export event: {e}"),
-                            }
-                        },
-                        () = cloned_token.cancelled() => {
-                            events_receiver.close();
-                            // drain events that are buffered
-                            while let Some(event) = events_receiver.recv().await {
-                                match exporter.push(event).await {
-                                    Ok(_) => (), // successfully pushed to exporter,
-                                    Err(e) => warn!("unable to export event: {e}"),
-                                }
-                            }
-                            break
-                        },
-                        else => {
-                            // we only enter here when the events_receiver
-                            // channel has been closed (.recv() returns None)
-                            // so no messages to receive or push to the
-                            // exporter, so simply break.
-                            break
-                        }
-                    }
-                }
-            }
-        });
-
         Ok(Context {
             id,
+            config: Some(config),
             handle: Some(handle),
-            events_sender: EventSender {
-                tx: Some(events_sender),
-                disable_error_log: Arc::new(AtomicBool::new(false)),
-            },
-            exporter: Some(exporter),
-            cancellation_token,
-            forwarder_handle: Some(forwarder_handle),
+            _model: PhantomData,
             _runtime: runtime,
         })
     }
@@ -213,27 +169,121 @@ where
         self.id
     }
 
-    pub fn events_sender(&self) -> EventSender<T> {
+    /// Build the pipeline for one entity's event stream `T`. Filesystem events
+    /// are written to `<root>/<id>/<T::NAME>/`. Returns a no-op observer when
+    /// the context has no exporter configured.
+    ///
+    /// # Errors
+    /// Returns an error if the exporter cannot be constructed.
+    pub fn observer<T>(&self) -> Result<Observer<T>, Box<dyn std::error::Error>>
+    where
+        T: Serialize + Send + EntityEvent + 'static,
+    {
+        let (Some(config), Some(handle)) = (&self.config, &self.handle) else {
+            return Ok(Observer::noop());
+        };
+
+        debug!("constructing exporter for stream `{}`", T::NAME);
+        let kind = config.clone().in_context_dir(self.id);
+        let exporter: Arc<dyn Exporter<T>> = handle.block_on(create_exporter(kind))?;
+
+        let cancellation_token = CancellationToken::new();
+        let cloned_token = cancellation_token.clone();
+        let (events_sender, mut events_receiver) = unbounded_channel();
+
+        let forwarder_handle = handle.spawn({
+            let exporter: Arc<dyn Exporter<T>> = Arc::clone(&exporter);
+            async move {
+                loop {
+                    tokio::select! {
+                        Some(event) = events_receiver.recv() => {
+                            if let Err(e) = exporter.push(event).await {
+                                warn!("unable to export event: {e}");
+                            }
+                        },
+                        () = cloned_token.cancelled() => {
+                            events_receiver.close();
+                            // drain events that are buffered
+                            while let Some(event) = events_receiver.recv().await {
+                                if let Err(e) = exporter.push(event).await {
+                                    warn!("unable to export event: {e}");
+                                }
+                            }
+                            break
+                        },
+                        // the events channel has been closed: nothing left to forward.
+                        else => break,
+                    }
+                }
+            }
+        });
+
+        Ok(Observer {
+            events_sender: EventSender {
+                tx: Some(events_sender),
+                disable_error_log: Arc::new(AtomicBool::new(false)),
+            },
+            exporter: Some(exporter),
+            cancellation_token,
+            forwarder_handle: Some(forwarder_handle),
+            handle: Some(handle.clone()),
+        })
+    }
+}
+
+/// One entity's event pipeline: channel → forwarder task → exporter. Hand out
+/// cloned senders with [`Self::sender`] and emit through them concurrently. On
+/// drop, drains buffered events and flushes the exporter, using the runtime
+/// [`Handle`] it was built with — so an observer must be dropped where
+/// [`Handle::block_on`] is valid and while that runtime is still alive.
+pub struct Observer<T>
+where
+    T: Serialize + Send + EntityEvent + 'static,
+{
+    events_sender: EventSender<T>,
+    exporter: Option<Arc<dyn Exporter<T>>>,
+    cancellation_token: CancellationToken,
+    forwarder_handle: Option<JoinHandle<()>>,
+    handle: Option<Handle>,
+}
+
+impl<T> Observer<T>
+where
+    T: Serialize + Send + EntityEvent + 'static,
+{
+    /// A no-op observer that discards events and holds no runtime resources.
+    fn noop() -> Self {
+        Self {
+            events_sender: EventSender::noop(),
+            exporter: None,
+            cancellation_token: CancellationToken::new(),
+            forwarder_handle: None,
+            handle: None,
+        }
+    }
+
+    /// A cloned [`EventSender`] for this stream; cheap and `Send + Sync + Clone`.
+    pub fn sender(&self) -> EventSender<T> {
         self.events_sender.clone()
     }
 }
 
-impl<T> Drop for Context<T>
+impl<T> Drop for Observer<T>
 where
-    T: Serialize + Send + 'static,
+    T: Serialize + Send + EntityEvent + 'static,
 {
     fn drop(&mut self) {
         self.cancellation_token.cancel();
 
         if let Some(handle) = &self.handle {
-            // Wait for the forwarder to finish processing remaining events
+            // Wait for the forwarder to finish processing remaining events.
             if let Some(forwarder_handle) = self.forwarder_handle.take()
                 && let Err(e) = handle.block_on(forwarder_handle)
             {
                 warn!("forwarder task failed: {e}");
             }
 
-            // Flush the exporter to ensure all events are sent
+            // Flush the exporter to ensure all events are sent.
             if let Some(exporter) = &self.exporter
                 && let Err(e) = handle.block_on(exporter.force_flush())
             {
@@ -246,11 +296,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quent_exporter::{FileSystemExporterOptions, FileSystemFormat};
 
-    #[derive(Debug, serde::Serialize)]
-    struct TestEvent;
+    #[derive(Debug)]
+    struct TestModel;
 
-    impl ModelSource for TestEvent {
+    impl ModelSource for TestModel {
         fn package() -> &'static str {
             "quent-instrumentation"
         }
@@ -259,19 +310,63 @@ mod tests {
         }
     }
 
+    #[derive(Debug, serde::Serialize)]
+    struct TestEvent;
+
+    impl EntityEvent for TestEvent {
+        const NAME: &'static str = "TestEvent";
+    }
+
     #[test]
-    fn noop_exporter() {
-        let ctx = Context::<TestEvent>::try_new(None).unwrap();
+    fn noop_context_creates_noop_observer() {
+        let ctx = Context::<TestModel>::try_new(None).unwrap();
         assert!(ctx.handle.is_none());
-        assert!(ctx.exporter.is_none());
-        assert!(ctx.forwarder_handle.is_none());
         assert!(ctx._runtime.is_none());
 
-        let sender = ctx.events_sender();
+        let observer = ctx.observer::<TestEvent>().unwrap();
+        let sender = observer.sender();
         assert!(sender.tx.is_none());
 
         sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
         sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
+        drop(observer);
         drop(ctx);
+    }
+
+    #[test]
+    fn filesystem_observer_writes_under_entity_subdir_with_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = Context::<TestModel>::try_new(Some(ExporterOptions::FileSystem(
+            FileSystemExporterOptions {
+                format: FileSystemFormat::Ndjson,
+                root: dir.path().to_path_buf(),
+            },
+        )))
+        .unwrap();
+
+        let context_dir = dir.path().join(ctx.id().to_string());
+
+        {
+            let observer = ctx.observer::<TestEvent>().unwrap();
+            let sender = observer.sender();
+            sender.send(Event::new_now(Uuid::now_v7(), TestEvent));
+            // Drop the observer to drain and flush before asserting.
+        }
+
+        assert!(
+            context_dir.join("model.qmi").is_file(),
+            "sidecar should sit in the context directory"
+        );
+        let ndjson_files: Vec<_> = std::fs::read_dir(context_dir.join("TestEvent"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("ndjson"))
+            .collect();
+        assert_eq!(
+            ndjson_files.len(),
+            1,
+            "one UUID-named ndjson batch file in the entity subdirectory"
+        );
     }
 }

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -3,10 +3,14 @@
 
 //! Quent Instrumentation API
 //!
-use quent_build_info::{ArtifactInfo, ModelSource};
+//! Instrumented application code should not import features from this crate directly
+//! unless there is a very special reason. Instead, it should interact with the
+//! generated instrumentation library only.
+use quent_build_info::{ArtifactInfo, ModelInfo};
 use quent_events::{EntityEvent, Event};
 use quent_exporter::{ExporterOptions, create_exporter};
 use serde::Serialize;
+use std::future::Future;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -20,9 +24,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
-/// Wrapper around an optional channel sender. When the inner sender is `None`
-/// (i.e. the noop exporter is selected), `send` is a no-op that avoids any
-/// channel or event-forwarding overhead.
+/// Wrapper around an optional channel sender.
+///
+/// When the inner sender is `None` (i.e. the noop exporter is selected), `send`
+/// is a no-op that avoids any channel or event-forwarding overhead.
 pub struct EventSender<T> {
     tx: Option<UnboundedSender<Event<T>>>,
     /// Flag shared across clones to prevent potentially massive log spam from
@@ -72,21 +77,42 @@ impl<T> EventSender<T> {
     }
 }
 
-/// The runtime an active context's observers run on. `Ambient` borrows a runtime
-/// that already existed (e.g. a `#[tokio::main]` or caller-managed one); `Owned`
-/// keeps alive the one this context spawned.
+/// The runtime an active context's observers run on.
 #[derive(Clone)]
-enum ActiveRuntime {
-    Ambient(Handle),
-    Owned(Arc<Runtime>),
+enum BackendRuntime {
+    /// A handle to a runtime owned elsewhere (`#[tokio::main]`, a caller-managed
+    /// one) and kept alive by that owner.
+    Borrowed(Handle),
+    /// The runtime this context spawned, shared by the context and every observer
+    /// (hence `Arc`) and shut down by the last holder's `Drop`.
+    Owned {
+        handle: Handle,
+        /// `Option` only so `Drop` can move the `Arc` out of `&mut self`; `Some`
+        /// for the value's whole life until then.
+        runtime: Option<Arc<Runtime>>,
+    },
 }
 
-impl ActiveRuntime {
+impl BackendRuntime {
     /// The handle observers spawn and block on.
     fn handle(&self) -> Handle {
         match self {
-            Self::Ambient(h) => h.clone(),
-            Self::Owned(rt) => rt.handle().clone(),
+            Self::Borrowed(handle) | Self::Owned { handle, .. } => handle.clone(),
+        }
+    }
+}
+
+impl Drop for BackendRuntime {
+    fn drop(&mut self) {
+        // On the last holder of a spawned runtime, shut it down without blocking,
+        // since a blocking `Runtime` drop panics on a runtime worker thread.
+        // `into_inner` yields the `Runtime` only when this was the final `Arc`.
+        // Safe to abandon tasks here: the observers' forwarders have already
+        // flushed by the time the last holder drops.
+        if let Self::Owned { runtime, .. } = self
+            && let Some(runtime) = runtime.take().and_then(Arc::into_inner)
+        {
+            runtime.shutdown_background();
         }
     }
 }
@@ -97,34 +123,42 @@ enum Backend {
     Noop,
     Active {
         config: ExporterOptions,
-        runtime: ActiveRuntime,
+        runtime: BackendRuntime,
     },
 }
 
+/// A context responsible for providing an asynchronous back-end to a
+/// synchronous context generated from an application event model.
+///
+/// Instrumented application code should not interact with this type directly
+/// unless there is a very special reason. Instead, it should interact with the
+/// generated context only through a fully synchronous API.
+///
+/// What it is responsible for:
+/// - Resolving the runtime its observers run on. It borrows an ambient one if
+///   present, otherwise spawns its own (see [`BackendRuntime`]).
+/// - Being the single sync→async bridge for async observer + exporter
+///   construction, provenance sidecar write, and the drop-time flush.
+///
+/// # Panics
+///
+/// The blocking sync/async crossings work off a runtime or on a multi-threaded
+/// one, but panic on a current-thread runtime.
 pub struct Context {
-    /// Identity of this context, generated on construction.
+    /// Unique identifier of this context.
     id: Uuid,
+    /// The asynchronous run-time the observers produced by this context operate
+    /// on.
     backend: Backend,
 }
 
 impl Context {
-    /// Create a context for the given `exporter` configuration (see
-    /// [`ExporterOptions`]).
-    ///
-    /// `M` defines the model provenance, which is written into a sidecar file
-    /// alongside events when `exporter` is a filesystem exporter variant.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when an async runtime is needed but cannot be obtained.
-    pub fn try_new<M: ModelSource>(
-        exporter: Option<ExporterOptions>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::try_with_id::<M>(Uuid::now_v7(), exporter)
+    pub fn try_new(exporter: Option<ExporterOptions>) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::try_with_id(Uuid::now_v7(), exporter)
     }
 
-    /// Like [`Self::try_new`], but adopts an existing `id`.
-    pub fn try_with_id<M: ModelSource>(
+    /// Construct a new context with the supplied ID.
+    pub fn try_with_id(
         id: Uuid,
         exporter: Option<ExporterOptions>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -138,25 +172,16 @@ impl Context {
 
         let runtime = if let Ok(handle) = Handle::try_current() {
             debug!("using existing async runtime");
-            ActiveRuntime::Ambient(handle)
+            BackendRuntime::Borrowed(handle)
         } else {
             debug!("spawning new async runtime");
             let runtime =
                 Runtime::new().map_err(|e| format!("unable to spawn async runtime: {e}"))?;
-            ActiveRuntime::Owned(Arc::new(runtime))
-        };
-
-        // Write the provenance sidecar once per context, in the context
-        // directory the per-entity observers nest their streams under.
-        // Filesystem exporters only.
-        if let Some(dir) = config.clone().in_context_dir(id).filesystem_root() {
-            let dir = dir.to_path_buf();
-            if let Err(e) = std::fs::create_dir_all(&dir)
-                .and_then(|()| ArtifactInfo::new(M::model_info()).write_sidecar(&dir))
-            {
-                warn!("failed to write provenance sidecar: {e}");
+            BackendRuntime::Owned {
+                handle: runtime.handle().clone(),
+                runtime: Some(Arc::new(runtime)),
             }
-        }
+        };
 
         Ok(Context {
             id,
@@ -164,9 +189,58 @@ impl Context {
         })
     }
 
-    /// Identity of this context, generated or set on construction.
     pub fn id(&self) -> Uuid {
         self.id
+    }
+
+    /// Drive `fut` to completion on this context's runtime, blocking the
+    /// calling thread.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a current-thread runtime.
+    pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
+        match &self.backend {
+            Backend::Active { runtime, .. } => drive(&runtime.handle(), fut),
+            // A noop context has no runtime, but its async work is immediately
+            // ready, so poll once. Invariant: the noop `observer()`/
+            // `write_sidecar()` futures must never pend (they early-return
+            // before any `.await`); the `unreachable!` below enforces it.
+            Backend::Noop => {
+                let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+                match std::pin::pin!(fut).poll(&mut cx) {
+                    std::task::Poll::Ready(v) => v,
+                    std::task::Poll::Pending => {
+                        unreachable!("noop context future is always ready")
+                    }
+                }
+            }
+        }
+    }
+
+    /// Write the model provenance sidecar file into the context's filesystem
+    /// exporter directory.
+    ///
+    /// If no filesystem exporter is configured, then this is a no-op.
+    pub async fn write_sidecar(&self, model: ModelInfo) {
+        let Backend::Active { config, .. } = &self.backend else {
+            return;
+        };
+        let kind = config.clone().in_context_dir(self.id);
+        let Some(root) = kind.filesystem_root() else {
+            return;
+        };
+        let dir = root.to_path_buf();
+        let result = tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(&dir)
+                .and_then(|()| ArtifactInfo::new(model).write_sidecar(&dir))
+        })
+        .await;
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => warn!("failed to write provenance sidecar: {e}"),
+            Err(e) => warn!("provenance sidecar task failed: {e}"),
+        }
     }
 
     /// Create an [`Observer`] of events of one *type* of entity `T`.
@@ -174,7 +248,7 @@ impl Context {
     /// # Errors
     ///
     /// Returns an error if the exporter cannot be constructed.
-    pub fn observer<T>(&self) -> Result<Observer<T>, Box<dyn std::error::Error>>
+    pub async fn observer<T>(&self) -> Result<Observer<T>, Box<dyn std::error::Error>>
     where
         T: Serialize + Send + EntityEvent + 'static,
     {
@@ -185,7 +259,7 @@ impl Context {
 
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().in_context_dir(self.id);
-        let exporter = handle.block_on(create_exporter::<T>(kind))?;
+        let exporter = create_exporter::<T>(kind).await?;
 
         let cancellation_token = CancellationToken::new();
         let cloned_token = cancellation_token.clone();
@@ -231,12 +305,14 @@ impl Context {
     }
 }
 
-/// Observes events of one *type* of entity `T`.
+/// Provides an event pipeline to "observe" events of one *type* of entity `T`
+/// and export them.
 ///
-/// It does so by dealing out (generated) handles per entity. These handles have
-/// functions with names and signatures generated from an application event
-/// model. Upon calling these functions, events are sent to an exporter that is
-/// managed by this observer.
+/// Instrumented application code should not interact with this type directly
+/// unless they have a very special reason. Instead, it interacts with the
+/// generated observer only.
+///
+/// A generated observer deals out generated handles per entity instance.
 pub struct Observer<T>
 where
     T: Serialize + Send + EntityEvent + 'static,
@@ -247,7 +323,7 @@ where
     /// The runtime this observer's forwarder runs on; `None` for a no-op
     /// observer. An `Owned` runtime is kept alive here for the observer's
     /// lifetime, so its drop flush is valid even after the [`Context`] is gone.
-    runtime: Option<ActiveRuntime>,
+    runtime: Option<BackendRuntime>,
 }
 
 impl<T> Observer<T>
@@ -286,26 +362,34 @@ where
         else {
             return;
         };
-        let handle = runtime.handle();
 
         // The forwarder drains remaining events and flushes the exporter on
-        // cancellation; joining only waits for that to finish. `block_on`
-        // panics on a runtime worker thread, so when dropped inside a runtime
-        // detach the join instead — the flush still runs, but drop no longer
-        // waits for it.
-        if Handle::try_current().is_ok() {
-            handle.spawn(async move {
-                let _ = forwarder_handle.await;
-            });
-        } else if let Err(e) = handle.block_on(forwarder_handle) {
+        // cancellation; joining waits for that to finish. `drive` blocks here
+        // whether dropped off a runtime or on a multi-threaded worker.
+        if let Err(e) = drive(&runtime.handle(), forwarder_handle) {
             warn!("forwarder task failed: {e}");
         }
+    }
+}
+
+/// Drive `fut` to completion on `handle`'s runtime, blocking the current thread.
+///
+/// - Off a runtime, it blocks directly.
+/// - On a multi-threaded runtime worker it uses `block_in_place` so the
+/// scheduler keeps progressing.
+/// - On a current-thread runtime it panics.
+fn drive<F: Future>(handle: &Handle, fut: F) -> F::Output {
+    if Handle::try_current().is_ok() {
+        tokio::task::block_in_place(|| handle.block_on(fut))
+    } else {
+        handle.block_on(fut)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quent_build_info::ModelSource;
     use quent_exporter::{FileSystemExporterOptions, FileSystemFormat};
 
     #[derive(Debug, serde::Serialize)]
@@ -335,10 +419,10 @@ mod tests {
 
     #[test]
     fn noop_context_creates_noop_observer() {
-        let ctx = Context::try_new::<TestModel>(None).unwrap();
+        let ctx = Context::try_new(None).unwrap();
         assert!(matches!(ctx.backend, Backend::Noop));
 
-        let observer = ctx.observer::<TestEvent>().unwrap();
+        let observer = ctx.block_on(ctx.observer::<TestEvent>()).unwrap();
         assert!(observer.events_sender.tx.is_none());
 
         observer.send(Event::new_now(Uuid::now_v7(), TestEvent));
@@ -350,7 +434,7 @@ mod tests {
     #[test]
     fn filesystem_observer_writes_under_entity_subdir_with_sidecar() {
         let dir = tempfile::tempdir().unwrap();
-        let ctx = Context::try_new::<TestModel>(Some(ExporterOptions::FileSystem(
+        let ctx = Context::try_new(Some(ExporterOptions::FileSystem(
             FileSystemExporterOptions {
                 format: FileSystemFormat::Ndjson,
                 root: dir.path().to_path_buf(),
@@ -361,7 +445,12 @@ mod tests {
         let context_dir = dir.path().join(ctx.id().to_string());
 
         {
-            let observer = ctx.observer::<TestEvent>().unwrap();
+            let observer = ctx
+                .block_on(async {
+                    ctx.write_sidecar(TestModel::model_info()).await;
+                    ctx.observer::<TestEvent>().await
+                })
+                .unwrap();
             observer.send(Event::new_now(Uuid::now_v7(), TestEvent));
             // Drop the observer to drain and flush before asserting.
         }

--- a/crates/instrumentation/tests/collector_roundtrip.rs
+++ b/crates/instrumentation/tests/collector_roundtrip.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A client whose exporter is the collector: events must survive the full
+//! gRPC round-trip, and dropping the context (which flushes the collector
+//! client) must not panic — exercising the teardown path the bench masks with
+//! `mem::forget`.
+
+#![cfg(feature = "collector")]
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use common::TestEvent;
+use quent_collector::{CollectorSink, server::CollectorService};
+use quent_collector_proto::collector_server::CollectorServer;
+use quent_events::{EntityEvent, Event};
+use quent_exporter::{CollectorExporterOptions, ExporterOptions};
+use quent_instrumentation::Context;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server as GrpcServer;
+use uuid::Uuid;
+
+const EVENTS: usize = 100;
+
+/// Collector-side sink: decodes each event and counts it.
+struct CountingSink {
+    received: Arc<AtomicUsize>,
+}
+
+impl CollectorSink for CountingSink {
+    fn ingest(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+        if entity != TestEvent::NAME {
+            return Err(format!("unexpected entity `{entity}`").into());
+        }
+        let _: Event<TestEvent> = ciborium::from_reader(event)?;
+        self.received.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// Start an in-process collector server on a random localhost port. Returns the
+/// dial address and the server's runtime — the caller keeps the runtime alive
+/// for the test and drops it to shut the server down.
+fn start_server(received: Arc<AtomicUsize>) -> (String, tokio::runtime::Runtime) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = format!("http://{}", std_listener.local_addr().unwrap());
+    std_listener.set_nonblocking(true).unwrap();
+
+    rt.spawn(async move {
+        let listener = tokio::net::TcpListener::from_std(std_listener).unwrap();
+        let service = CollectorService::new(move |_id| {
+            Ok::<_, String>(CountingSink {
+                received: received.clone(),
+            })
+        });
+        let _ = GrpcServer::builder()
+            .add_service(CollectorServer::new(service))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await;
+    });
+
+    (address, rt)
+}
+
+#[test]
+fn collector_client_flushes_all_events_on_drop() {
+    let received = Arc::new(AtomicUsize::new(0));
+    // `_server` keeps the collector running for the test and shuts it down on
+    // drop at the end.
+    let (address, _server) = start_server(received.clone());
+
+    // A plain sync client (no ambient runtime); the context spawns its own.
+    let ctx = Context::try_new(Some(ExporterOptions::Collector(CollectorExporterOptions {
+        address,
+        source_context_id: Uuid::now_v7(),
+    })))
+    .unwrap();
+    {
+        let observer = ctx.block_on(ctx.observer::<TestEvent>()).unwrap();
+        for _ in 0..EVENTS {
+            observer.emit(Uuid::now_v7(), TestEvent);
+        }
+        // Dropping the observer flushes the collector client (force_flush ->
+        // shutdown) and tears down its tasks — this is what must not panic.
+    }
+    drop(ctx);
+
+    // Delivery completes asynchronously on the server; poll until all arrive.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while received.load(Ordering::SeqCst) < EVENTS && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(
+        received.load(Ordering::SeqCst),
+        EVENTS,
+        "collector did not receive all events"
+    );
+}

--- a/crates/instrumentation/tests/collector_roundtrip.rs
+++ b/crates/instrumentation/tests/collector_roundtrip.rs
@@ -14,7 +14,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use common::TestEvent;
+use common::{TestEvent, TestModel};
+use quent_build_info::ModelSource;
 use quent_collector::{CollectorSink, server::CollectorService};
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_events::{EntityEvent, Event};
@@ -80,9 +81,12 @@ fn collector_client_flushes_all_events_on_drop() {
     let (address, _server) = start_server(received.clone());
 
     // A plain sync client (no ambient runtime); the context spawns its own.
-    let ctx = Context::try_new(Some(ExporterOptions::Collector(CollectorExporterOptions {
-        address,
-    })))
+    let ctx = Context::try_new(
+        TestModel::model_info(),
+        Some(ExporterOptions::Collector(CollectorExporterOptions {
+            address,
+        })),
+    )
     .unwrap();
     {
         let observer = ctx.block_on(ctx.observer::<TestEvent>()).unwrap();

--- a/crates/instrumentation/tests/collector_roundtrip.rs
+++ b/crates/instrumentation/tests/collector_roundtrip.rs
@@ -82,7 +82,6 @@ fn collector_client_flushes_all_events_on_drop() {
     // A plain sync client (no ambient runtime); the context spawns its own.
     let ctx = Context::try_new(Some(ExporterOptions::Collector(CollectorExporterOptions {
         address,
-        source_context_id: Uuid::now_v7(),
     })))
     .unwrap();
     {

--- a/crates/instrumentation/tests/common/mod.rs
+++ b/crates/instrumentation/tests/common/mod.rs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared fixtures for the instrumentation integration tests.
+
+#![allow(dead_code)]
+
+use quent_build_info::{BuildInfo, ModelSource};
+use quent_events::EntityEvent;
+use serde::{Deserialize, Serialize};
+
+/// Model marker, only used to supply provenance to `write_sidecar`.
+pub struct TestModel;
+
+impl ModelSource for TestModel {
+    fn package() -> &'static str {
+        "quent-instrumentation-tests"
+    }
+    fn source() -> BuildInfo {
+        BuildInfo::unknown()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestEvent;
+
+impl EntityEvent for TestEvent {
+    const NAME: &'static str = "TestEvent";
+}

--- a/crates/instrumentation/tests/runtime_flavors.rs
+++ b/crates/instrumentation/tests/runtime_flavors.rs
@@ -22,14 +22,10 @@ fn fs_opts(root: &Path) -> ExporterOptions {
     })
 }
 
-/// Build sidecar + observer through the one bridge, mirroring what a generated
-/// `{App}Context::try_new` does.
+/// Build an observer through the one bridge, mirroring what a generated
+/// `{App}Context::try_new` does (the sidecar is written at construction).
 fn build(ctx: &Context) -> Observer<TestEvent> {
-    ctx.block_on(async {
-        ctx.write_sidecar(TestModel::model_info()).await;
-        ctx.observer::<TestEvent>().await
-    })
-    .unwrap()
+    ctx.block_on(ctx.observer::<TestEvent>()).unwrap()
 }
 
 /// Assert the observer flushed one non-empty ndjson batch under `<root>/<id>/`.
@@ -57,7 +53,7 @@ fn assert_flushed(root: &Path, id: Uuid) {
 #[test]
 fn plain_sync_app() {
     let dir = tempfile::tempdir().unwrap();
-    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let ctx = Context::try_new(TestModel::model_info(), Some(fs_opts(dir.path()))).unwrap();
     let id = ctx.id();
     {
         let observer = build(&ctx);
@@ -71,7 +67,7 @@ fn plain_sync_app() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tokio_main_multi_thread() {
     let dir = tempfile::tempdir().unwrap();
-    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let ctx = Context::try_new(TestModel::model_info(), Some(fs_opts(dir.path()))).unwrap();
     let id = ctx.id();
     {
         let observer = build(&ctx);
@@ -87,7 +83,7 @@ async fn tokio_main_multi_thread() {
 #[should_panic]
 async fn current_thread_runtime_panics() {
     let dir = tempfile::tempdir().unwrap();
-    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let ctx = Context::try_new(TestModel::model_info(), Some(fs_opts(dir.path()))).unwrap();
     let _ = build(&ctx);
 }
 
@@ -101,7 +97,7 @@ fn self_managed_runtime() {
         .build()
         .unwrap();
     let id = rt.block_on(async {
-        let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+        let ctx = Context::try_new(TestModel::model_info(), Some(fs_opts(dir.path()))).unwrap();
         let id = ctx.id();
         let observer = build(&ctx);
         observer.emit(Uuid::now_v7(), TestEvent);
@@ -117,7 +113,7 @@ fn self_managed_runtime() {
 #[test]
 fn owned_runtime_observer_dropped_in_another_runtime() {
     let dir = tempfile::tempdir().unwrap();
-    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let ctx = Context::try_new(TestModel::model_info(), Some(fs_opts(dir.path()))).unwrap();
     let id = ctx.id();
     let observer = build(&ctx);
     observer.emit(Uuid::now_v7(), TestEvent);

--- a/crates/instrumentation/tests/runtime_flavors.rs
+++ b/crates/instrumentation/tests/runtime_flavors.rs
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The sync/async bridge across the runtime setups a client application can have:
+//! a `#[tokio::main]` app, a current-thread app, a plain sync app (no runtime),
+//! and an app with its own manually-managed runtime.
+
+mod common;
+
+use std::path::Path;
+
+use common::{TestEvent, TestModel};
+use quent_build_info::ModelSource;
+use quent_exporter::{ExporterOptions, FileSystemExporterOptions, FileSystemFormat};
+use quent_instrumentation::{Context, Observer};
+use uuid::Uuid;
+
+fn fs_opts(root: &Path) -> ExporterOptions {
+    ExporterOptions::FileSystem(FileSystemExporterOptions {
+        format: FileSystemFormat::Ndjson,
+        root: root.to_path_buf(),
+    })
+}
+
+/// Build sidecar + observer through the one bridge, mirroring what a generated
+/// `{App}Context::try_new` does.
+fn build(ctx: &Context) -> Observer<TestEvent> {
+    ctx.block_on(async {
+        ctx.write_sidecar(TestModel::model_info()).await;
+        ctx.observer::<TestEvent>().await
+    })
+    .unwrap()
+}
+
+/// Assert the observer flushed one non-empty ndjson batch under `<root>/<id>/`.
+fn assert_flushed(root: &Path, id: Uuid) {
+    let entity_dir = root.join(id.to_string()).join("TestEvent");
+    let files: Vec<_> = std::fs::read_dir(&entity_dir)
+        .unwrap_or_else(|e| panic!("reading {entity_dir:?}: {e}"))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("ndjson"))
+        .collect();
+    assert_eq!(
+        files.len(),
+        1,
+        "expected one ndjson batch in {entity_dir:?}"
+    );
+    assert!(
+        files[0].metadata().unwrap().len() > 0,
+        "ndjson batch is empty"
+    );
+}
+
+/// Plain sync app, no ambient runtime: the context spawns its own (`Owned`), and
+/// the bridge/drop block directly on it.
+#[test]
+fn plain_sync_app() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let id = ctx.id();
+    {
+        let observer = build(&ctx);
+        observer.emit(Uuid::now_v7(), TestEvent);
+    } // observer dropped on this non-runtime thread -> blocking flush
+    assert_flushed(dir.path(), id);
+}
+
+/// `#[tokio::main]`-style app: an ambient multi-threaded runtime. The bridge and
+/// the drop-time flush run on a worker via `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tokio_main_multi_thread() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let id = ctx.id();
+    {
+        let observer = build(&ctx);
+        observer.emit(Uuid::now_v7(), TestEvent);
+    } // observer dropped on a worker thread -> block_in_place flush
+    assert_flushed(dir.path(), id);
+}
+
+/// `#[tokio::main(flavor = "current_thread")]` app: the bridge must block the only
+/// worker, which is impossible — pins the documented panic so it can't silently
+/// change.
+#[tokio::test(flavor = "current_thread")]
+#[should_panic]
+async fn current_thread_runtime_panics() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let _ = build(&ctx);
+}
+
+/// App that builds and manages its own runtime and runs everything inside it.
+#[test]
+fn self_managed_runtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let id = rt.block_on(async {
+        let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+        let id = ctx.id();
+        let observer = build(&ctx);
+        observer.emit(Uuid::now_v7(), TestEvent);
+        drop(observer); // flush on a worker of `rt`
+        id
+    });
+    assert_flushed(dir.path(), id);
+}
+
+/// An `Owned`-runtime observer dropped from inside a *different* runtime: the last
+/// `Arc` to the owned runtime is released on a worker thread. Must not panic (the
+/// runtime shuts down without blocking) and must still flush.
+#[test]
+fn owned_runtime_observer_dropped_in_another_runtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = Context::try_new(Some(fs_opts(dir.path()))).unwrap();
+    let id = ctx.id();
+    let observer = build(&ctx);
+    observer.emit(Uuid::now_v7(), TestEvent);
+    drop(ctx); // observer now solely keeps the owned runtime alive
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async move {
+        drop(observer); // last owned-runtime Arc dropped on a worker of `rt`
+    });
+    assert_flushed(dir.path(), id);
+}

--- a/crates/model-macros/src/entity_macro.rs
+++ b/crates/model-macros/src/entity_macro.rs
@@ -489,6 +489,11 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
                     Self { inner: ::std::sync::Arc::new(observer) }
                 }
 
+                /// Forward a pre-built event into this entity's stream.
+                pub fn send(&self, event: quent_model::Event<E>) {
+                    self.inner.send(event);
+                }
+
                 #[doc = #doc_method]
                 pub fn #alias(&self, id: quent_model::uuid::Uuid, event: #ty) {
                     self.inner.emit(id, #event_enum::#variant(event));
@@ -558,6 +563,11 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
             {
                 pub fn new(observer: quent_model::Observer<E>) -> Self {
                     Self { inner: ::std::sync::Arc::new(observer) }
+                }
+
+                /// Forward a pre-built event into this entity's stream.
+                pub fn send(&self, event: quent_model::Event<E>) {
+                    self.inner.send(event);
                 }
 
                 #[doc = #doc_create]
@@ -686,6 +696,11 @@ fn expand_self_event(
         {
             pub fn new(observer: quent_model::Observer<E>) -> Self {
                 Self { inner: ::std::sync::Arc::new(observer) }
+            }
+
+            /// Forward a pre-built event into this entity's stream.
+            pub fn send(&self, event: quent_model::Event<E>) {
+                self.inner.send(event);
             }
 
             #[doc = #doc_observer_method]
@@ -947,6 +962,11 @@ fn expand_rg_attrs(
         {
             pub fn new(observer: quent_model::Observer<E>) -> Self {
                 Self { inner: ::std::sync::Arc::new(observer) }
+            }
+
+            /// Forward a pre-built event into this entity's stream.
+            pub fn send(&self, event: quent_model::Event<E>) {
+                self.inner.send(event);
             }
 
             #[doc = #doc_observer_method]

--- a/crates/model-macros/src/entity_macro.rs
+++ b/crates/model-macros/src/entity_macro.rs
@@ -307,7 +307,9 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let input: EntityInput = syn::parse2(input)?;
     let ua = &input.user_attrs;
     let event_enum = format_ident!("{}Event", &input.name);
-    let event_name = event_enum.to_string();
+    // The stream name (exporter subdirectory, collector wire tag, ingest key) is
+    // the entity's snake-case name.
+    let event_name = crate::util::to_snake_case(&input.name);
     let body = match input.kind {
         EntityKind::SelfEvent(fields) => expand_self_event(&input.name, &fields, ua)?,
         EntityKind::MultiEvent(events) => expand_multi_event(&input.name, &events, ua)?,

--- a/crates/model-macros/src/entity_macro.rs
+++ b/crates/model-macros/src/entity_macro.rs
@@ -55,9 +55,7 @@ use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::{Token, Type, braced};
 
-use crate::util::{
-    resolve_value_type, serde_bound, serde_crate_attr, serde_derives, to_snake_case,
-};
+use crate::util::{resolve_value_type, serde_crate_attr, serde_derives, to_snake_case};
 
 struct InlineField {
     name: Ident,
@@ -338,7 +336,6 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 struct EntityIdents {
     serde_derives: TokenStream,
     serde_crate_attr: TokenStream,
-    serde_bound: TokenStream,
     entity_snake: String,
     event_enum: Ident,
     observer_name: Ident,
@@ -351,7 +348,6 @@ impl EntityIdents {
         Self {
             serde_derives: serde_derives(),
             serde_crate_attr: serde_crate_attr(),
-            serde_bound: serde_bound(),
             event_enum: format_ident!("{}Event", name),
             observer_name: format_ident!("{}Observer", name),
             data_struct: format_ident!("{}Data", name),
@@ -445,7 +441,6 @@ fn codegen_events(events: &[EventEntry], event_enum: &Ident) -> EventCodegen {
 fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIdents) -> TokenStream {
     let event_enum = &ids.event_enum;
     let observer_name = &ids.observer_name;
-    let serde_bound = &ids.serde_bound;
     let entity_snake = &ids.entity_snake;
 
     let doc_observer = format!(
@@ -464,30 +459,24 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
         quote! {
             #[doc = #doc_observer]
             #[doc(alias = "observer")]
-            pub struct #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
-                inner: ::std::sync::Arc<quent_model::Observer<E>>,
+            pub struct #observer_name {
+                inner: ::std::sync::Arc<quent_model::Observer<#event_enum>>,
             }
 
-            // Cloning shares the underlying observer; `E: Clone` is not required.
-            impl<E> Clone for #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
+            // Cloning shares the underlying observer.
+            impl Clone for #observer_name {
                 fn clone(&self) -> Self {
                     Self { inner: self.inner.clone() }
                 }
             }
 
-            impl<E> #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
-                pub fn new(observer: quent_model::Observer<E>) -> Self {
+            impl #observer_name {
+                pub fn new(observer: quent_model::Observer<#event_enum>) -> Self {
                     Self { inner: ::std::sync::Arc::new(observer) }
                 }
 
                 /// Forward a pre-built event into this entity's stream.
-                pub fn send(&self, event: quent_model::Event<E>) {
+                pub fn send(&self, event: quent_model::Event<#event_enum>) {
                     self.inner.send(event);
                 }
 
@@ -523,16 +512,12 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
         quote! {
             #[doc = #doc_handle]
             #[doc(alias = "handle")]
-            pub struct #handle_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
+            pub struct #handle_name {
                 id: quent_model::uuid::Uuid,
-                inner: ::std::sync::Arc<quent_model::Observer<E>>,
+                inner: ::std::sync::Arc<quent_model::Observer<#event_enum>>,
             }
 
-            impl<E> #handle_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
+            impl #handle_name {
                 #[doc = #doc_handle_uuid]
                 pub fn uuid(&self) -> quent_model::uuid::Uuid { self.id }
                 #(#handle_methods)*
@@ -540,35 +525,29 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
 
             #[doc = #doc_observer]
             #[doc(alias = "observer")]
-            pub struct #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
-                inner: ::std::sync::Arc<quent_model::Observer<E>>,
+            pub struct #observer_name {
+                inner: ::std::sync::Arc<quent_model::Observer<#event_enum>>,
             }
 
-            // Cloning shares the underlying observer; `E: Clone` is not required.
-            impl<E> Clone for #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
+            // Cloning shares the underlying observer.
+            impl Clone for #observer_name {
                 fn clone(&self) -> Self {
                     Self { inner: self.inner.clone() }
                 }
             }
 
-            impl<E> #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-            {
-                pub fn new(observer: quent_model::Observer<E>) -> Self {
+            impl #observer_name {
+                pub fn new(observer: quent_model::Observer<#event_enum>) -> Self {
                     Self { inner: ::std::sync::Arc::new(observer) }
                 }
 
                 /// Forward a pre-built event into this entity's stream.
-                pub fn send(&self, event: quent_model::Event<E>) {
+                pub fn send(&self, event: quent_model::Event<#event_enum>) {
                     self.inner.send(event);
                 }
 
                 #[doc = #doc_create]
-                pub fn create(&self, id: quent_model::uuid::Uuid) -> #handle_name<E> {
+                pub fn create(&self, id: quent_model::uuid::Uuid) -> #handle_name {
                     #handle_name { id, inner: self.inner.clone() }
                 }
             }
@@ -586,7 +565,6 @@ fn expand_self_event(
     let ids = EntityIdents::new(name);
     let serde_derives = &ids.serde_derives;
     let serde_crate_attr = &ids.serde_crate_attr;
-    let serde_bound = &ids.serde_bound;
     let entity_snake = &ids.entity_snake;
     let event_enum = &ids.event_enum;
     let observer_name = &ids.observer_name;
@@ -670,30 +648,24 @@ fn expand_self_event(
 
         #[doc = #doc_observer]
             #[doc(alias = "observer")]
-        pub struct #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        pub struct #observer_name {
+            inner: ::std::sync::Arc<quent_model::Observer<#event_enum>>,
         }
 
-        // Cloning shares the underlying observer; `E: Clone` is not required.
-        impl<E> Clone for #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        // Cloning shares the underlying observer.
+        impl Clone for #observer_name {
             fn clone(&self) -> Self {
                 Self { inner: self.inner.clone() }
             }
         }
 
-        impl<E> #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            pub fn new(observer: quent_model::Observer<E>) -> Self {
+        impl #observer_name {
+            pub fn new(observer: quent_model::Observer<#event_enum>) -> Self {
                 Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             /// Forward a pre-built event into this entity's stream.
-            pub fn send(&self, event: quent_model::Event<E>) {
+            pub fn send(&self, event: quent_model::Event<#event_enum>) {
                 self.inner.send(event);
             }
 
@@ -828,7 +800,6 @@ fn expand_rg_attrs(
     let ids = EntityIdents::new(name);
     let serde_derives = &ids.serde_derives;
     let serde_crate_attr = &ids.serde_crate_attr;
-    let serde_bound = &ids.serde_bound;
     let entity_snake = &ids.entity_snake;
     let event_enum = &ids.event_enum;
     let observer_name = &ids.observer_name;
@@ -933,30 +904,24 @@ fn expand_rg_attrs(
 
         #[doc = #doc_observer]
             #[doc(alias = "observer")]
-        pub struct #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        pub struct #observer_name {
+            inner: ::std::sync::Arc<quent_model::Observer<#event_enum>>,
         }
 
-        // Cloning shares the underlying observer; `E: Clone` is not required.
-        impl<E> Clone for #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        // Cloning shares the underlying observer.
+        impl Clone for #observer_name {
             fn clone(&self) -> Self {
                 Self { inner: self.inner.clone() }
             }
         }
 
-        impl<E> #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            pub fn new(observer: quent_model::Observer<E>) -> Self {
+        impl #observer_name {
+            pub fn new(observer: quent_model::Observer<#event_enum>) -> Self {
                 Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             /// Forward a pre-built event into this entity's stream.
-            pub fn send(&self, event: quent_model::Event<E>) {
+            pub fn send(&self, event: quent_model::Event<#event_enum>) {
                 self.inner.send(event);
             }
 

--- a/crates/model-macros/src/entity_macro.rs
+++ b/crates/model-macros/src/entity_macro.rs
@@ -308,18 +308,28 @@ impl Parse for EntityInput {
 pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let input: EntityInput = syn::parse2(input)?;
     let ua = &input.user_attrs;
-    match input.kind {
-        EntityKind::SelfEvent(fields) => expand_self_event(&input.name, &fields, ua),
-        EntityKind::MultiEvent(events) => expand_multi_event(&input.name, &events, ua),
+    let event_enum = format_ident!("{}Event", &input.name);
+    let event_name = event_enum.to_string();
+    let body = match input.kind {
+        EntityKind::SelfEvent(fields) => expand_self_event(&input.name, &fields, ua)?,
+        EntityKind::MultiEvent(events) => expand_multi_event(&input.name, &events, ua)?,
         EntityKind::ResourceGroupAttrs { meta, fields } => {
-            expand_rg_attrs(&input.name, &meta, &fields, ua)
+            expand_rg_attrs(&input.name, &meta, &fields, ua)?
         }
         EntityKind::ResourceGroupEvents {
             meta,
             declaration,
             events,
-        } => expand_rg_events(&input.name, &meta, declaration.as_ref(), &events, ua),
-    }
+        } => expand_rg_events(&input.name, &meta, declaration.as_ref(), &events, ua)?,
+    };
+    // Every entity exposes its event enum as a named stream for exporters.
+    Ok(quote! {
+        #body
+
+        impl quent_model::EntityEvent for #event_enum {
+            const NAME: &'static str = #event_name;
+        }
+    })
 }
 
 // Shared helpers

--- a/crates/model-macros/src/entity_macro.rs
+++ b/crates/model-macros/src/entity_macro.rs
@@ -467,23 +467,31 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
         quote! {
             #[doc = #doc_observer]
             #[doc(alias = "observer")]
-            #[derive(Clone)]
             pub struct #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + 'static,
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
             {
-                tx: quent_model::EventSender<E>,
+                inner: ::std::sync::Arc<quent_model::Observer<E>>,
+            }
+
+            // Cloning shares the underlying observer; `E: Clone` is not required.
+            impl<E> Clone for #observer_name<E>
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
+            {
+                fn clone(&self) -> Self {
+                    Self { inner: self.inner.clone() }
+                }
             }
 
             impl<E> #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + 'static,
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
             {
-                pub fn new(tx: &quent_model::EventSender<E>) -> Self {
-                    Self { tx: tx.clone() }
+                pub fn new(observer: quent_model::Observer<E>) -> Self {
+                    Self { inner: ::std::sync::Arc::new(observer) }
                 }
 
                 #[doc = #doc_method]
                 pub fn #alias(&self, id: quent_model::uuid::Uuid, event: #ty) {
-                    self.tx.emit(id, #event_enum::#variant(event));
+                    self.inner.emit(id, #event_enum::#variant(event));
                 }
             }
         }
@@ -504,7 +512,7 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
                 quote! {
                     #[doc = #doc_method]
                     pub fn #alias(&self, event: #ty) {
-                        self.tx.emit(self.id, #event_enum::#variant(event));
+                        self.inner.emit(self.id, #event_enum::#variant(event));
                     }
                 }
             })
@@ -514,14 +522,14 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
             #[doc = #doc_handle]
             #[doc(alias = "handle")]
             pub struct #handle_name<E>
-            where E: From<#event_enum> #serde_bound + Send + 'static,
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
             {
                 id: quent_model::uuid::Uuid,
-                tx: quent_model::EventSender<E>,
+                inner: ::std::sync::Arc<quent_model::Observer<E>>,
             }
 
             impl<E> #handle_name<E>
-            where E: From<#event_enum> #serde_bound + Send + 'static,
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
             {
                 #[doc = #doc_handle_uuid]
                 pub fn uuid(&self) -> quent_model::uuid::Uuid { self.id }
@@ -530,23 +538,31 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
 
             #[doc = #doc_observer]
             #[doc(alias = "observer")]
-            #[derive(Clone)]
             pub struct #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + 'static,
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
             {
-                tx: quent_model::EventSender<E>,
+                inner: ::std::sync::Arc<quent_model::Observer<E>>,
+            }
+
+            // Cloning shares the underlying observer; `E: Clone` is not required.
+            impl<E> Clone for #observer_name<E>
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
+            {
+                fn clone(&self) -> Self {
+                    Self { inner: self.inner.clone() }
+                }
             }
 
             impl<E> #observer_name<E>
-            where E: From<#event_enum> #serde_bound + Send + 'static,
+            where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
             {
-                pub fn new(tx: &quent_model::EventSender<E>) -> Self {
-                    Self { tx: tx.clone() }
+                pub fn new(observer: quent_model::Observer<E>) -> Self {
+                    Self { inner: ::std::sync::Arc::new(observer) }
                 }
 
                 #[doc = #doc_create]
                 pub fn create(&self, id: quent_model::uuid::Uuid) -> #handle_name<E> {
-                    #handle_name { id, tx: self.tx.clone() }
+                    #handle_name { id, inner: self.inner.clone() }
                 }
             }
         }
@@ -650,24 +666,32 @@ fn expand_self_event(
 
         #[doc = #doc_observer]
             #[doc(alias = "observer")]
-        #[derive(Clone)]
         pub struct #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + 'static,
+        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            tx: quent_model::EventSender<E>,
+            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        }
+
+        // Cloning shares the underlying observer; `E: Clone` is not required.
+        impl<E> Clone for #observer_name<E>
+        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
+        {
+            fn clone(&self) -> Self {
+                Self { inner: self.inner.clone() }
+            }
         }
 
         impl<E> #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + 'static,
+        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            pub fn new(tx: &quent_model::EventSender<E>) -> Self {
-                Self { tx: tx.clone() }
+            pub fn new(observer: quent_model::Observer<E>) -> Self {
+                Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             #[doc = #doc_observer_method]
             #[doc(alias = "observer")]
             pub fn #method_name(&self, id: quent_model::uuid::Uuid, #(#param_defs,)*) {
-                self.tx.emit(id, #event_enum::from(#name { #(#field_names,)* }));
+                self.inner.emit(id, #event_enum::from(#name { #(#field_names,)* }));
             }
         }
 
@@ -903,18 +927,26 @@ fn expand_rg_attrs(
 
         #[doc = #doc_observer]
             #[doc(alias = "observer")]
-        #[derive(Clone)]
         pub struct #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + 'static,
+        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            tx: quent_model::EventSender<E>,
+            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        }
+
+        // Cloning shares the underlying observer; `E: Clone` is not required.
+        impl<E> Clone for #observer_name<E>
+        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
+        {
+            fn clone(&self) -> Self {
+                Self { inner: self.inner.clone() }
+            }
         }
 
         impl<E> #observer_name<E>
-        where E: From<#event_enum> #serde_bound + Send + 'static,
+        where E: From<#event_enum> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            pub fn new(tx: &quent_model::EventSender<E>) -> Self {
-                Self { tx: tx.clone() }
+            pub fn new(observer: quent_model::Observer<E>) -> Self {
+                Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             #[doc = #doc_observer_method]
@@ -929,7 +961,7 @@ fn expand_rg_attrs(
                     instance_name: instance_name.to_string(),
                     #(#decl_field_inits)*
                 };
-                self.tx.emit(id, #event_enum::from(event));
+                self.inner.emit(id, #event_enum::from(event));
                 id
             }
         }

--- a/crates/model-macros/src/entity_macro.rs
+++ b/crates/model-macros/src/entity_macro.rs
@@ -449,11 +449,8 @@ fn gen_observer_and_handle(name: &Ident, events: &[EventEntry], ids: &EntityIden
     let entity_snake = &ids.entity_snake;
 
     let doc_observer = format!(
-        "Observer for `{name}` events.\n\n\
-         An observer emits events for a model component. Obtain one from the \
-         instrumentation context via `{entity_snake}_observer()`.\n\n\
-         The type parameter `E` is the model's top-level event enum, allowing \
-         the same component to be reused across different models."
+        "Observer for `{name}` events. Obtain it from the instrumentation \
+         context via `{entity_snake}_observer()`."
     );
 
     if events.len() == 1 {
@@ -634,11 +631,8 @@ fn expand_self_event(
     let doc_struct = format!("`{name}` self-event entity.");
     let doc_event = format!("Events emitted by `{name}`.");
     let doc_observer = format!(
-        "Observer for `{name}` events.\n\n\
-         An observer emits events for a model component. Obtain one from the \
-         instrumentation context via `{entity_snake}_observer()`.\n\n\
-         The type parameter `E` is the model's top-level event enum, allowing \
-         the same component to be reused across different models."
+        "Observer for `{name}` events. Obtain it from the instrumentation \
+         context via `{entity_snake}_observer()`."
     );
     let doc_observer_method = format!("Emit a `{name}` event.");
     let doc_data =
@@ -906,11 +900,8 @@ fn expand_rg_attrs(
     let doc_decl = format!("Declaration attributes for the {name} resource group.");
     let doc_event = format!("Events emitted by {name}.");
     let doc_observer = format!(
-        "Observer for `{name}` resource group declarations.\n\n\
-         An observer emits events for a model component. Obtain one from the \
-         instrumentation context via `{entity_snake}_observer()`.\n\n\
-         The type parameter `E` is the model's top-level event enum, allowing \
-         the same component to be reused across different models."
+        "Observer for `{name}` resource group declarations. Obtain it from the \
+         instrumentation context via `{entity_snake}_observer()`."
     );
     let doc_observer_method = format!("Declare a new `{name}` resource group instance.");
     let doc_data =

--- a/crates/model-macros/src/fsm_macro.rs
+++ b/crates/model-macros/src/fsm_macro.rs
@@ -180,7 +180,9 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
     let transition_enum = format_ident!("{}Transition", name);
     let event_type = format_ident!("{}Event", name);
-    let event_name = event_type.to_string();
+    // The stream name (exporter subdirectory, collector wire tag, ingest key) is
+    // the entity's snake-case name.
+    let event_name = fsm_snake.clone();
     let handle_name = format_ident!("{}Handle", name);
     let observer_name = format_ident!("{}Observer", name);
 

--- a/crates/model-macros/src/fsm_macro.rs
+++ b/crates/model-macros/src/fsm_macro.rs
@@ -546,6 +546,11 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 Self { inner: ::std::sync::Arc::new(observer) }
             }
 
+            /// Forward a pre-built event into this entity's stream.
+            pub fn send(&self, event: quent_model::Event<E>) {
+                self.inner.send(event);
+            }
+
             #observer_methods
         }
 

--- a/crates/model-macros/src/fsm_macro.rs
+++ b/crates/model-macros/src/fsm_macro.rs
@@ -181,6 +181,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
     let transition_enum = format_ident!("{}Transition", name);
     let event_type = format_ident!("{}Event", name);
+    let event_name = event_type.to_string();
     let handle_name = format_ident!("{}Handle", name);
     let observer_name = format_ident!("{}Observer", name);
 
@@ -441,6 +442,12 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
         #[doc = #doc_event]
         pub type #event_type = quent_model::FsmEvent<#transition_enum>;
+
+        // The transition enum carries the FSM's event-stream name; a blanket impl
+        // on `FsmEvent<S>` forwards it (the alias is over a foreign type).
+        impl quent_model::EntityEvent for #transition_enum {
+            const NAME: &'static str = #event_name;
+        }
 
         impl quent_model::ModelComponent for #name {
             fn collect(builder: &mut quent_model::ModelBuilder) {

--- a/crates/model-macros/src/fsm_macro.rs
+++ b/crates/model-macros/src/fsm_macro.rs
@@ -380,12 +380,9 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let doc_handle_uuid = format!("Returns the UUID of this {name} FSM instance.");
     let doc_handle_exit = format!("Transition the {name} FSM to the exit state.");
     let doc_observer = format!(
-        "Observer for `{name}` FSM instances.\n\n\
-         An observer emits events for a model component. Obtain one from the \
-         instrumentation context via the corresponding observer method. \
-         Call the entry state method to create an FSM handle.\n\n\
-         The type parameter `E` is the model's top-level event enum, allowing \
-         the same component to be reused across different models."
+        "Observer for `{name}` FSM instances. Obtain it from the instrumentation \
+         context via the corresponding observer method; call the entry state \
+         method to create an FSM handle."
     );
 
     let output = quote! {

--- a/crates/model-macros/src/fsm_macro.rs
+++ b/crates/model-macros/src/fsm_macro.rs
@@ -353,7 +353,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     // Methods are always flat-arg: instance_name + attributes + optional usages.
     let entry_callback = format_ident!("__quent_state_{}", entry_alias.to_string());
     let observer_methods = quote! {
-        #entry_callback!(entry_method pub #handle_name #transition_enum tx);
+        #entry_callback!(entry_method pub #handle_name #transition_enum inner);
     };
 
     let handle_methods = {
@@ -471,17 +471,17 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         #[doc(alias = "handle")]
         pub struct #handle_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             id: quent_model::uuid::Uuid,
             seq: u64,
             exited: bool,
-            tx: quent_model::EventSender<E>,
+            inner: ::std::sync::Arc<quent_model::Observer<E>>,
         }
 
         impl<E> #handle_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             #[doc = #doc_handle_uuid]
             pub fn uuid(&self) -> quent_model::uuid::Uuid { self.id }
@@ -502,7 +502,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 let seq = self.seq;
                 self.seq += 1;
                 let event = quent_model::FsmEvent { seq, state };
-                self.tx.send(quent_model::Event::new(
+                self.inner.send(quent_model::Event::new(
                     self.id,
                     quent_model::timestamp(),
                     E::from(event),
@@ -514,27 +514,36 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
         impl<E> Drop for #handle_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             fn drop(&mut self) { self.exit(); }
         }
 
         #[doc = #doc_observer]
         #[doc(alias = "observer")]
-        #[derive(Clone)]
         pub struct #observer_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            tx: quent_model::EventSender<E>,
+            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        }
+
+        // Cloning shares the underlying observer; `E: Clone` is not required.
+        impl<E> Clone for #observer_name<E>
+        where
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
+        {
+            fn clone(&self) -> Self {
+                Self { inner: self.inner.clone() }
+            }
         }
 
         impl<E> #observer_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            pub fn new(tx: &quent_model::EventSender<E>) -> Self {
-                Self { tx: tx.clone() }
+            pub fn new(observer: quent_model::Observer<E>) -> Self {
+                Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             #observer_methods

--- a/crates/model-macros/src/fsm_macro.rs
+++ b/crates/model-macros/src/fsm_macro.rs
@@ -177,7 +177,6 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let fsm_snake = to_snake_case(name);
     let serde_derives = crate::util::serde_derives();
     let serde_crate_attr = crate::util::serde_crate_attr();
-    let serde_bound = crate::util::serde_bound();
 
     let transition_enum = format_ident!("{}Transition", name);
     let event_type = format_ident!("{}Event", name);
@@ -466,20 +465,14 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
         #[doc = #doc_handle]
         #[doc(alias = "handle")]
-        pub struct #handle_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        pub struct #handle_name {
             id: quent_model::uuid::Uuid,
             seq: u64,
             exited: bool,
-            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+            inner: ::std::sync::Arc<quent_model::Observer<#event_type>>,
         }
 
-        impl<E> #handle_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        impl #handle_name {
             #[doc = #doc_handle_uuid]
             pub fn uuid(&self) -> quent_model::uuid::Uuid { self.id }
 
@@ -502,49 +495,37 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 self.inner.send(quent_model::Event::new(
                     self.id,
                     quent_model::timestamp(),
-                    E::from(event),
+                    event,
                 ));
             }
 
             #handle_methods
         }
 
-        impl<E> Drop for #handle_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        impl Drop for #handle_name {
             fn drop(&mut self) { self.exit(); }
         }
 
         #[doc = #doc_observer]
         #[doc(alias = "observer")]
-        pub struct #observer_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        pub struct #observer_name {
+            inner: ::std::sync::Arc<quent_model::Observer<#event_type>>,
         }
 
-        // Cloning shares the underlying observer; `E: Clone` is not required.
-        impl<E> Clone for #observer_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        // Cloning shares the underlying observer.
+        impl Clone for #observer_name {
             fn clone(&self) -> Self {
                 Self { inner: self.inner.clone() }
             }
         }
 
-        impl<E> #observer_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            pub fn new(observer: quent_model::Observer<E>) -> Self {
+        impl #observer_name {
+            pub fn new(observer: quent_model::Observer<#event_type>) -> Self {
                 Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             /// Forward a pre-built event into this entity's stream.
-            pub fn send(&self, event: quent_model::Event<E>) {
+            pub fn send(&self, event: quent_model::Event<#event_type>) {
                 self.inner.send(event);
             }
 

--- a/crates/model-macros/src/lib.rs
+++ b/crates/model-macros/src/lib.rs
@@ -61,7 +61,7 @@ pub fn derive_resizable_resource(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Composes model components into a model type and event enum.
+/// Composes a model's entities into a model type and event enum.
 ///
 /// ```ignore
 /// model! {
@@ -89,10 +89,9 @@ pub fn model(input: TokenStream) -> TokenStream {
 /// This generates `AppContext`, the entry point for instrumenting your
 /// application. To start emitting events:
 ///
-/// 1. Mint the root entity's id: `let cluster_id = Uuid::now_v7();`
-/// 2. Create a context with it: `let ctx = AppContext::try_new(cluster_id, Some(exporter_options))?;`
-/// 3. Get an observer: `let obs = ctx.cluster_observer();`
-/// 4. Declare the root with the same id: `obs.cluster(cluster_id, "my-cluster");`
+/// 1. Create a context: `let ctx = AppContext::try_new(Some(exporter_options))?;`
+/// 2. Get an observer: `let obs = ctx.cluster_observer();`
+/// 3. Declare the root entity with the context id: `obs.cluster(ctx.id(), "my-cluster");`
 ///
 /// For FSMs: the observer's entry method returns a handle for state transitions.
 /// For resources: the observer's `initializing()` method returns a handle for

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -193,6 +193,24 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         })
         .collect();
 
+    // Per-entity observer accessor method names, reused by the router impl.
+    let observer_method_names: Vec<Ident> = variants
+        .iter()
+        .map(|variant| format_ident!("{}_observer", crate::util::to_snake_case(variant)))
+        .collect();
+
+    let feed_arms: Vec<TokenStream> = variants
+        .iter()
+        .zip(observer_method_names.iter())
+        .map(|(variant, method)| {
+            quote! {
+                #event_type::#variant(data) => self.#method().send(
+                    quent_model::Event::new(event.id, event.timestamp, data),
+                ),
+            }
+        })
+        .collect();
+
     let doc_model = format!("Model type alias for {name}.");
     let doc_event = format!("Events emitted by the {name} model.");
     let doc_context = format!(
@@ -290,6 +308,32 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     }
 
                     #(#observer_methods)*
+                }
+
+                // Collector routing for `#context_type`. Kept as a separate
+                // trait impl so the context's inherent API stays a pure
+                // local-production type. Emitted unconditionally for now;
+                // feature-gating it is a future refinement.
+                impl quent_model::CollectorContext for #context_type {
+                    type Event = #event_type;
+
+                    fn with_source_id(
+                        id: quent_model::uuid::Uuid,
+                        exporter: Option<quent_model::exporter::ExporterOptions>,
+                    ) -> Result<Self, Box<dyn std::error::Error>> {
+                        let inner = quent_model::Context::<#event_type>::try_with_id(id, exporter)?;
+                        #(#observer_inits)*
+                        Ok(Self {
+                            #(#observer_fields,)*
+                            _inner: inner,
+                        })
+                    }
+
+                    fn feed(&self, event: quent_model::Event<#event_type>) {
+                        match event.data {
+                            #(#feed_arms)*
+                        }
+                    }
                 }
             };
         }

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -212,13 +212,13 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         .collect();
 
     let doc_model = format!("Model type alias for {name}.");
-    let doc_event = format!("Events emitted by the {name} model.");
+    let doc_event = format!("Event types of the {name} model.");
     let doc_context = format!(
-        "Instrumentation context for the `{name}` model.\n\
+        "Instrumentation context for `{name}`.\n\
          \n\
-         This is the entry point for instrumentation. Create one with \
-         [`Self::try_new()`], then call the `*_observer()` methods to get \
-         observers for each model component."
+         The entry point for instrumentation: create one with \
+         [`Self::try_new()`], then call the `*_observer()` methods to get an \
+         observer per entity."
     );
     let doc_try_new = format!(
         "Create a new {name} instrumentation context.\n\
@@ -310,10 +310,8 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     #(#observer_methods)*
                 }
 
-                // Collector routing for `#context_type`. Kept as a separate
-                // trait impl so the context's inherent API stays a pure
-                // local-production type. Emitted unconditionally for now;
-                // feature-gating it is a future refinement.
+                // Collector routing, kept out of the context's own API.
+                // TODO(jp): gate behind a `collector` feature.
                 impl quent_model::CollectorContext for #context_type {
                     type Event = #event_type;
 

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -165,7 +165,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         .zip(observer_fields.iter())
         .map(|(((variant, obs_type), comp_event), field)| {
             let method_name = format_ident!("{}_observer", crate::util::to_snake_case(variant));
-            let doc_factory = format!("Create an observer for {variant} entities.");
+            let doc_factory = format!("Observer for {variant} entities.");
             quote! {
                 #[doc = #doc_factory]
                 pub fn #method_name(&self) -> #obs_type<#comp_event> {
@@ -175,7 +175,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         })
         .collect();
 
-    // Per-entity observer field declarations and their construction in `try_new`.
+    // Per-entity observer field declarations.
     let observer_field_decls: Vec<TokenStream> = observer_fields
         .iter()
         .zip(observer_types.iter())
@@ -185,32 +185,17 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         })
         .collect();
 
-    let observer_inits: Vec<TokenStream> = observer_fields
-        .iter()
-        .zip(observer_types.iter())
-        .zip(event_types.iter())
-        .map(|((field, obs_type), comp_event)| {
-            quote! { let #field = #obs_type::new(inner.observer::<#comp_event>()?); }
-        })
-        .collect();
-
-    // Per-entity observer accessor method names, reused by the router impl.
-    let observer_method_names: Vec<Ident> = variants
-        .iter()
-        .map(|variant| format_ident!("{}_observer", crate::util::to_snake_case(variant)))
-        .collect();
-
     // One `ingest` arm per entity: match the wire `entity` name against the
     // entity event type's `NAME`, deserialize its `Event`, and route it.
     let ingest_arms: Vec<TokenStream> = event_types
         .iter()
-        .zip(observer_method_names.iter())
-        .map(|(comp_event, method)| {
+        .zip(observer_fields.iter())
+        .map(|(comp_event, field)| {
             quote! {
                 if entity == <#comp_event as quent_model::EntityEvent>::NAME {
                     let e: quent_model::Event<#comp_event> =
                         quent_model::ciborium::from_reader(event)?;
-                    self.#method().send(e);
+                    self.#field.send(e);
                     return Ok(());
                 }
             }
@@ -228,10 +213,24 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
          \n\
          The entry point for instrumentation: create one with \
          [`Self::try_new()`], then call the `*_observer()` methods to get an \
-         observer per entity."
+         observer per entity.\n\
+         \n\
+         # Runtime\n\
+         \n\
+         Construction and drop are synchronous but block the calling thread \
+         while building exporters and flushing them. Call them from outside any \
+         async runtime, or from within a **multi-threaded** Tokio runtime. They \
+         **panic** on a current-thread runtime (`#[tokio::main(flavor = \
+         \"current_thread\")]`), which has no spare thread to make progress \
+         while the caller blocks. The `*_observer()` accessors are cheap and \
+         have no such restriction."
     );
     let doc_try_new = format!(
         "Create a new {name} instrumentation context.\n\
+         \n\
+         Builds every entity's exporter, blocking until they are ready. See the \
+         [type docs](Self) for the runtime restriction (panics on a \
+         current-thread runtime).\n\
          \n\
          # Arguments\n\
          * `exporter` — optional exporter configuration (e.g., ndjson, msgpack). \
@@ -307,25 +306,46 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     pub fn try_new(
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::try_new::<#name>(exporter)?;
-                        #(#observer_inits)*
-                        Ok(Self {
-                            #(#observer_fields,)*
-                            _inner: inner,
-                        })
+                        let inner = quent_model::Context::try_new(exporter)?;
+                        Self::assemble(inner)
                     }
 
                     /// Build a context that adopts an existing `id` instead of
                     /// generating one — e.g. the collector reproducing a remote
-                    /// source's output under that source's id.
+                    /// source's output under that source's id. Same blocking and
+                    /// runtime restriction as [`Self::try_new`].
                     pub fn try_with_id(
                         id: quent_model::uuid::Uuid,
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::try_with_id::<#name>(id, exporter)?;
-                        #(#observer_inits)*
+                        let inner = quent_model::Context::try_with_id(id, exporter)?;
+                        Self::assemble(inner)
+                    }
+
+                    // The single sync/async bridge: build the provenance sidecar
+                    // and every entity observer concurrently on the context's
+                    // runtime, block until all complete, then assemble. Everything
+                    // below this `block_on` is plain async.
+                    fn assemble(
+                        inner: quent_model::Context,
+                    ) -> Result<Self, Box<dyn std::error::Error>> {
+                        let ( #(#observer_fields,)* ) = inner.block_on(async {
+                            let ( _sidecar, #(#observer_fields,)* ) =
+                                quent_model::tokio::try_join!(
+                                    async {
+                                        inner
+                                            .write_sidecar(
+                                                <#name as quent_model::build_info::ModelSource>::model_info(),
+                                            )
+                                            .await;
+                                        Ok::<(), Box<dyn std::error::Error>>(())
+                                    },
+                                    #(inner.observer::<#event_types>(),)*
+                                )?;
+                            Ok::<_, Box<dyn std::error::Error>>(( #(#observer_fields,)* ))
+                        })?;
                         Ok(Self {
-                            #(#observer_fields,)*
+                            #(#observer_fields: #observer_types::new(#observer_fields),)*
                             _inner: inner,
                         })
                     }
@@ -338,7 +358,9 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     #(#observer_methods)*
                 }
 
-                // Collector routing, kept out of the context's own API.
+                // Collector routing, kept out of the context's own API. A
+                // collector factory awaits the `*_observer()` accessors to build
+                // the observers before any `ingest` call reads them.
                 #[cfg(feature = "collector")]
                 impl quent_model::CollectorSink for #context_type {
                     fn ingest(

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -235,6 +235,23 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
          Pass `None` for a no-op context that discards events."
     );
 
+    let doc_import = format!(
+        "Reconstruct the [`{event_type}`] stream for a single context directory.\n\
+         \n\
+         Reads each entity's per-stream subdirectory under `dir` in `format`, \
+         deserializes its events, and chains them. The events carry their own \
+         timestamps, so the analyzer orders them; this does not sort.\n\
+         \n\
+         # Assumption\n\
+         \n\
+         Treats one context directory as the complete telemetry of one model \
+         instance: every process of that instance is assumed to build its context \
+         with the same id and export through the collector, which centralizes \
+         their per-entity streams under that one id. This does not cover the \
+         alternative of lazily loading distributed per-node exports on demand \
+         with no collector at capture time."
+    );
+
     let output = quote! {
         #[doc = #doc_model]
         pub type #model_type = quent_model::Model<#model_tuple>;
@@ -275,6 +292,44 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     option_env!("QUENT_SOURCE_DIRTY"),
                     option_env!("QUENT_SOURCE_BUILT_AT"),
                 )
+            }
+        }
+
+        impl #name {
+            #[doc = #doc_import]
+            pub fn import_events(
+                dir: &std::path::Path,
+                format: quent_model::exporter::FileSystemFormat,
+            ) -> quent_model::exporter::ImporterResult<
+                Box<dyn Iterator<Item = quent_model::Event<#event_type>>>,
+            > {
+                let mut streams: Vec<
+                    Box<dyn Iterator<Item = quent_model::Event<#event_type>>>,
+                > = Vec::new();
+                #(
+                    {
+                        let path =
+                            dir.join(<#event_types as quent_model::EntityEvent>::NAME);
+                        if path.is_dir() {
+                            let importer = quent_model::exporter::create_importer::<#event_types>(
+                                &quent_model::exporter::ImporterOptions::FileSystem(
+                                    quent_model::exporter::FileSystemImporterOptions {
+                                        format,
+                                        path,
+                                    },
+                                ),
+                            )?;
+                            streams.push(Box::new(importer.map(|e| {
+                                quent_model::Event::new(
+                                    e.id,
+                                    e.timestamp,
+                                    #event_type::from(e.data),
+                                )
+                            })));
+                        }
+                    }
+                )*
+                Ok(Box::new(streams.into_iter().flatten()))
             }
         }
 

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -200,9 +200,9 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         .map(|variant| format_ident!("{}_observer", crate::util::to_snake_case(variant)))
         .collect();
 
-    // One `feed` arm per entity: match the wire `entity` name against the
+    // One `ingest` arm per entity: match the wire `entity` name against the
     // entity event type's `NAME`, deserialize its `Event`, and route it.
-    let feed_arms: Vec<TokenStream> = event_types
+    let ingest_arms: Vec<TokenStream> = event_types
         .iter()
         .zip(observer_method_names.iter())
         .map(|(comp_event, method)| {
@@ -315,18 +315,10 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         })
                     }
 
-                    /// Identity of this context, generated on construction.
-                    pub fn id(&self) -> quent_model::uuid::Uuid {
-                        self._inner.id()
-                    }
-
-                    #(#observer_methods)*
-                }
-
-                // Collector routing, kept out of the context's own API.
-                // TODO(jp): gate behind a `collector` feature.
-                impl quent_model::CollectorContext for #context_type {
-                    fn with_source_id(
+                    /// Build a context that adopts an existing `id` instead of
+                    /// generating one — e.g. the collector reproducing a remote
+                    /// source's output under that source's id.
+                    pub fn try_with_id(
                         id: quent_model::uuid::Uuid,
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -338,12 +330,23 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         })
                     }
 
-                    fn feed(
+                    /// Identity of this context, generated on construction.
+                    pub fn id(&self) -> quent_model::uuid::Uuid {
+                        self._inner.id()
+                    }
+
+                    #(#observer_methods)*
+                }
+
+                // Collector routing, kept out of the context's own API.
+                #[cfg(feature = "collector")]
+                impl quent_model::CollectorSink for #context_type {
+                    fn ingest(
                         &self,
                         entity: &str,
                         event: &[u8],
                     ) -> Result<(), Box<dyn std::error::Error>> {
-                        #(#feed_arms)*
+                        #(#ingest_arms)*
                         Err(format!("unknown entity stream `{entity}`").into())
                     }
                 }

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -151,40 +151,46 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         crate::util::to_snake_case(name)
     );
 
-    // One pipeline field per entity, named `<entity>_pipeline`.
-    let pipeline_fields: Vec<Ident> = variants
+    // One observer field per entity, named with the bare entity snake-case name.
+    let observer_fields: Vec<Ident> = variants
         .iter()
-        .map(|variant| format_ident!("{}_pipeline", crate::util::to_snake_case(variant)))
+        .map(|variant| format_ident!("{}", crate::util::to_snake_case(variant)))
         .collect();
 
     let observer_methods: Vec<TokenStream> = variants
         .iter()
         .zip(observer_types.iter())
         .zip(event_types.iter())
-        .zip(pipeline_fields.iter())
-        .map(|(((variant, obs_type), comp_event), pipeline_field)| {
+        .zip(observer_fields.iter())
+        .map(|(((variant, obs_type), comp_event), field)| {
             let method_name = format_ident!("{}_observer", crate::util::to_snake_case(variant));
             let doc_factory = format!("Create an observer for {variant} entities.");
             quote! {
                 #[doc = #doc_factory]
                 pub fn #method_name(&self) -> #obs_type<#comp_event> {
-                    #obs_type::new(&self.#pipeline_field.sender())
+                    self.#field.clone()
                 }
             }
         })
         .collect();
 
-    // Per-entity pipeline declarations and their construction in `try_new`.
-    let pipeline_field_decls: Vec<TokenStream> = pipeline_fields
+    // Per-entity observer field declarations and their construction in `try_new`.
+    let observer_field_decls: Vec<TokenStream> = observer_fields
         .iter()
+        .zip(observer_types.iter())
         .zip(event_types.iter())
-        .map(|(field, comp_event)| quote! { #field: quent_model::Observer<#comp_event> })
+        .map(|((field, obs_type), comp_event)| {
+            quote! { #field: #obs_type<#comp_event> }
+        })
         .collect();
 
-    let pipeline_inits: Vec<TokenStream> = pipeline_fields
+    let observer_inits: Vec<TokenStream> = observer_fields
         .iter()
+        .zip(observer_types.iter())
         .zip(event_types.iter())
-        .map(|(field, comp_event)| quote! { let #field = inner.observer::<#comp_event>()?; })
+        .map(|((field, obs_type), comp_event)| {
+            quote! { let #field = #obs_type::new(inner.observer::<#comp_event>()?); }
+        })
         .collect();
 
     let doc_model = format!("Model type alias for {name}.");
@@ -261,9 +267,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 #[doc = #doc_context]
                 #[doc(alias = "context")]
                 pub struct #context_type {
-                    // Pipelines are declared before `_inner` so they drop first,
-                    // draining and flushing while the runtime is still alive.
-                    #(#pipeline_field_decls,)*
+                    #(#observer_field_decls,)*
                     _inner: quent_model::Context<#event_type>,
                 }
 
@@ -273,9 +277,9 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
                         let inner = quent_model::Context::<#event_type>::try_new(exporter)?;
-                        #(#pipeline_inits)*
+                        #(#observer_inits)*
                         Ok(Self {
-                            #(#pipeline_fields,)*
+                            #(#observer_fields,)*
                             _inner: inner,
                         })
                     }

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -161,14 +161,13 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let observer_methods: Vec<TokenStream> = variants
         .iter()
         .zip(observer_types.iter())
-        .zip(event_types.iter())
         .zip(observer_fields.iter())
-        .map(|(((variant, obs_type), comp_event), field)| {
+        .map(|((variant, obs_type), field)| {
             let method_name = format_ident!("{}_observer", crate::util::to_snake_case(variant));
             let doc_factory = format!("Observer for {variant} entities.");
             quote! {
                 #[doc = #doc_factory]
-                pub fn #method_name(&self) -> #obs_type<#comp_event> {
+                pub fn #method_name(&self) -> #obs_type {
                     self.#field.clone()
                 }
             }
@@ -179,9 +178,8 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     let observer_field_decls: Vec<TokenStream> = observer_fields
         .iter()
         .zip(observer_types.iter())
-        .zip(event_types.iter())
-        .map(|((field, obs_type), comp_event)| {
-            quote! { #field: #obs_type<#comp_event> }
+        .map(|(field, obs_type)| {
+            quote! { #field: #obs_type }
         })
         .collect();
 

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -359,7 +359,10 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     pub fn try_new(
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::try_new(exporter)?;
+                        let inner = quent_model::Context::try_new(
+                            <#name as quent_model::build_info::ModelSource>::model_info(),
+                            exporter,
+                        )?;
                         Self::assemble(inner)
                     }
 
@@ -371,28 +374,24 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         id: quent_model::uuid::Uuid,
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::try_with_id(id, exporter)?;
+                        let inner = quent_model::Context::try_with_id(
+                            id,
+                            <#name as quent_model::build_info::ModelSource>::model_info(),
+                            exporter,
+                        )?;
                         Self::assemble(inner)
                     }
 
-                    // The single sync/async bridge: build the provenance sidecar
-                    // and every entity observer concurrently on the context's
-                    // runtime, block until all complete, then assemble. Everything
-                    // below this `block_on` is plain async.
+                    // The single sync/async bridge: build every entity observer
+                    // concurrently on the context's runtime, block until all
+                    // complete, then assemble. Everything below this `block_on`
+                    // is plain async.
                     fn assemble(
                         inner: quent_model::Context,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
                         let ( #(#observer_fields,)* ) = inner.block_on(async {
-                            let ( _sidecar, #(#observer_fields,)* ) =
+                            let ( #(#observer_fields,)* ) =
                                 quent_model::tokio::try_join!(
-                                    async {
-                                        inner
-                                            .write_sidecar(
-                                                <#name as quent_model::build_info::ModelSource>::model_info(),
-                                            )
-                                            .await;
-                                        Ok::<(), Box<dyn std::error::Error>>(())
-                                    },
                                     #(inner.observer::<#event_types>(),)*
                                 )?;
                             Ok::<_, Box<dyn std::error::Error>>(( #(#observer_fields,)* ))

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -299,7 +299,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 #[doc(alias = "context")]
                 pub struct #context_type {
                     #(#observer_field_decls,)*
-                    _inner: quent_model::Context<#name>,
+                    _inner: quent_model::Context,
                 }
 
                 impl #context_type {
@@ -307,7 +307,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     pub fn try_new(
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::<#name>::try_new(exporter)?;
+                        let inner = quent_model::Context::try_new::<#name>(exporter)?;
                         #(#observer_inits)*
                         Ok(Self {
                             #(#observer_fields,)*
@@ -322,7 +322,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         id: quent_model::uuid::Uuid,
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::<#name>::try_with_id(id, exporter)?;
+                        let inner = quent_model::Context::try_with_id::<#name>(id, exporter)?;
                         #(#observer_inits)*
                         Ok(Self {
                             #(#observer_fields,)*

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -151,19 +151,40 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         crate::util::to_snake_case(name)
     );
 
+    // One pipeline field per entity, named `<entity>_pipeline`.
+    let pipeline_fields: Vec<Ident> = variants
+        .iter()
+        .map(|variant| format_ident!("{}_pipeline", crate::util::to_snake_case(variant)))
+        .collect();
+
     let observer_methods: Vec<TokenStream> = variants
         .iter()
         .zip(observer_types.iter())
-        .map(|(variant, obs_type)| {
+        .zip(event_types.iter())
+        .zip(pipeline_fields.iter())
+        .map(|(((variant, obs_type), comp_event), pipeline_field)| {
             let method_name = format_ident!("{}_observer", crate::util::to_snake_case(variant));
             let doc_factory = format!("Create an observer for {variant} entities.");
             quote! {
                 #[doc = #doc_factory]
-                pub fn #method_name(&self) -> #obs_type<#event_type> {
-                    #obs_type::new(&self.tx)
+                pub fn #method_name(&self) -> #obs_type<#comp_event> {
+                    #obs_type::new(&self.#pipeline_field.sender())
                 }
             }
         })
+        .collect();
+
+    // Per-entity pipeline declarations and their construction in `try_new`.
+    let pipeline_field_decls: Vec<TokenStream> = pipeline_fields
+        .iter()
+        .zip(event_types.iter())
+        .map(|(field, comp_event)| quote! { #field: quent_model::Observer<#comp_event> })
+        .collect();
+
+    let pipeline_inits: Vec<TokenStream> = pipeline_fields
+        .iter()
+        .zip(event_types.iter())
+        .map(|(field, comp_event)| quote! { let #field = inner.observer::<#comp_event>()?; })
         .collect();
 
     let doc_model = format!("Model type alias for {name}.");
@@ -240,8 +261,10 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 #[doc = #doc_context]
                 #[doc(alias = "context")]
                 pub struct #context_type {
+                    // Pipelines are declared before `_inner` so they drop first,
+                    // draining and flushing while the runtime is still alive.
+                    #(#pipeline_field_decls,)*
                     _inner: quent_model::Context<#event_type>,
-                    tx: quent_model::EventSender<#event_type>,
                 }
 
                 impl #context_type {
@@ -249,9 +272,12 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     pub fn try_new(
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::try_new(exporter)?;
-                        let tx = inner.events_sender();
-                        Ok(Self { _inner: inner, tx })
+                        let inner = quent_model::Context::<#event_type>::try_new(exporter)?;
+                        #(#pipeline_inits)*
+                        Ok(Self {
+                            #(#pipeline_fields,)*
+                            _inner: inner,
+                        })
                     }
 
                     /// Identity of this context, generated on construction.

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -15,7 +15,8 @@
 //! }
 //! ```
 //!
-//! Generates `SimulatorModel` (type alias) and `SimulatorEvent` (event enum).
+//! Generates `SimulatorModel` (type alias), `SimulatorEvent` (event enum), and
+//! `Simulator` (the model marker carrying provenance).
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
@@ -199,20 +200,29 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         .map(|variant| format_ident!("{}_observer", crate::util::to_snake_case(variant)))
         .collect();
 
-    let feed_arms: Vec<TokenStream> = variants
+    // One `feed` arm per entity: match the wire `entity` name against the
+    // entity event type's `NAME`, deserialize its `Event`, and route it.
+    let feed_arms: Vec<TokenStream> = event_types
         .iter()
         .zip(observer_method_names.iter())
-        .map(|(variant, method)| {
+        .map(|(comp_event, method)| {
             quote! {
-                #event_type::#variant(data) => self.#method().send(
-                    quent_model::Event::new(event.id, event.timestamp, data),
-                ),
+                if entity == <#comp_event as quent_model::EntityEvent>::NAME {
+                    let e: quent_model::Event<#comp_event> =
+                        quent_model::ciborium::from_reader(event)?;
+                    self.#method().send(e);
+                    return Ok(());
+                }
             }
         })
         .collect();
 
     let doc_model = format!("Model type alias for {name}.");
     let doc_event = format!("Event types of the {name} model.");
+    let doc_marker = format!(
+        "Marker type for the {name} model. Carries the model's provenance via \
+         its [`ModelSource`](quent_model::build_info::ModelSource) impl."
+    );
     let doc_context = format!(
         "Instrumentation context for `{name}`.\n\
          \n\
@@ -247,12 +257,15 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
             }
         )*
 
+        #[doc = #doc_marker]
+        pub struct #name;
+
         // Records this model's package and source git so exporters can trace an
         // artifact back to the crate that defines it — including out-of-repo
         // crates, whose own `build.rs` populates `QUENT_SOURCE_*` (in-repo it
         // falls back to quent's git). `env!`/`option_env!` resolve in the crate
         // that invokes `model!`. The type path and name come from `type_name`.
-        impl quent_model::build_info::ModelSource for #event_type {
+        impl quent_model::build_info::ModelSource for #name {
             fn package() -> &'static str {
                 env!("CARGO_PKG_NAME")
             }
@@ -286,7 +299,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 #[doc(alias = "context")]
                 pub struct #context_type {
                     #(#observer_field_decls,)*
-                    _inner: quent_model::Context<#event_type>,
+                    _inner: quent_model::Context<#name>,
                 }
 
                 impl #context_type {
@@ -294,7 +307,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     pub fn try_new(
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::<#event_type>::try_new(exporter)?;
+                        let inner = quent_model::Context::<#name>::try_new(exporter)?;
                         #(#observer_inits)*
                         Ok(Self {
                             #(#observer_fields,)*
@@ -313,13 +326,11 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                 // Collector routing, kept out of the context's own API.
                 // TODO(jp): gate behind a `collector` feature.
                 impl quent_model::CollectorContext for #context_type {
-                    type Event = #event_type;
-
                     fn with_source_id(
                         id: quent_model::uuid::Uuid,
                         exporter: Option<quent_model::exporter::ExporterOptions>,
                     ) -> Result<Self, Box<dyn std::error::Error>> {
-                        let inner = quent_model::Context::<#event_type>::try_with_id(id, exporter)?;
+                        let inner = quent_model::Context::<#name>::try_with_id(id, exporter)?;
                         #(#observer_inits)*
                         Ok(Self {
                             #(#observer_fields,)*
@@ -327,10 +338,13 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         })
                     }
 
-                    fn feed(&self, event: quent_model::Event<#event_type>) {
-                        match event.data {
-                            #(#feed_arms)*
-                        }
+                    fn feed(
+                        &self,
+                        entity: &str,
+                        event: &[u8],
+                    ) -> Result<(), Box<dyn std::error::Error>> {
+                        #(#feed_arms)*
+                        Err(format!("unknown entity stream `{entity}`").into())
                     }
                 }
             };

--- a/crates/model-macros/src/resource_derive.rs
+++ b/crates/model-macros/src/resource_derive.rs
@@ -834,6 +834,11 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
                 Self { inner: ::std::sync::Arc::new(observer) }
             }
 
+            /// Forward a pre-built event into this entity's stream.
+            pub fn send(&self, event: quent_model::Event<E>) {
+                self.inner.send(event);
+            }
+
             #[doc = #doc_observer_init]
             pub fn initializing(&self, id: quent_model::uuid::Uuid, instance_name: &str, parent_group_id: quent_model::uuid::Uuid, #(#user_init_param_defs,)*) -> #handle_name<E> {
                 let state = #init_state {

--- a/crates/model-macros/src/resource_derive.rs
+++ b/crates/model-macros/src/resource_derive.rs
@@ -809,20 +809,29 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
 
         #[doc = #doc_observer]
         #[doc(alias = "observer")]
-        #[derive(Clone)]
         #vis struct #observer_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            tx: quent_model::EventSender<E>,
+            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        }
+
+        // Cloning shares the underlying observer; `E: Clone` is not required.
+        impl<E> Clone for #observer_name<E>
+        where
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
+        {
+            fn clone(&self) -> Self {
+                Self { inner: self.inner.clone() }
+            }
         }
 
         impl<E> #observer_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
-            pub fn new(tx: &quent_model::EventSender<E>) -> Self {
-                Self { tx: tx.clone() }
+            pub fn new(observer: quent_model::Observer<E>) -> Self {
+                Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             #[doc = #doc_observer_init]
@@ -833,7 +842,7 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
                     resource_type_name: #name_snake.to_string(),
                     #(#user_init_field_names,)*
                 };
-                let mut handle = #handle_name { id, seq: 0, exited: false, tx: self.tx.clone() };
+                let mut handle = #handle_name { id, seq: 0, exited: false, inner: self.inner.clone() };
                 handle.emit_transition(#transition_enum::from(state));
                 handle
             }
@@ -843,17 +852,17 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
         #[doc(alias = "handle")]
         #vis struct #handle_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             id: quent_model::uuid::Uuid,
             seq: u64,
             exited: bool,
-            tx: quent_model::EventSender<E>,
+            inner: ::std::sync::Arc<quent_model::Observer<E>>,
         }
 
         impl<E> #handle_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             #[doc = #doc_handle_uuid]
             pub fn uuid(&self) -> quent_model::uuid::Uuid { self.id }
@@ -876,7 +885,7 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
                 let seq = self.seq;
                 self.seq += 1;
                 let event = quent_model::FsmEvent { seq, state };
-                self.tx.send(quent_model::Event::new(
+                self.inner.send(quent_model::Event::new(
                     self.id,
                     quent_model::timestamp(),
                     E::from(event),
@@ -886,14 +895,14 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
 
         impl<E> Drop for #handle_name<E>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             fn drop(&mut self) { self.exit(); }
         }
 
         impl<E> From<&#handle_name<E>> for quent_model::Ref<#resource_marker>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             fn from(handle: &#handle_name<E>) -> Self {
                 quent_model::Ref::new(handle.uuid())
@@ -902,7 +911,7 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
 
         impl<E> From<&#handle_name<E>> for quent_model::Ref<#name>
         where
-            E: From<#event_type> #serde_bound + Send + 'static,
+            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
         {
             fn from(handle: &#handle_name<E>) -> Self {
                 quent_model::Ref::new(handle.uuid())

--- a/crates/model-macros/src/resource_derive.rs
+++ b/crates/model-macros/src/resource_derive.rs
@@ -219,7 +219,6 @@ fn emit_operating_conversions(name: &proc_macro2::Ident, fields: &ResourceFields
 fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> {
     let serde_derives = crate::util::serde_derives();
     let serde_crate_attr = crate::util::serde_crate_attr();
-    let serde_bound = crate::util::serde_bound();
     let vis = &input.vis;
     let name = &input.ident;
     let name_snake = to_snake_case(name);
@@ -806,38 +805,29 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
 
         #[doc = #doc_observer]
         #[doc(alias = "observer")]
-        #vis struct #observer_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+        #vis struct #observer_name {
+            inner: ::std::sync::Arc<quent_model::Observer<#event_type>>,
         }
 
-        // Cloning shares the underlying observer; `E: Clone` is not required.
-        impl<E> Clone for #observer_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        // Cloning shares the underlying observer.
+        impl Clone for #observer_name {
             fn clone(&self) -> Self {
                 Self { inner: self.inner.clone() }
             }
         }
 
-        impl<E> #observer_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            pub fn new(observer: quent_model::Observer<E>) -> Self {
+        impl #observer_name {
+            pub fn new(observer: quent_model::Observer<#event_type>) -> Self {
                 Self { inner: ::std::sync::Arc::new(observer) }
             }
 
             /// Forward a pre-built event into this entity's stream.
-            pub fn send(&self, event: quent_model::Event<E>) {
+            pub fn send(&self, event: quent_model::Event<#event_type>) {
                 self.inner.send(event);
             }
 
             #[doc = #doc_observer_init]
-            pub fn initializing(&self, id: quent_model::uuid::Uuid, instance_name: &str, parent_group_id: quent_model::uuid::Uuid, #(#user_init_param_defs,)*) -> #handle_name<E> {
+            pub fn initializing(&self, id: quent_model::uuid::Uuid, instance_name: &str, parent_group_id: quent_model::uuid::Uuid, #(#user_init_param_defs,)*) -> #handle_name {
                 let state = #init_state {
                     instance_name: instance_name.to_string(),
                     parent_group_id,
@@ -852,20 +842,14 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
 
         #[doc = #doc_handle]
         #[doc(alias = "handle")]
-        #vis struct #handle_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        #vis struct #handle_name {
             id: quent_model::uuid::Uuid,
             seq: u64,
             exited: bool,
-            inner: ::std::sync::Arc<quent_model::Observer<E>>,
+            inner: ::std::sync::Arc<quent_model::Observer<#event_type>>,
         }
 
-        impl<E> #handle_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        impl #handle_name {
             #[doc = #doc_handle_uuid]
             pub fn uuid(&self) -> quent_model::uuid::Uuid { self.id }
 
@@ -890,32 +874,23 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
                 self.inner.send(quent_model::Event::new(
                     self.id,
                     quent_model::timestamp(),
-                    E::from(event),
+                    event,
                 ));
             }
         }
 
-        impl<E> Drop for #handle_name<E>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
+        impl Drop for #handle_name {
             fn drop(&mut self) { self.exit(); }
         }
 
-        impl<E> From<&#handle_name<E>> for quent_model::Ref<#resource_marker>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            fn from(handle: &#handle_name<E>) -> Self {
+        impl From<&#handle_name> for quent_model::Ref<#resource_marker> {
+            fn from(handle: &#handle_name) -> Self {
                 quent_model::Ref::new(handle.uuid())
             }
         }
 
-        impl<E> From<&#handle_name<E>> for quent_model::Ref<#name>
-        where
-            E: From<#event_type> #serde_bound + Send + quent_model::EntityEvent + 'static,
-        {
-            fn from(handle: &#handle_name<E>) -> Self {
+        impl From<&#handle_name> for quent_model::Ref<#name> {
+            fn from(handle: &#handle_name) -> Self {
                 quent_model::Ref::new(handle.uuid())
             }
         }

--- a/crates/model-macros/src/resource_derive.rs
+++ b/crates/model-macros/src/resource_derive.rs
@@ -232,7 +232,9 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
     let resize_state = format_ident!("{}Resizing", name);
     let transition_enum = format_ident!("{}Transition", name);
     let event_type = format_ident!("{}Event", name);
-    let event_name = event_type.to_string();
+    // The stream name (exporter subdirectory, collector wire tag, ingest key) is
+    // the entity's snake-case name.
+    let event_name = name_snake.clone();
     let handle_name = format_ident!("{}Handle", name);
     let observer_name = format_ident!("{}Observer", name);
     let resource_marker = format_ident!("{}Resource", name);

--- a/crates/model-macros/src/resource_derive.rs
+++ b/crates/model-macros/src/resource_derive.rs
@@ -707,12 +707,9 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
     let doc_handle_uuid = format!("Returns the UUID of this {name} resource instance.");
     let doc_handle_exit = format!("Transition the {name} resource FSM to the exit state.");
     let doc_observer = format!(
-        "Observer for `{name}` resource lifecycle events.\n\n\
-         An observer emits events for a model component. Obtain one from the \
-         instrumentation context via the corresponding observer method. \
-         Call `initializing()` to create a resource handle.\n\n\
-         The type parameter `E` is the model's top-level event enum, allowing \
-         the same component to be reused across different models."
+        "Observer for `{name}` resource lifecycle events. Obtain it from the \
+         instrumentation context via the corresponding observer method; call \
+         `initializing()` to create a resource handle."
     );
     let doc_observer_init = format!("Create a new `{name}` resource in the initializing state.");
     let doc_resource_marker = format!("Resource marker type for {name}.");

--- a/crates/model-macros/src/resource_derive.rs
+++ b/crates/model-macros/src/resource_derive.rs
@@ -233,6 +233,7 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
     let resize_state = format_ident!("{}Resizing", name);
     let transition_enum = format_ident!("{}Transition", name);
     let event_type = format_ident!("{}Event", name);
+    let event_name = event_type.to_string();
     let handle_name = format_ident!("{}Handle", name);
     let observer_name = format_ident!("{}Observer", name);
     let resource_marker = format_ident!("{}Resource", name);
@@ -770,6 +771,12 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
 
         #[doc = #doc_event]
         #vis type #event_type = quent_model::FsmEvent<#transition_enum>;
+
+        // The transition enum carries the resource's event-stream name; a blanket
+        // impl on `FsmEvent<S>` forwards it (the alias is over a foreign type).
+        impl quent_model::EntityEvent for #transition_enum {
+            const NAME: &'static str = #event_name;
+        }
 
         impl quent_model::HasEventType for #name {
             type Event = quent_model::FsmEvent<#transition_enum>;

--- a/crates/model-macros/src/state_macro.rs
+++ b/crates/model-macros/src/state_macro.rs
@@ -339,7 +339,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         #[doc(hidden)]
         #[macro_export]
         macro_rules! #callback_name {
-            (entry_method $vis:vis $handle:ident $transition:ident $observer_tx:ident) => {
+            (entry_method $vis:vis $handle:ident $transition:ident $observer_inner:ident) => {
                 $vis fn #entry_alias(
                     &self,
                     id: quent_model::uuid::Uuid,
@@ -354,7 +354,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                         id,
                         seq: 0,
                         exited: false,
-                        tx: self.$observer_tx.clone(),
+                        inner: self.$observer_inner.clone(),
                     };
                     handle.emit_transition($transition::from(state));
                     handle

--- a/crates/model-macros/src/state_macro.rs
+++ b/crates/model-macros/src/state_macro.rs
@@ -345,7 +345,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     id: quent_model::uuid::Uuid,
                     #(#attrs_params)*
                     #(#usage_params)*
-                ) -> $handle<E> {
+                ) -> $handle {
                     let state = #name {
                         #(#attrs_field_inits)*
                         #(#usage_field_inits)*

--- a/crates/model-macros/src/util.rs
+++ b/crates/model-macros/src/util.rs
@@ -16,16 +16,6 @@ pub fn serde_derives() -> TokenStream {
     }
 }
 
-/// Returns `+ quent_model::serde::Serialize` trait bound when the `serde`
-/// feature is enabled, or empty tokens otherwise.
-pub fn serde_bound() -> TokenStream {
-    if cfg!(feature = "serde") {
-        quote! { + quent_model::serde::Serialize }
-    } else {
-        quote! {}
-    }
-}
-
 /// Returns `#[serde(crate = "quent_model::serde")]` when the `serde` feature
 /// is enabled. Tells the serde derive macros where to find the serde runtime.
 pub fn serde_crate_attr() -> TokenStream {

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -11,6 +11,7 @@ serde = ["dep:serde", "quent-model-macros/serde", "uuid/serde"]
 [dependencies]
 uuid = { workspace = true, features = ["v7"] }
 serde = { workspace = true, optional = true }
+ciborium = "0.2.2"
 quent-attributes = { path = "../attributes" }
 quent-build-info = { path = "../build-info" }
 quent-model-macros = { path = "../model-macros" }

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -7,8 +7,10 @@ publish.workspace = true
 [features]
 default = ["serde"]
 serde = ["dep:serde", "quent-model-macros/serde", "uuid/serde"]
+collector = ["dep:quent-collector-client"]
 
 [dependencies]
+quent-collector-client = { path = "../collector/client", optional = true }
 uuid = { workspace = true, features = ["v7"] }
 serde = { workspace = true, optional = true }
 ciborium = "0.2.2"

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -21,6 +21,7 @@ quent-events = { path = "../events" }
 quent-exporter = { path = "../exporter" }
 quent-instrumentation = { path = "../instrumentation" }
 quent-time = { path = "../time" }
+tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]
 quent-stdlib = { path = "../stdlib" }

--- a/crates/model/src/fsm_event.rs
+++ b/crates/model/src/fsm_event.rs
@@ -20,3 +20,13 @@ pub struct FsmEvent<S> {
     /// The state being entered and its attributes.
     pub state: S,
 }
+
+// An FSM's event stream is named after its transition set. `FsmEvent` is foreign
+// to the crate that defines an FSM, so its transition enum (which is local
+// there) carries the name and this blanket forwards it.
+impl<S> quent_events::EntityEvent for FsmEvent<S>
+where
+    S: quent_events::EntityEvent,
+{
+    const NAME: &'static str = S::NAME;
+}

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -83,6 +83,7 @@ pub trait ResourceGroup {
 }
 
 // Re-export instrumentation types needed by generated code.
+pub use ciborium;
 pub use quent_attributes as attributes;
 pub use quent_build_info as build_info;
 pub use quent_events::{EntityEvent, Event};

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -89,7 +89,7 @@ pub use quent_events::{EntityEvent, Event};
 pub use quent_exporter as exporter;
 #[doc(hidden)]
 pub use quent_instrumentation::EventSender;
-pub use quent_instrumentation::{Context, Observer};
+pub use quent_instrumentation::{CollectorContext, Context, Observer};
 pub use quent_time::timestamp;
 #[cfg(feature = "serde")]
 pub use serde;

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -82,7 +82,7 @@ pub trait ResourceGroup {
     const IS_ROOT: bool = false;
 }
 
-// Re-export instrumentation types needed by generated code.
+// Re-exports referenced by generated instrumentation code and by model consumers.
 pub use ciborium;
 pub use quent_attributes as attributes;
 pub use quent_build_info as build_info;
@@ -90,10 +90,10 @@ pub use quent_build_info as build_info;
 pub use quent_collector_client::CollectorSink;
 pub use quent_events::{EntityEvent, Event};
 pub use quent_exporter as exporter;
-#[doc(hidden)]
-pub use quent_instrumentation::EventSender;
 pub use quent_instrumentation::{Context, Observer};
 pub use quent_time::timestamp;
 #[cfg(feature = "serde")]
 pub use serde;
+#[doc(hidden)]
+pub use tokio;
 pub use uuid;

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -85,11 +85,11 @@ pub trait ResourceGroup {
 // Re-export instrumentation types needed by generated code.
 pub use quent_attributes as attributes;
 pub use quent_build_info as build_info;
-pub use quent_events::Event;
+pub use quent_events::{EntityEvent, Event};
 pub use quent_exporter as exporter;
-pub use quent_instrumentation::Context;
 #[doc(hidden)]
 pub use quent_instrumentation::EventSender;
+pub use quent_instrumentation::{Context, Observer};
 pub use quent_time::timestamp;
 #[cfg(feature = "serde")]
 pub use serde;

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -86,11 +86,13 @@ pub trait ResourceGroup {
 pub use ciborium;
 pub use quent_attributes as attributes;
 pub use quent_build_info as build_info;
+#[cfg(feature = "collector")]
+pub use quent_collector_client::CollectorSink;
 pub use quent_events::{EntityEvent, Event};
 pub use quent_exporter as exporter;
 #[doc(hidden)]
 pub use quent_instrumentation::EventSender;
-pub use quent_instrumentation::{CollectorContext, Context, Observer};
+pub use quent_instrumentation::{Context, Observer};
 pub use quent_time::timestamp;
 #[cfg(feature = "serde")]
 pub use serde;

--- a/crates/model/tests/fsm_macro.rs
+++ b/crates/model/tests/fsm_macro.rs
@@ -3,11 +3,12 @@
 
 //! Integration test for the `fsm!` proc macro.
 
+use quent_model::build_info::ModelInfo;
 use quent_model::{Context, FsmEvent, ModelBuilder, ModelComponent, Observer, StateMetadata};
 use uuid::Uuid;
 
 fn noop_task_observer() -> Observer<TaskEvent> {
-    let ctx = Context::try_new(None).unwrap();
+    let ctx = Context::try_new(ModelInfo::unknown(), None).unwrap();
     ctx.block_on(ctx.observer::<TaskEvent>()).unwrap()
 }
 

--- a/crates/model/tests/fsm_macro.rs
+++ b/crates/model/tests/fsm_macro.rs
@@ -6,30 +6,9 @@
 use quent_model::{Context, FsmEvent, ModelBuilder, ModelComponent, Observer, StateMetadata};
 use uuid::Uuid;
 
-/// Umbrella model event used only to obtain a no-op [`Context`] in tests.
-#[derive(serde::Serialize)]
-struct TestModel(TaskEvent);
-
-impl From<TaskEvent> for TestModel {
-    fn from(e: TaskEvent) -> Self {
-        TestModel(e)
-    }
-}
-
-impl quent_model::build_info::ModelSource for TestModel {
-    fn package() -> &'static str {
-        "quent-model"
-    }
-    fn source() -> quent_model::build_info::BuildInfo {
-        quent_model::build_info::BuildInfo::unknown()
-    }
-}
-
 fn noop_task_observer() -> Observer<TaskEvent> {
-    Context::try_new::<TestModel>(None)
-        .unwrap()
-        .observer::<TaskEvent>()
-        .unwrap()
+    let ctx = Context::try_new(None).unwrap();
+    ctx.block_on(ctx.observer::<TaskEvent>()).unwrap()
 }
 
 // States via state! macro

--- a/crates/model/tests/fsm_macro.rs
+++ b/crates/model/tests/fsm_macro.rs
@@ -26,7 +26,7 @@ impl quent_model::build_info::ModelSource for TestModel {
 }
 
 fn noop_task_observer() -> Observer<TaskEvent> {
-    Context::<TestModel>::try_new(None)
+    Context::try_new::<TestModel>(None)
         .unwrap()
         .observer::<TaskEvent>()
         .unwrap()

--- a/crates/model/tests/fsm_macro.rs
+++ b/crates/model/tests/fsm_macro.rs
@@ -6,8 +6,15 @@
 use quent_model::{Context, FsmEvent, ModelBuilder, ModelComponent, Observer, StateMetadata};
 use uuid::Uuid;
 
-/// Model marker used only to obtain a no-op [`Context`] in tests.
-struct TestModel;
+/// Umbrella model event used only to obtain a no-op [`Context`] in tests.
+#[derive(serde::Serialize)]
+struct TestModel(TaskEvent);
+
+impl From<TaskEvent> for TestModel {
+    fn from(e: TaskEvent) -> Self {
+        TestModel(e)
+    }
+}
 
 impl quent_model::build_info::ModelSource for TestModel {
     fn package() -> &'static str {

--- a/crates/model/tests/fsm_macro.rs
+++ b/crates/model/tests/fsm_macro.rs
@@ -3,8 +3,27 @@
 
 //! Integration test for the `fsm!` proc macro.
 
-use quent_model::{EventSender, FsmEvent, ModelBuilder, ModelComponent, StateMetadata};
+use quent_model::{Context, FsmEvent, ModelBuilder, ModelComponent, Observer, StateMetadata};
 use uuid::Uuid;
+
+/// Model marker used only to obtain a no-op [`Context`] in tests.
+struct TestModel;
+
+impl quent_model::build_info::ModelSource for TestModel {
+    fn package() -> &'static str {
+        "quent-model"
+    }
+    fn source() -> quent_model::build_info::BuildInfo {
+        quent_model::build_info::BuildInfo::unknown()
+    }
+}
+
+fn noop_task_observer() -> Observer<TaskEvent> {
+    Context::<TestModel>::try_new(None)
+        .unwrap()
+        .observer::<TaskEvent>()
+        .unwrap()
+}
 
 // States via state! macro
 
@@ -93,8 +112,7 @@ fn state_metadata() {
 
 #[test]
 fn observer_entry_method() {
-    let tx: EventSender<TaskEvent> = EventSender::default();
-    let observer = TaskObserver::new(&tx);
+    let observer = TaskObserver::new(noop_task_observer());
     let id = Uuid::nil();
     let mut handle = observer.queued(id, "my_task", 5);
     assert_eq!(handle.uuid(), id);
@@ -103,8 +121,7 @@ fn observer_entry_method() {
 
 #[test]
 fn handle_transition_method() {
-    let tx: EventSender<TaskEvent> = EventSender::default();
-    let observer = TaskObserver::new(&tx);
+    let observer = TaskObserver::new(noop_task_observer());
     let id = Uuid::nil();
     let mut handle = observer.queued(id, "my_task", 5);
     handle.running("my_task", Uuid::nil());

--- a/crates/model/tests/state_macro.rs
+++ b/crates/model/tests/state_macro.rs
@@ -6,8 +6,15 @@
 use quent_model::{Context, ModelBuilder, ModelComponent, Observer, Ref, StateMetadata};
 use uuid::Uuid;
 
-/// Model marker used only to obtain a no-op [`Context`] in tests.
-struct TestModel;
+/// Umbrella model event used only to obtain a no-op [`Context`] in tests.
+#[derive(serde::Serialize)]
+struct TestModel(TaskEvent);
+
+impl From<TaskEvent> for TestModel {
+    fn from(e: TaskEvent) -> Self {
+        TestModel(e)
+    }
+}
 
 impl quent_model::build_info::ModelSource for TestModel {
     fn package() -> &'static str {

--- a/crates/model/tests/state_macro.rs
+++ b/crates/model/tests/state_macro.rs
@@ -3,8 +3,27 @@
 
 //! Integration test for the `state!` proc macro with flat-arg FSM methods.
 
-use quent_model::{EventSender, ModelBuilder, ModelComponent, Ref, StateMetadata};
+use quent_model::{Context, ModelBuilder, ModelComponent, Observer, Ref, StateMetadata};
 use uuid::Uuid;
+
+/// Model marker used only to obtain a no-op [`Context`] in tests.
+struct TestModel;
+
+impl quent_model::build_info::ModelSource for TestModel {
+    fn package() -> &'static str {
+        "quent-model"
+    }
+    fn source() -> quent_model::build_info::BuildInfo {
+        quent_model::build_info::BuildInfo::unknown()
+    }
+}
+
+fn noop_task_observer() -> Observer<TaskEvent> {
+    Context::<TestModel>::try_new(None)
+        .unwrap()
+        .observer::<TaskEvent>()
+        .unwrap()
+}
 
 // States defined with state! macro.
 // Inline attributes auto-add `instance_name: String`.
@@ -110,8 +129,7 @@ fn fsm_model_component() {
 
 #[test]
 fn flat_args_observer_entry() {
-    let tx: EventSender<TaskEvent> = EventSender::default();
-    let observer = TaskObserver::new(&tx);
+    let observer = TaskObserver::new(noop_task_observer());
     let id = Uuid::nil();
 
     let mut handle = observer.queued(id, "my_task", 5);
@@ -121,8 +139,7 @@ fn flat_args_observer_entry() {
 
 #[test]
 fn flat_args_handle_transition() {
-    let tx: EventSender<TaskEvent> = EventSender::default();
-    let observer = TaskObserver::new(&tx);
+    let observer = TaskObserver::new(noop_task_observer());
     let id = Uuid::nil();
 
     let mut handle = observer.queued(id, "my_task", 5);

--- a/crates/model/tests/state_macro.rs
+++ b/crates/model/tests/state_macro.rs
@@ -3,11 +3,12 @@
 
 //! Integration test for the `state!` proc macro with flat-arg FSM methods.
 
+use quent_model::build_info::ModelInfo;
 use quent_model::{Context, ModelBuilder, ModelComponent, Observer, Ref, StateMetadata};
 use uuid::Uuid;
 
 fn noop_task_observer() -> Observer<TaskEvent> {
-    let ctx = Context::try_new(None).unwrap();
+    let ctx = Context::try_new(ModelInfo::unknown(), None).unwrap();
     ctx.block_on(ctx.observer::<TaskEvent>()).unwrap()
 }
 

--- a/crates/model/tests/state_macro.rs
+++ b/crates/model/tests/state_macro.rs
@@ -6,30 +6,9 @@
 use quent_model::{Context, ModelBuilder, ModelComponent, Observer, Ref, StateMetadata};
 use uuid::Uuid;
 
-/// Umbrella model event used only to obtain a no-op [`Context`] in tests.
-#[derive(serde::Serialize)]
-struct TestModel(TaskEvent);
-
-impl From<TaskEvent> for TestModel {
-    fn from(e: TaskEvent) -> Self {
-        TestModel(e)
-    }
-}
-
-impl quent_model::build_info::ModelSource for TestModel {
-    fn package() -> &'static str {
-        "quent-model"
-    }
-    fn source() -> quent_model::build_info::BuildInfo {
-        quent_model::build_info::BuildInfo::unknown()
-    }
-}
-
 fn noop_task_observer() -> Observer<TaskEvent> {
-    Context::try_new::<TestModel>(None)
-        .unwrap()
-        .observer::<TaskEvent>()
-        .unwrap()
+    let ctx = Context::try_new(None).unwrap();
+    ctx.block_on(ctx.observer::<TaskEvent>()).unwrap()
 }
 
 // States defined with state! macro.

--- a/crates/model/tests/state_macro.rs
+++ b/crates/model/tests/state_macro.rs
@@ -26,7 +26,7 @@ impl quent_model::build_info::ModelSource for TestModel {
 }
 
 fn noop_task_observer() -> Observer<TaskEvent> {
-    Context::<TestModel>::try_new(None)
+    Context::try_new::<TestModel>(None)
         .unwrap()
         .observer::<TaskEvent>()
         .unwrap()

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,4 +1,0 @@
-*.ndjson
-*.dot
-*.msgpack
-*.postcard

--- a/domains/query_engine/analyzer/src/model.rs
+++ b/domains/query_engine/analyzer/src/model.rs
@@ -280,7 +280,18 @@ impl InMemoryQueryEngineModelBuilder {
             data,
         } = event;
         match data {
-            QueryEngineEvent::Engine(e) => self.engine.push(Event::new(id, timestamp, e)),
+            QueryEngineEvent::Engine(e) => {
+                // One engine instance per model: the imported streams for an
+                // engine must not carry a second, distinct engine id.
+                let engine_id = Entity::id(&self.engine);
+                if id != engine_id {
+                    return Err(AnalyzerError::Validation(format!(
+                        "multiple engine instances in one query engine model: \
+                         expected {engine_id}, found {id}"
+                    )));
+                }
+                self.engine.push(Event::new(id, timestamp, e))
+            }
             QueryEngineEvent::Worker(e) => {
                 if let std::collections::hash_map::Entry::Vacant(e) = self.workers.entry(id) {
                     e.insert(Worker::try_new(id)?);

--- a/domains/query_engine/server/Cargo.toml
+++ b/domains/query_engine/server/Cargo.toml
@@ -14,8 +14,10 @@ quent-analyzer = { path = "../../../crates/analyzer" }
 quent-collector = { path = "../../../crates/collector/server" }
 quent-collector-proto = { path = "../../../crates/collector/proto" }
 quent-events = { path = "../../../crates/events" }
+quent-exporter = { path = "../../../crates/exporter" }
 quent-exporter-types = { path = "../../../crates/exporter/types" }
 quent-query-engine-analyzer = { path = "../../../domains/query_engine/analyzer" }
+quent-query-engine-model = { path = "../model" }
 quent-query-engine-ui = { path = "../../../domains/query_engine/ui" }
 quent-time = { path = "../../../crates/time" }
 quent-ui = { path = "../../../crates/ui" }
@@ -31,6 +33,3 @@ utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 uuid.workspace = true
 mime_guess = { version = "2", optional = true }
 rust-embed = { version = "8", optional = true }
-
-[dev-dependencies]
-quent-query-engine-model = { path = "../model" }

--- a/domains/query_engine/server/src/analyzer_cache.rs
+++ b/domains/query_engine/server/src/analyzer_cache.rs
@@ -1,22 +1,162 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::Path;
 use std::{sync::Arc, time::Duration};
 
 use moka::future::Cache;
-use quent_events::Event;
+use quent_events::{EntityEvent, Event};
+use quent_exporter::{
+    FileSystemFormat, FileSystemImporterOptions, ImporterOptions, create_importer,
+};
 use quent_query_engine_analyzer::ui::UiAnalyzer;
+use quent_query_engine_model::{engine::EngineEvent, worker::WorkerEvent};
 use quent_query_engine_ui as ui;
 use tracing::info_span;
 use uuid::Uuid;
 
 use crate::error::{ServerError, ServerResult};
 
+/// Reads one source's events for a context id. Called once per context that
+/// makes up a root; the cache chains the results.
 pub type ImporterFn<A> = dyn Fn(Uuid) -> ServerResult<Box<dyn Iterator<Item = Event<<A as UiAnalyzer>::Event>>>>
     + Send
     + Sync;
 
-pub type ListerFn = dyn Fn() -> ServerResult<Vec<Uuid>> + Send + Sync;
+/// Produces the [`EngineIndex`] of available engines and the contexts backing
+/// each.
+pub type ListerFn = dyn Fn() -> ServerResult<EngineIndex> + Send + Sync;
+
+/// Which contexts make up each query-engine instance's telemetry.
+///
+/// An engine instance spans multiple processes — the engine itself and its
+/// workers — each of which may hold its own context. This index ties them
+/// together by engine id: the engine's own context plus every context in which
+/// a worker of that engine appears.
+///
+/// Built by scanning context directories (see [`index_query_engines`]).
+#[derive(Debug, Default)]
+pub struct EngineIndex {
+    /// Engine id to the contexts holding its telemetry (its own and its
+    /// workers'). `BTreeSet` so it is deduplicated and deterministically ordered.
+    contexts: HashMap<Uuid, BTreeSet<Uuid>>,
+    /// Engine id to its workers and the context each was found in.
+    workers: HashMap<Uuid, Vec<(Uuid, Uuid)>>,
+}
+
+impl EngineIndex {
+    fn attribute_context(&mut self, engine_id: Uuid, context_id: Uuid) {
+        self.contexts
+            .entry(engine_id)
+            .or_default()
+            .insert(context_id);
+    }
+
+    fn add_worker(&mut self, engine_id: Uuid, worker_id: Uuid, context_id: Uuid) {
+        self.attribute_context(engine_id, context_id);
+        self.workers
+            .entry(engine_id)
+            .or_default()
+            .push((worker_id, context_id));
+    }
+
+    /// All known engine ids.
+    pub fn engine_ids(&self) -> impl Iterator<Item = Uuid> + '_ {
+        self.contexts.keys().copied()
+    }
+
+    /// The contexts whose events make up `engine_id`'s telemetry (engine plus
+    /// workers).
+    pub fn contexts_of(&self, engine_id: Uuid) -> Vec<Uuid> {
+        self.contexts
+            .get(&engine_id)
+            .map(|set| set.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// `engine_id`'s workers as `(worker_id, context_id)` pairs.
+    pub fn workers_of(&self, engine_id: Uuid) -> &[(Uuid, Uuid)] {
+        self.workers.get(&engine_id).map_or(&[], Vec::as_slice)
+    }
+}
+
+/// A dumb lister for query-engine-domain models: scan every `<output_dir>/<ctx>/`
+/// directory and, from its engine and worker streams, index each engine to the
+/// contexts that make up its telemetry (the engine's own context plus the
+/// contexts of its workers, found via each worker's `parent_engine_id`).
+///
+/// "Dumb" because it re-scans and rebuilds from scratch on every call — a real
+/// history/indexing service replaces this later.
+pub fn index_query_engines(
+    output_dir: &Path,
+    format: FileSystemFormat,
+) -> ServerResult<EngineIndex> {
+    let mut index = EngineIndex::default();
+    for entry in std::fs::read_dir(output_dir)? {
+        let context_dir = entry?.path();
+        let Some(context_id) = context_dir
+            .file_name()
+            .and_then(|s| s.to_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+        else {
+            continue;
+        };
+
+        // Engines living in this context.
+        let engine_dir = context_dir.join(<EngineEvent as EntityEvent>::NAME);
+        if engine_dir.is_dir() {
+            let importer = create_importer::<EngineEvent>(&ImporterOptions::FileSystem(
+                FileSystemImporterOptions {
+                    format,
+                    path: engine_dir,
+                },
+            ))?;
+            let mut seen = HashSet::new();
+            for event in importer {
+                if seen.insert(event.id) {
+                    index.attribute_context(event.id, context_id);
+                }
+            }
+        }
+
+        // Workers living in this context attribute it to their parent engine.
+        let worker_dir = context_dir.join(<WorkerEvent as EntityEvent>::NAME);
+        if worker_dir.is_dir() {
+            let importer = create_importer::<WorkerEvent>(&ImporterOptions::FileSystem(
+                FileSystemImporterOptions {
+                    format,
+                    path: worker_dir,
+                },
+            ))?;
+            let mut seen = HashSet::new();
+            for event in importer {
+                if let WorkerEvent::Init(init) = &event.data
+                    && seen.insert(event.id)
+                {
+                    index.add_worker(init.parent_engine_id.uuid(), event.id, context_id);
+                }
+            }
+        }
+    }
+    Ok(index)
+}
+
+/// Chain one source-importer call per context into a single event stream.
+fn chain_context_events<A: UiAnalyzer>(
+    importer: &ImporterFn<A>,
+    context_ids: &[Uuid],
+) -> ServerResult<Box<dyn Iterator<Item = Event<A::Event>>>>
+where
+    A::Event: 'static,
+{
+    let mut streams: Vec<Box<dyn Iterator<Item = Event<A::Event>>>> =
+        Vec::with_capacity(context_ids.len());
+    for &context_id in context_ids {
+        streams.push(importer(context_id)?);
+    }
+    Ok(Box::new(streams.into_iter().flatten()))
+}
 
 /// Cache for analyzer instances, keyed by engine ID.
 pub struct AnalyzerCache<A>
@@ -57,18 +197,21 @@ where
     }
 
     pub(crate) fn list(&self) -> ServerResult<Vec<Uuid>> {
-        (self.lister)()
+        Ok((self.lister)()?.engine_ids().collect())
     }
 
     pub(crate) async fn list_with_metadata(&self) -> ServerResult<Vec<ui::Engine>> {
-        let ids = self.list()?;
+        let lister = Arc::clone(&self.lister);
         let importer = Arc::clone(&self.importer);
         tokio::task::spawn_blocking(move || {
             let _span = info_span!("list_with_metadata").entered();
-            ids.into_iter()
-                .map(|id| {
-                    let events = importer(id)?;
-                    Ok(A::extract_engine(id, events)?)
+            let index = lister()?;
+            index
+                .engine_ids()
+                .map(|engine_id| {
+                    let events =
+                        chain_context_events::<A>(&*importer, &index.contexts_of(engine_id))?;
+                    Ok(A::extract_engine(engine_id, events)?)
                 })
                 .collect()
         })
@@ -77,13 +220,15 @@ where
     }
 
     pub(crate) async fn get(&self, engine_id: Uuid) -> ServerResult<Arc<A>> {
+        let lister = Arc::clone(&self.lister);
         let importer = Arc::clone(&self.importer);
         self.analyzers
             .entry(engine_id)
             .or_try_insert_with(async {
                 tokio::task::spawn_blocking(move || -> ServerResult<Arc<A>> {
                     let _span = info_span!("load_engine", %engine_id).entered();
-                    let events = importer(engine_id)?;
+                    let context_ids = lister()?.contexts_of(engine_id);
+                    let events = chain_context_events::<A>(&*importer, &context_ids)?;
                     Ok(A::try_new(engine_id, events).map(Arc::new)?)
                 })
                 .await

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -9,7 +9,7 @@ use quent_collector::server::{CollectorService, CollectorServiceOptions};
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_query_engine_analyzer::ui::UiAnalyzer;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tonic::transport::{Server as GrpcServer, server::Router};
 use tower_http::cors::CorsLayer;
 
@@ -41,14 +41,14 @@ pub fn initialize_tracing(log_level: &str) {
         .init();
 }
 
-pub fn collector_service<E>(
+pub fn collector_service<C>(
     options: CollectorServiceOptions,
 ) -> Result<Router, Box<dyn std::error::Error>>
 where
-    E: Serialize + Send + Sync + 'static + quent_collector::ModelSource,
-    for<'de> E: Deserialize<'de>,
+    C: quent_collector::CollectorContext + Send + Sync + 'static,
+    for<'de> C::Event: Deserialize<'de>,
 {
-    let collector = CollectorService::<E>::new(options);
+    let collector = CollectorService::<C>::new(options);
     Ok(GrpcServer::builder().add_service(CollectorServer::new(collector)))
 }
 

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -9,7 +9,6 @@ use quent_collector::server::{CollectorService, CollectorServiceOptions};
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_query_engine_analyzer::ui::UiAnalyzer;
 
-use serde::Deserialize;
 use tonic::transport::{Server as GrpcServer, server::Router};
 use tower_http::cors::CorsLayer;
 
@@ -46,7 +45,6 @@ pub fn collector_service<C>(
 ) -> Result<Router, Box<dyn std::error::Error>>
 where
     C: quent_collector::CollectorContext + Send + Sync + 'static,
-    for<'de> C::Event: Deserialize<'de>,
 {
     let collector = CollectorService::<C>::new(options);
     Ok(GrpcServer::builder().add_service(CollectorServer::new(collector)))

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -5,12 +5,13 @@
 
 use crate::{analyzer_cache::AnalyzerCache, state::ServiceState, timeline_cache::TimelineCache};
 use axum::Router as AxumRouter;
-use quent_collector::server::{CollectorService, CollectorServiceOptions};
+use quent_collector::server::CollectorService;
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_query_engine_analyzer::ui::UiAnalyzer;
 
 use tonic::transport::{Server as GrpcServer, server::Router};
 use tower_http::cors::CorsLayer;
+use uuid::Uuid;
 
 pub mod analyzer_cache;
 pub mod error;
@@ -40,13 +41,12 @@ pub fn initialize_tracing(log_level: &str) {
         .init();
 }
 
-pub fn collector_service<C>(
-    options: CollectorServiceOptions,
-) -> Result<Router, Box<dyn std::error::Error>>
+pub fn collector_service<C, F>(make: F) -> Result<Router, Box<dyn std::error::Error>>
 where
-    C: quent_collector::CollectorContext + Send + Sync + 'static,
+    C: quent_collector::CollectorSink + Send + Sync + 'static,
+    F: Fn(Uuid) -> Result<C, String> + Send + Sync + 'static,
 {
-    let collector = CollectorService::<C>::new(options);
+    let collector = CollectorService::<C>::new(make);
     Ok(GrpcServer::builder().add_service(CollectorServer::new(collector)))
 }
 

--- a/domains/query_engine/tests/cpp/cpp/src/main.cpp
+++ b/domains/query_engine/tests/cpp/cpp/src/main.cpp
@@ -135,6 +135,7 @@ int main() {
   // Engine: exit.
   engine_obs->exit(engine_id);
 
-  // Context destruction flushes all pending events.
+  // At scope end the observers, handles, and context all drop; each stream
+  // flushes when its last clone is released.
   return 0;
 }

--- a/domains/query_engine/tests/cpp/instrumentation/Cargo.toml
+++ b/domains/query_engine/tests/cpp/instrumentation/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[features]
+collector = ["quent-model/collector"]
+
 [dependencies]
 quent-attributes = { path = "../../../../../crates/attributes" }
 quent-model = { path = "../../../../../crates/model" }

--- a/domains/query_engine/tests/fixed/src/main.rs
+++ b/domains/query_engine/tests/fixed/src/main.rs
@@ -645,7 +645,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })),
         "collector" => Some(ExporterOptions::Collector(CollectorExporterOptions {
             address: args.collector_address,
-            application_id: ENGINE,
+            // The context injects its id via `in_context_dir`; this is a placeholder.
+            source_context_id: Uuid::nil(),
         })),
         "none" => None,
         _ => {

--- a/domains/query_engine/tests/fixed/src/main.rs
+++ b/domains/query_engine/tests/fixed/src/main.rs
@@ -645,8 +645,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })),
         "collector" => Some(ExporterOptions::Collector(CollectorExporterOptions {
             address: args.collector_address,
-            // The context injects its id via `in_context_dir`; this is a placeholder.
-            source_context_id: Uuid::nil(),
         })),
         "none" => None,
         _ => {

--- a/domains/query_engine/tests/python/instrumentation/Cargo.toml
+++ b/domains/query_engine/tests/python/instrumentation/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[features]
+collector = ["quent-model/collector"]
+
 [dependencies]
 quent-model = { path = "../../../../../crates/model" }
 quent-query-engine-model = { path = "../../../model" }

--- a/domains/query_engine/tests/python/test_query_engine.py
+++ b/domains/query_engine/tests/python/test_query_engine.py
@@ -105,8 +105,16 @@ def test_engine_definition(tmp_path_factory: pytest.TempPathFactory) -> None:
 
     worker.exit()
     engine.exit()
+    # Each entity's stream flushes only when its last handle is released, so drop
+    # the handles before closing the context.
+    del engine, worker, query, operator, port
     context.close()
 
-    output_path = (path / str(engine_id) / "events.ndjson").resolve()
-    assert output_path.exists(), output_path
-    assert output_path.stat().st_size > 0, output_path
+    # Events are written per entity: <context>/<entity>/<uuid>.<ext>, alongside a
+    # model.qmi provenance sidecar.
+    context_dir = (path / str(engine_id)).resolve()
+    assert context_dir.is_dir(), context_dir
+    assert (context_dir / "model.qmi").exists(), context_dir
+    event_files = list(context_dir.glob("*/*.ndjson"))
+    assert event_files, context_dir
+    assert all(f.stat().st_size > 0 for f in event_files), event_files

--- a/examples/cpp-integration/cpp/src/main.cpp
+++ b/examples/cpp-integration/cpp/src/main.cpp
@@ -124,11 +124,12 @@ int main() {
     // Task exits.
     task->exit();
 
-  } // Drop context to flush all pending events.
+  } // Scope end drops the observers, handles, and the context together; each
+    // stream flushes when its last clone is released.
 
-  auto output_path = std::filesystem::canonical("./events").string() + "/" +
-                     std::string(uuid::to_string(cluster_id)) + ".ndjson";
-  std::cout << "Events written to: " << output_path << std::endl;
+  // Events are written per entity under a context-id subdirectory of ./events.
+  auto output_path = std::filesystem::canonical("./events").string();
+  std::cout << "Events written under: " << output_path << std::endl;
 
   return 0;
 }

--- a/examples/readme/Cargo.toml
+++ b/examples/readme/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[features]
+collector = ["quent-model/collector"]
+
 [dependencies]
 quent-attributes = { path = "../../crates/attributes" }
 quent-model = { path = "../../crates/model" }

--- a/examples/readme/src/main.rs
+++ b/examples/readme/src/main.rs
@@ -88,7 +88,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Events are written per entity under the context directory.
     let output_dir = root.join(id.to_string());
-    println!("Events written to: {}", output_dir.canonicalize()?.display());
+    println!(
+        "Events written to: {}",
+        output_dir.canonicalize()?.display()
+    );
 
     Ok(())
 }

--- a/examples/readme/src/main.rs
+++ b/examples/readme/src/main.rs
@@ -82,14 +82,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     task.computing(Some(usage(&thread)), Some(usage((&mem_pool, 1024))));
     task.exit();
 
-    // Drop context to flush all pending events.
-    drop(context);
+    // Each entity stream flushes when its last handle drops, so drop the handles
+    // along with the context to write all pending events before reading them.
+    drop((context, queue, mem_pool, thread, task, file_stats_handle));
 
-    let output_path = root.join(id.to_string()).join("events.ndjson");
-    println!(
-        "Events written to: {}",
-        output_path.canonicalize()?.display()
-    );
+    // Events are written per entity under the context directory.
+    let output_dir = root.join(id.to_string());
+    println!("Events written to: {}", output_dir.canonicalize()?.display());
 
     Ok(())
 }

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -1156,7 +1156,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })),
         "collector" => Some(ExporterOptions::Collector(CollectorExporterOptions {
             address: args.collector_address,
-            application_id: engine.id,
+            // The context injects its id via `in_context_dir`; this is a placeholder.
+            source_context_id: Uuid::nil(),
         })),
         "none" => None,
         _ => {

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -1223,9 +1223,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     engine.shut_down(&context);
 
-    drop(context);
+    // Each entity stream flushes only when its last observer clone is released.
+    // `engine` co-owns those clones through its worker and network-link handles,
+    // so it must drop together with the context to write all pending events.
+    drop((engine, context));
 
-    info!("instrumentation context dropped");
     info!("simulation completed");
     Ok(())
 }

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -1155,8 +1155,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })),
         "collector" => Some(ExporterOptions::Collector(CollectorExporterOptions {
             address: args.collector_address,
-            // The context injects its id via `in_context_dir`; this is a placeholder.
-            source_context_id: Uuid::nil(),
         })),
         "none" => None,
         _ => {

--- a/examples/simulator/application/src/main.rs
+++ b/examples/simulator/application/src/main.rs
@@ -20,7 +20,6 @@ use quent_query_engine_model::{
     operator, plan, port, query_group, worker,
 };
 use quent_simulator_instrumentation::SimulatorContext;
-use quent_simulator_instrumentation::SimulatorEvent;
 use rand::{Rng, distr::slice::Choose, rng};
 use tracing::{debug, info};
 use uuid::Uuid;
@@ -503,9 +502,9 @@ struct Worker {
     thread_pool: Uuid,
     threads: Vec<Uuid>,
     // Resource handles — kept alive until shut_down().
-    memory_handles: Vec<quent_stdlib::memory::MemoryHandle<SimulatorEvent>>,
-    channel_handles: Vec<quent_stdlib::channel::ChannelHandle<SimulatorEvent>>,
-    processor_handles: Vec<quent_stdlib::processor::ProcessorHandle<SimulatorEvent>>,
+    memory_handles: Vec<quent_stdlib::memory::MemoryHandle>,
+    channel_handles: Vec<quent_stdlib::channel::ChannelHandle>,
+    processor_handles: Vec<quent_stdlib::processor::ProcessorHandle>,
 }
 
 impl Worker {
@@ -1025,7 +1024,7 @@ struct Engine {
     workers: HashMap<Uuid, Worker>,
     network: Uuid,
     network_links: HashMap<(Uuid, Uuid), Uuid>,
-    network_link_handles: Vec<quent_stdlib::channel::ChannelHandle<SimulatorEvent>>,
+    network_link_handles: Vec<quent_stdlib::channel::ChannelHandle>,
 }
 
 impl Engine {

--- a/examples/simulator/instrumentation/Cargo.toml
+++ b/examples/simulator/instrumentation/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[features]
+collector = ["quent-model/collector"]
+
 [dependencies]
 quent-model = { path = "../../../crates/model" }
 quent-query-engine-model = { path = "../../../domains/query_engine/model" }

--- a/examples/simulator/server/Cargo.toml
+++ b/examples/simulator/server/Cargo.toml
@@ -11,10 +11,9 @@ swagger = ["quent-query-engine-server/swagger"]
 axum = { version = "0.8.7" }
 clap = { version = "4.5", features = ["derive", "env"] }
 quent-exporter = { path = "../../../crates/exporter" }
-quent-collector = { path = "../../../crates/collector/server" }
 quent-query-engine-server = { path = "../../../domains/query_engine/server" }
 quent-simulator-analyzer = { path = "../analyzer" }
-quent-simulator-instrumentation = { path = "../instrumentation" }
+quent-simulator-instrumentation = { path = "../instrumentation", features = ["collector"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"]}
 tracing.workspace = true
 uuid.workspace = true

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -3,16 +3,14 @@
 
 use std::{net::ToSocketAddrs, path::PathBuf};
 
-use uuid::Uuid;
-
 use clap::Parser;
-use quent_exporter::{
-    ExporterOptions, FileSystemExporterOptions, FileSystemFormat, FileSystemImporterOptions,
-    ImporterOptions, create_importer,
+use quent_exporter::{ExporterOptions, FileSystemExporterOptions, FileSystemFormat};
+use quent_query_engine_server::{
+    analyzer_cache::index_query_engines, analyzer_service_router, collector_service,
+    initialize_tracing,
 };
-use quent_query_engine_server::{analyzer_service_router, collector_service, initialize_tracing};
 use quent_simulator_analyzer::SimulatorUiAnalyzer;
-use quent_simulator_instrumentation::{SimulatorContext, SimulatorEvent};
+use quent_simulator_instrumentation::{Simulator, SimulatorContext};
 use tokio::net::TcpListener;
 
 mod defaults {
@@ -116,32 +114,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .next()
         .ok_or_else(|| format!("unable to resolve socket address: {analyzer_address}"))?;
 
-    // Each context exports to its own `output_dir/<context-id>/` subdirectory;
-    // list those subdirectories whose name is a uuid.
-    let lister = move || {
-        let mut ids = Vec::new();
-        for entry in std::fs::read_dir(&lister_output_dir)? {
-            let path = entry?.path();
-            if !path.is_dir() {
-                continue;
-            }
-            if let Some(id) = path
-                .file_name()
-                .and_then(|s| s.to_str())
-                .and_then(|s| Uuid::parse_str(s).ok())
-            {
-                ids.push(id);
-            }
-        }
-        Ok(ids)
-    };
+    // Index the exported contexts by engine instance: each engine's telemetry is
+    // the engine's own context plus its workers' contexts.
+    let lister = move || index_query_engines(&lister_output_dir, format);
 
-    // Hand the importer the per-context directory; it locates the event file by
-    // the configured format's extension.
+    // Reconstruct one context's umbrella event stream from its per-entity
+    // subdirectories; the analyzer cache chains this across all the contexts that
+    // make up an engine instance.
     let importer = move |context_id| {
         let dir = importer_output_dir.join(format!("{context_id}"));
-        let kind = ImporterOptions::FileSystem(FileSystemImporterOptions { format, path: dir });
-        Ok(Box::new(create_importer::<SimulatorEvent>(&kind)?) as Box<dyn Iterator<Item = _>>)
+        Ok(Simulator::import_events(&dir, format)?)
     };
 
     let analyzer = async {

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -6,7 +6,6 @@ use std::{net::ToSocketAddrs, path::PathBuf};
 use uuid::Uuid;
 
 use clap::Parser;
-use quent_collector::server::CollectorServiceOptions;
 use quent_exporter::{
     ExporterOptions, FileSystemExporterOptions, FileSystemFormat, FileSystemImporterOptions,
     ImporterOptions, create_importer,
@@ -102,14 +101,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         root: output_dir,
     });
 
-    let collector_options = CollectorServiceOptions {
-        exporter: exporter_kind,
-    };
     let collector = async {
-        collector_service::<SimulatorContext>(collector_options)?
-            .serve(collector_addr)
-            .await
-            .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })
+        collector_service::<SimulatorContext, _>(move |id| {
+            SimulatorContext::try_with_id(id, Some(exporter_kind.clone()))
+                .map_err(|e| e.to_string())
+        })?
+        .serve(collector_addr)
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })
     };
 
     let analyzer_addr = analyzer_address

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -13,7 +13,7 @@ use quent_exporter::{
 };
 use quent_query_engine_server::{analyzer_service_router, collector_service, initialize_tracing};
 use quent_simulator_analyzer::SimulatorUiAnalyzer;
-use quent_simulator_instrumentation::SimulatorEvent;
+use quent_simulator_instrumentation::{SimulatorContext, SimulatorEvent};
 use tokio::net::TcpListener;
 
 mod defaults {
@@ -106,7 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         exporter: exporter_kind,
     };
     let collector = async {
-        collector_service::<SimulatorEvent>(collector_options)?
+        collector_service::<SimulatorContext>(collector_options)?
             .serve(collector_addr)
             .await
             .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })

--- a/proto/quent/collector/v1/collector.proto
+++ b/proto/quent/collector/v1/collector.proto
@@ -6,9 +6,9 @@ syntax = "proto3";
 package quent.collector.v1;
 
 service Collector {
-  // Request to set up an event stream.
-  //
-  // Must include metadata key "source-context-id": "<uuid string>".
+  // Opens an event stream for a single entity of a single source. Each stream
+  // must carry two metadata keys: "source-context-id" (the producing context's
+  // UUID) and "entity-type" (the entity event stream's name).
   rpc CollectEvents(stream CollectEventRequest) returns (CollectEventResponse);
 }
 

--- a/proto/quent/collector/v1/collector.proto
+++ b/proto/quent/collector/v1/collector.proto
@@ -8,7 +8,7 @@ package quent.collector.v1;
 service Collector {
   // Request to set up an event stream.
   //
-  // Must include metadata key "engine-id": "<uuid string>".
+  // Must include metadata key "source-context-id": "<uuid string>".
   rpc CollectEvents(stream CollectEventRequest) returns (CollectEventResponse);
 }
 


### PR DESCRIPTION
# Description

This PR is of mainly instrumentation infrastructure / support crates based on two issues:

1. Have one exporter per observer instead of one exporter per context (see #229)
2. Make the context id unrelated to the id of the root entity (e.g. the engine id in the query engine domain model). 

2 allows every context to write events without the need to synchronize on the root id or to consider the root entity as something special versus other entities. While this would be ideally propagated back to the modeling API, #191 will remove that in its current form entirely anyway, so it is left as is for now so upstream model definitions experience no breaking changes twice in a short period of time.

I initially tried to deal with 1 and 2 separately, but since this touches a lot of the same code across many layers it seemed best to tackle these in one pass.

The consequences are as follows. In this description, only {App}Context and {Entity}Observer/Handle are user-facing, plain Context and Observer/Handle mentions are not user facing, but are the model-agonistic backing structures for their generated counterparts.

- There is no longer a need for an "umbrella" event type representing all events of an application event model. This is for now still generated by the model macros because the analyzer side still relies on it. Removing that is intentionally not done in this PR to reduce the scope.
- The quent_instrumentation::Context (not user facing) is now mainly responsible for ensuring there is an async runtime that observers can work with, it no longer owns the exporter, and to provide a bridge from sync <-> async code.
- A generated {App}Context now concurrently writes the model provenance sidecar file, constructs (+connects) exporters and observers, and blocks until all of that is ready.
- Each Observer now manages its own Exporter (which lives in an async forwarder task that it cancels on drop)
- Each {Entity}Observer deals out {Entity}Handles for entity instances which hold an Arc to the inner Observer, which ensures everything is kept alive as long as a handle exists.

This means as long as there are any live handles, even when all Observers or Context is dropped, events can be emitted. Also, constructing or dropping Context / Observer / Handle can be done from both synchronous and asynchronous code as long as that code is not using a `current-thread` runtime (also raised in #226). This PR adds tests for all flavors of runtime environments for the Context to live in.

- Filesystem exporters now write in the following directory tree:

```
  - <context uuid>
    - <entity_name>
      - <uuid>.<extension>  (using a uuid here is just a non-enforced convention 
                             that mainly batching no-append file format exporters 
                             will benefit from as they can just generate a new uuid 
                             for each batch of events as file name).
    - <another entity name>
      - <uuid>.<extension>
      - <uuid>.<extension>
      - ...
    - model.qmi        (sidecar file) 
```

- For the query engine domain, since a (distributed) engine's events could now be spread out across multiple contexts / directories, listing engines is done by first scanning all engine events across the entire data source folder to obtain all engine ids. Then, all worker events are scanned to figure out which workers were spawned on behalf of those engines. For now it is assumed that these entities are directly tied to all event-producing processes of the engines, such that their instrumentation contexts together capture all events for an entire engine model. This is a rather brittle assumption that should not be relied on in follow-up work. I intend to address this with a generated importing stack that leverages the quent-ref-tree constraint after #191 is done, plus some sort of indexing service hinted at in #40.

## Related Issues

Closes #229



## For reference: example of macro generated code by 🤖:

### Generated event type + stream name
```rust
pub enum FileStatsEvent { Checksum(Checksum), Decompressed(Decompressed) }

impl quent_model::EntityEvent for FileStatsEvent {
    const NAME: &'static str = "file_stats";   // exporter subdir / wire tag / ingest key
}
```

### `{App}Context` (the user entry point), the relevant slice
```rust
pub struct AppContext {
    file_stats: FileStatsObserver,     // ... one field per entity
    _inner: quent_model::Context,
}

impl AppContext {
    pub fn try_new(exporter: Option<…ExporterOptions>) -> Result<Self, …> {
        let inner = quent_model::Context::try_new(exporter)?;   // sync: resolve runtime only
        Self::assemble(inner)
    }

    // The single sync→async bridge: sidecar + every observer built concurrently,
    // blocked once.
    fn assemble(inner: quent_model::Context) -> Result<Self, …> {
        let (file_stats, …) = inner.block_on(async {
            let (_sidecar, file_stats, …) = quent_model::tokio::try_join!(
                async { inner.write_sidecar(<App as ModelSource>::model_info()).await; Ok(()) },
                inner.observer::<FileStatsEvent>(),     // ... one per entity
            )?;
            Ok((file_stats, …))
        })?;
        Ok(Self { file_stats: FileStatsObserver::new(file_stats), …, _inner: inner })
    }

    pub fn file_stats_observer(&self) -> FileStatsObserver { self.file_stats.clone() }   // cheap Arc clone
}
```

### `{Entity}Observer` facade → `{Entity}Handle`
```rust
pub struct FileStatsObserver { inner: Arc<quent_model::Observer<FileStatsEvent>> }

impl FileStatsObserver {
    pub fn new(observer: quent_model::Observer<FileStatsEvent>) -> Self { Self { inner: Arc::new(observer) } }
    pub fn send(&self, event: quent_model::Event<FileStatsEvent>) { self.inner.send(event); }  // pre-built (collector path)
    pub fn create(&self, id: Uuid) -> FileStatsHandle {
        FileStatsHandle { id, inner: self.inner.clone() }   // handle co-owns the observer
    }
}

pub struct FileStatsHandle { id: Uuid, inner: Arc<quent_model::Observer<FileStatsEvent>> }

impl FileStatsHandle {
    pub fn uuid(&self) -> Uuid { self.id }
    pub fn checksum(&self, event: Checksum) {
        self.inner.emit(self.id, FileStatsEvent::Checksum(event));   // Observer::emit -> EventSender -> forwarder
    }
    pub fn decompressed(&self, event: Decompressed) {
        self.inner.emit(self.id, FileStatsEvent::Decompressed(event));
    }
}
```

Emit path: `AppContext.file_stats_observer().create(id).checksum(..)` → `Observer::emit` → mpsc → forwarder task → exporter.

### Read/route side (collector + analyzer), same entity
```rust
// CollectorSink::ingest (server replays a received stream)
if entity == <FileStatsEvent as EntityEvent>::NAME {
    let e: Event<FileStatsEvent> = ciborium::from_reader(event)?;
    self.file_stats.send(e);                 // into the (already built) observer
    return Ok(());
}

// {Model}::import_events (analyzer reconstruction), per entity:
let path = dir.join(<FileStatsEvent as EntityEvent>::NAME);   // <ctx>/file_stats
if path.is_dir() {
    let importer = create_importer::<FileStatsEvent>(&FileSystem { format, path })?;
    streams.push(importer.map(|e| Event::new(e.id, e.timestamp, AppEvent::from(e.data))));
}
```

`AppEvent` (the umbrella enum) + its `From<{Entity}Event>` impls are still generated solely for this analyzer reconstruction; nothing on the capture path uses them.
