### PR TITLE
chore(deps): upgrade `ts-rs` to `12`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "ts-rs"
-version = "11.1.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
+checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -3252,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "ts-rs-macros"
-version = "11.1.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
+checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,5 +125,5 @@ tonic = "0.14.2"
 tonic-prost = "0.14.2"
 tracing = "0.1.43"
 tracing-subscriber = "0.3"
-ts-rs = "11.1.0"
+ts-rs = "12.0.1"
 uuid = {version = "1.18.1", features = ["v7"]}

--- a/crates/schema/src/schema/identifier.rs
+++ b/crates/schema/src/schema/identifier.rs
@@ -13,8 +13,44 @@ use thiserror::Error;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
-#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 pub struct Identifier(String);
+
+#[cfg(feature = "ts")]
+impl ts_rs::TS for Identifier {
+    type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+
+    fn docs() -> Option<String> {
+        Some(
+            concat!(
+                "/**\n",
+                " * An identifier adhering to the grammar `[A-Za-z][A-Za-z0-9_]*`\n",
+                " *\n",
+                " * This grammar is chosen such that a minimal amount of friction is expected\n",
+                " * when interoperating across multiple programming languages and event data\n",
+                " * formats.\n",
+                " */\n",
+            )
+            .to_owned(),
+        )
+    }
+
+    fn name(_: &ts_rs::Config) -> String {
+        "Identifier".to_owned()
+    }
+
+    fn inline(_: &ts_rs::Config) -> String {
+        "string".to_owned()
+    }
+
+    fn decl(_: &ts_rs::Config) -> String {
+        "type Identifier = string;".to_owned()
+    }
+
+    fn output_path() -> Option<std::path::PathBuf> {
+        Some("Identifier.ts".into())
+    }
+}
 
 /// Reason a string failed to parse as an [`Identifier`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/crates/schema/tests/export_bindings.rs
+++ b/crates/schema/tests/export_bindings.rs
@@ -14,15 +14,16 @@ use std::fs;
 use std::path::Path;
 
 use quent_schema::Schema;
-use ts_rs::TS;
+use ts_rs::{Config, TS};
 
 const OUT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/ts/src/generated");
 
 #[test]
 fn export_bindings() {
     let out = Path::new(OUT_DIR);
+    let cfg = Config::new().with_out_dir(out);
     // Exporting from Schema transitively emits every reachable schema type.
-    Schema::export_all_to(out).expect("export schema bindings");
+    Schema::export_all(&cfg).expect("export schema bindings");
     write_barrel(out);
 }
 

--- a/examples/simulator/server/build.rs
+++ b/examples/simulator/server/build.rs
@@ -7,18 +7,20 @@ use quent_ui::timeline::{
     request::{BulkTimelineRequest, SingleTimelineRequest},
     response::{BulkTimelinesResponse, SingleTimelineResponse},
 };
-use ts_rs::TS;
+use ts_rs::{Config, TS};
 
 const TS_OUT_DIR: &str = "./ts-bindings/";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Export TypeScript bindings to ts-bindings directory
-    <QueryBundle<EntityRef> as TS>::export_all_to(TS_OUT_DIR)?;
+    let cfg = Config::new().with_out_dir(TS_OUT_DIR);
 
-    <SingleTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all_to(TS_OUT_DIR)?;
-    <SingleTimelineResponse as TS>::export_all_to(TS_OUT_DIR)?;
-    <BulkTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all_to(TS_OUT_DIR)?;
-    <BulkTimelinesResponse as TS>::export_all_to(TS_OUT_DIR)?;
+    <QueryBundle<EntityRef> as TS>::export_all(&cfg)?;
+
+    <SingleTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all(&cfg)?;
+    <SingleTimelineResponse as TS>::export_all(&cfg)?;
+    <BulkTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all(&cfg)?;
+    <BulkTimelinesResponse as TS>::export_all(&cfg)?;
 
     Ok(())
 }

--- a/examples/simulator/server/ts-bindings/BulkTimelineRequest.ts
+++ b/examples/simulator/server/ts-bindings/BulkTimelineRequest.ts
@@ -8,7 +8,7 @@ export type BulkTimelineRequest<GlobalParams, TimelineParams> = {
 /**
  * The list of timelines requested.
  */
-entries: { [key in string]?: TimelineRequest<TimelineParams> }, 
+entries: { [key in string]: TimelineRequest<TimelineParams> }, 
 /**
  * Global application-specific parameters, e.g. filters.
  */

--- a/examples/simulator/server/ts-bindings/BulkTimelinesResponse.ts
+++ b/examples/simulator/server/ts-bindings/BulkTimelinesResponse.ts
@@ -8,4 +8,4 @@ export type BulkTimelinesResponse = {
 /**
  * The timeline responses, keyed by the same keys as the request entries.
  */
-entries: { [key in string]?: BulkTimelinesResponseEntry }, };
+entries: { [key in string]: BulkTimelinesResponseEntry }, };

--- a/examples/simulator/server/ts-bindings/Operator.ts
+++ b/examples/simulator/server/ts-bindings/Operator.ts
@@ -28,7 +28,7 @@ operator_type_name: string | null,
 /**
  * The custom attributes of this [`Operator`].
  */
-custom_attributes: { [key in string]?: Value | null }, 
+custom_attributes: { [key in string]: Value | null }, 
 /**
  * The statistics of this [`Operator`].
  *

--- a/examples/simulator/server/ts-bindings/OperatorStatistics.ts
+++ b/examples/simulator/server/ts-bindings/OperatorStatistics.ts
@@ -5,4 +5,4 @@ export type OperatorStatistics = {
 /**
  * Custom statistics
  */
-custom_statistics: { [key in string]?: Value | null }, };
+custom_statistics: { [key in string]: Value | null }, };

--- a/examples/simulator/server/ts-bindings/PortStatistics.ts
+++ b/examples/simulator/server/ts-bindings/PortStatistics.ts
@@ -5,4 +5,4 @@ export type PortStatistics = {
 /**
  * Custom statistics
  */
-custom_statistics: { [key in string]?: Value | null }, };
+custom_statistics: { [key in string]: Value | null }, };

--- a/examples/simulator/server/ts-bindings/QueryBundle.ts
+++ b/examples/simulator/server/ts-bindings/QueryBundle.ts
@@ -28,7 +28,7 @@ unique_operator_names: Array<string>,
 /**
  * Quantity specifications for capacity display, keyed by capacity name.
  */
-quantity_specs: { [key in string]?: QuantitySpec }, 
+quantity_specs: { [key in string]: QuantitySpec }, 
 /**
  * The number of nanoseconds passed since the Unix epoch at which the
  * engine started executing this query.

--- a/examples/simulator/server/ts-bindings/QueryEntities.ts
+++ b/examples/simulator/server/ts-bindings/QueryEntities.ts
@@ -36,29 +36,29 @@ query: Query,
  *
  * Is a Resource Group.
  */
-workers: { [key in string]?: Worker }, 
+workers: { [key in string]: Worker }, 
 /**
  * The plans of this query.
  *
  * Is a Resource Group.
  */
-plans: { [key in string]?: Plan }, 
+plans: { [key in string]: Plan }, 
 /**
  * The operators of the plans.
  *
  * Is a Resource Group.
  */
-operators: { [key in string]?: Operator }, 
+operators: { [key in string]: Operator }, 
 /**
  * The ports of the operators.
  *
  * Is a Resource Group.
  */
-ports: { [key in string]?: Port }, 
+ports: { [key in string]: Port }, 
 /**
  * Application-specific resource types
  */
-resource_types: { [key in string]?: ResourceTypeDecl }, 
+resource_types: { [key in string]: ResourceTypeDecl }, 
 /**
  * Resource group types.
  *
@@ -71,16 +71,16 @@ resource_types: { [key in string]?: ResourceTypeDecl },
  * - [`Operator`]
  * - [`Port`]
  */
-resource_group_types: { [key in string]?: ResourceGroupTypeDecl }, 
+resource_group_types: { [key in string]: ResourceGroupTypeDecl }, 
 /**
  * Application-specific resources
  */
-resources: { [key in string]?: Resource }, 
+resources: { [key in string]: Resource }, 
 /**
  * Application-specific resource groups
  */
-resource_groups: { [key in string]?: ResourceGroup }, 
+resource_groups: { [key in string]: ResourceGroup }, 
 /**
  * Application-specific FSMs
  */
-fsm_types: { [key in string]?: FsmTypeDecl }, };
+fsm_types: { [key in string]: FsmTypeDecl }, };

--- a/examples/simulator/server/ts-bindings/ResourceTimelineBinned.ts
+++ b/examples/simulator/server/ts-bindings/ResourceTimelineBinned.ts
@@ -11,7 +11,7 @@ config: BinnedSpanSec,
  * Maps a resource capacity name to a vector where each element holds an
  * aggregated value of a time bin.
  */
-capacities_values: { [key in string]?: Array<number> }, 
+capacities_values: { [key in string]: Array<number> }, 
 /**
  * FSMs that have usage spans exceeding the long_entities_threshold.
  */

--- a/examples/simulator/server/ts-bindings/ResourceTimelineBinnedByState.ts
+++ b/examples/simulator/server/ts-bindings/ResourceTimelineBinnedByState.ts
@@ -11,7 +11,7 @@ config: BinnedSpanSec,
  * Maps a resource capacity name to a map of a state name to a vector where
  * each element holds an aggregated value of a time bin.
  */
-capacities_states_values: { [key in string]?: { [key in string]?: Array<number> } }, 
+capacities_states_values: { [key in string]: { [key in string]: Array<number> } }, 
 /**
  * FSMs that have usage spans exceeding the long_entities_threshold.
  */


### PR DESCRIPTION
Upgrades `ts-rs` from `11.1.0` to `12.0.1`.

Changes:

  - Migrates manual exports from `export_all_to(...)` to `Config::with_out_dir(...)` + `export_all(&cfg)`.
  - Adds a manual `TS` impl for schema `Identifier` to preserve `Identifier = string` and avoid the unsupported `serde(try_from)` warning.
  - Regenerates simulator TypeScript bindings; map types now use the v12 default non-optional index signature.