### PR TITLE
refactor: rework exporter trait so mutexes can be removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target/
-data/
-events/
+/data/
+/events/
 .DS_Store
 .pnpm-store/
 .rumdl_cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "quent-exporter-types",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! A gRPC-based client that can send [`Event`]s to a collector.
 
-use std::sync::Mutex;
 use std::time::Duration;
 
 use quent_events::Event;
@@ -56,10 +55,10 @@ pub struct Client<T> {
     _grpc_client: CollectorClient<Channel>,
     event_sender: Sender<Event<T>>,
     cancellation_token: CancellationToken,
-    // `Mutex<Option<..>>` so the join handles can be taken from `&self` in
-    // `shutdown`; awaited there, never under the lock.
-    events_sender_handle: Mutex<Option<JoinHandle<()>>>,
-    events_collector_handle: Mutex<Option<JoinHandle<()>>>,
+    // Taken via `Option::take` in `shutdown(&mut self)` so they can be joined
+    // once; a second call finds `None` and is a no-op.
+    events_sender_handle: Option<JoinHandle<()>>,
+    events_collector_handle: Option<JoinHandle<()>>,
 }
 
 impl<T> Client<T>
@@ -227,8 +226,8 @@ where
             _grpc_client: client,
             event_sender,
             cancellation_token,
-            events_sender_handle: Mutex::new(Some(events_sender_handle)),
-            events_collector_handle: Mutex::new(Some(events_collector_handle)),
+            events_sender_handle: Some(events_sender_handle),
+            events_collector_handle: Some(events_collector_handle),
         })
     }
 
@@ -245,16 +244,14 @@ where
     /// tasks to finish. Async so it can be awaited from the forwarder rather
     /// than blocking in `Drop` (which would run on a runtime worker thread).
     /// Idempotent; subsequent calls are no-ops.
-    pub async fn shutdown(&self) {
+    pub async fn shutdown(&mut self) {
         self.cancellation_token.cancel();
-        let sender = self.events_sender_handle.lock().unwrap().take();
-        if let Some(handle) = sender
+        if let Some(handle) = self.events_sender_handle.take()
             && let Err(e) = handle.await
         {
             warn!("grpc sender task failed: {e}");
         }
-        let collector = self.events_collector_handle.lock().unwrap().take();
-        if let Some(handle) = collector
+        if let Some(handle) = self.events_collector_handle.take()
             && let Err(e) = handle.await
         {
             warn!("grpc collector task failed: {e}");

--- a/crates/exporter/collector/src/lib.rs
+++ b/crates/exporter/collector/src/lib.rs
@@ -25,7 +25,8 @@ pub struct CollectorExporterOptions {
 /// entity observer.
 #[derive(Debug)]
 pub struct CollectorExporter<T> {
-    client: Client<T>,
+    /// `None` once [`shutdown`](Exporter::shutdown) has drained and released it.
+    client: Option<Client<T>>,
 }
 
 impl<T> CollectorExporter<T>
@@ -37,9 +38,11 @@ where
     pub async fn try_new(
         address: http::Uri,
         source_context_id: Uuid,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let client = Client::new(source_context_id, T::NAME, address).await?;
-        Ok(Self { client })
+        Ok(Self {
+            client: Some(client),
+        })
     }
 }
 
@@ -48,19 +51,20 @@ impl<T> Exporter<T> for CollectorExporter<T>
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
-    async fn push(&self, event: Event<T>) -> ExporterResult<()> {
-        self.client
-            .send(event)
-            .await
-            .map_err(|e| ExporterError::Collector(format!("{e:?}")))?;
+    async fn push(&mut self, event: Event<T>) -> ExporterResult<()> {
+        let client = self.client.as_ref().ok_or(ExporterError::Shutdown)?;
+        client.send(event).await.map_err(ExporterError::other)?;
         Ok(())
     }
-    async fn force_flush(&self) -> ExporterResult<()> {
+    async fn shutdown(&mut self) -> ExporterResult<()> {
+        let Some(mut client) = self.client.take() else {
+            return Ok(());
+        };
         // Drain buffered events and wait for delivery. The forwarder awaits this
         // on shutdown, so the client's tasks are joined here rather than in
         // `Client::drop` (which may run on a runtime worker, where blocking
         // panics).
-        self.client.shutdown().await;
+        client.shutdown().await;
         Ok(())
     }
 }

--- a/crates/exporter/msgpack/src/lib.rs
+++ b/crates/exporter/msgpack/src/lib.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncWriteExt, BufWriter},
-    sync::Mutex,
 };
 use tracing::{debug, error};
 use uuid::Uuid;
@@ -34,7 +33,8 @@ pub struct MsgpackExporterOptions {
 
 #[derive(Debug)]
 pub struct MsgpackExporter {
-    writer: Mutex<BufWriter<File>>,
+    /// `None` once [`shutdown`](Exporter::shutdown) has flushed and released it.
+    writer: Option<BufWriter<File>>,
 }
 
 impl MsgpackExporter {
@@ -49,7 +49,7 @@ impl MsgpackExporter {
             .open(&path)
             .await?;
         Ok(Self {
-            writer: Mutex::new(BufWriter::new(file)),
+            writer: Some(BufWriter::new(file)),
         })
     }
 }
@@ -59,25 +59,21 @@ impl<T> Exporter<T> for MsgpackExporter
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
-    async fn push(&self, event: Event<T>) -> ExporterResult<()> {
-        let payload =
-            rmp_serde::to_vec(&event).map_err(|e| ExporterError::Serde(format!("{e:?}")))?;
+    async fn push(&mut self, event: Event<T>) -> ExporterResult<()> {
+        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+        let payload = rmp_serde::to_vec(&event).map_err(ExporterError::other)?;
         let len = (payload.len() as u32).to_be_bytes();
-        let mut lock = self.writer.lock().await;
-        lock.write_all(&len).await?;
-        lock.write_all(&payload).await?;
+        writer.write_all(&len).await?;
+        writer.write_all(&payload).await?;
         Ok(())
     }
 
-    async fn force_flush(&self) -> ExporterResult<()> {
-        match self.writer.lock().await.flush().await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let err = format!("unable to flush msgpack exporter: {e}");
-                error!("{err}");
-                Err(ExporterError::Flush(err))
-            }
-        }
+    async fn shutdown(&mut self) -> ExporterResult<()> {
+        let Some(mut writer) = self.writer.take() else {
+            return Ok(());
+        };
+        writer.flush().await?;
+        Ok(())
     }
 }
 

--- a/crates/exporter/ndjson/Cargo.toml
+++ b/crates/exporter/ndjson/Cargo.toml
@@ -12,3 +12,7 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["sync", "fs", "io-util"]}
 tracing.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+tempfile = "3"

--- a/crates/exporter/ndjson/src/lib.rs
+++ b/crates/exporter/ndjson/src/lib.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncWriteExt, BufWriter},
-    sync::Mutex,
 };
 use tracing::{debug, error};
 use uuid::Uuid;
@@ -36,7 +35,8 @@ pub struct NdjsonExporterOptions {
 
 #[derive(Debug)]
 pub struct NdjsonExporter {
-    writer: Mutex<BufWriter<File>>,
+    /// `None` once [`shutdown`](Exporter::shutdown) has flushed and released it.
+    writer: Option<BufWriter<File>>,
 }
 
 impl NdjsonExporter {
@@ -52,7 +52,7 @@ impl NdjsonExporter {
             .await?;
 
         Ok(Self {
-            writer: Mutex::new(BufWriter::new(file)),
+            writer: Some(BufWriter::new(file)),
         })
     }
 }
@@ -62,25 +62,22 @@ impl<T> Exporter<T> for NdjsonExporter
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
-    async fn push(&self, event: Event<T>) -> ExporterResult<()> {
+    async fn push(&mut self, event: Event<T>) -> ExporterResult<()> {
+        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
         let line = format!(
             "{}\n",
-            serde_json::to_string(&event).map_err(|e| ExporterError::Serde(format!("{e:?}")))?
+            serde_json::to_string(&event).map_err(ExporterError::other)?
         );
-        let mut lock = self.writer.lock().await;
-        lock.write_all(line.as_bytes()).await?;
+        writer.write_all(line.as_bytes()).await?;
         Ok(())
     }
 
-    async fn force_flush(&self) -> ExporterResult<()> {
-        match self.writer.lock().await.flush().await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let err = format!("unable to flush ndjson exporter: {e}");
-                error!("{err}");
-                Err(ExporterError::Flush(err))
-            }
-        }
+    async fn shutdown(&mut self) -> ExporterResult<()> {
+        let Some(mut writer) = self.writer.take() else {
+            return Ok(());
+        };
+        writer.flush().await?;
+        Ok(())
     }
 }
 
@@ -134,5 +131,45 @@ where
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct TestEvent;
+    impl EntityEvent for TestEvent {
+        const NAME: &'static str = "TestEvent";
+    }
+
+    #[tokio::test]
+    async fn push_after_shutdown_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut exporter = NdjsonExporter::try_new::<TestEvent>(NdjsonExporterOptions {
+            dir: dir.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+
+        exporter
+            .push(Event::new_now(Uuid::now_v7(), TestEvent))
+            .await
+            .unwrap();
+        Exporter::<TestEvent>::shutdown(&mut exporter)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            exporter
+                .push(Event::new_now(Uuid::now_v7(), TestEvent))
+                .await,
+            Err(ExporterError::Shutdown)
+        ));
+        // A second shutdown is a no-op.
+        Exporter::<TestEvent>::shutdown(&mut exporter)
+            .await
+            .unwrap();
     }
 }

--- a/crates/exporter/postcard/src/lib.rs
+++ b/crates/exporter/postcard/src/lib.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncWriteExt, BufWriter},
-    sync::Mutex,
 };
 use tracing::{debug, error};
 use uuid::Uuid;
@@ -34,7 +33,8 @@ pub struct PostcardExporterOptions {
 
 #[derive(Debug)]
 pub struct PostcardExporter {
-    writer: Mutex<BufWriter<File>>,
+    /// `None` once [`shutdown`](Exporter::shutdown) has flushed and released it.
+    writer: Option<BufWriter<File>>,
 }
 
 impl PostcardExporter {
@@ -49,7 +49,7 @@ impl PostcardExporter {
             .open(&path)
             .await?;
         Ok(Self {
-            writer: Mutex::new(BufWriter::new(file)),
+            writer: Some(BufWriter::new(file)),
         })
     }
 }
@@ -59,25 +59,21 @@ impl<T> Exporter<T> for PostcardExporter
 where
     T: Serialize + Send + EntityEvent + 'static,
 {
-    async fn push(&self, event: Event<T>) -> ExporterResult<()> {
-        let payload =
-            postcard::to_allocvec(&event).map_err(|e| ExporterError::Serde(format!("{e:?}")))?;
+    async fn push(&mut self, event: Event<T>) -> ExporterResult<()> {
+        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+        let payload = postcard::to_allocvec(&event).map_err(ExporterError::other)?;
         let len = (payload.len() as u32).to_be_bytes();
-        let mut lock = self.writer.lock().await;
-        lock.write_all(&len).await?;
-        lock.write_all(&payload).await?;
+        writer.write_all(&len).await?;
+        writer.write_all(&payload).await?;
         Ok(())
     }
 
-    async fn force_flush(&self) -> ExporterResult<()> {
-        match self.writer.lock().await.flush().await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let err = format!("unable to flush postcard exporter: {e}");
-                error!("{err}");
-                Err(ExporterError::Flush(err))
-            }
-        }
+    async fn shutdown(&mut self) -> ExporterResult<()> {
+        let Some(mut writer) = self.writer.take() else {
+            return Ok(());
+        };
+        writer.flush().await?;
+        Ok(())
     }
 }
 

--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -177,16 +177,14 @@ where
             address,
             source_context_id,
         } => {
-            let address: http::Uri = address
-                .parse()
-                .map_err(|e: http::uri::InvalidUri| ExporterError::Collector(e.to_string()))?;
+            let address: http::Uri = address.parse().map_err(ExporterError::other)?;
             Ok(Box::new(
                 quent_exporter_collector::CollectorExporter::<T>::try_new(
                     address,
                     source_context_id,
                 )
                 .await
-                .map_err(|e| ExporterError::Collector(e.to_string()))?,
+                .map_err(ExporterError::Other)?,
             ) as Box<dyn Exporter<T>>)
         }
     }

--- a/crates/exporter/types/src/lib.rs
+++ b/crates/exporter/types/src/lib.rs
@@ -9,14 +9,25 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ExporterError {
-    #[error("i/o error: {0}")]
-    IoError(#[from] std::io::Error),
-    #[error("flush error: {0}")]
-    Flush(String),
-    #[error("serde error: {0}")]
-    Serde(String),
-    #[error("collector error: {0}")]
-    Collector(String),
+    /// Push was called after [`Exporter::shutdown`].
+    #[error("exporter has been shut down")]
+    Shutdown,
+    /// Any failure originating in the exporter implementation.
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl ExporterError {
+    /// Wrap an implementation-specific error as [`ExporterError::Other`].
+    pub fn other<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
+        Self::Other(Box::new(error))
+    }
+}
+
+impl From<std::io::Error> for ExporterError {
+    fn from(error: std::io::Error) -> Self {
+        Self::other(error)
+    }
 }
 
 #[derive(Error, Debug)]
@@ -54,13 +65,19 @@ pub fn resolve_import_path(
     )))
 }
 
+/// A sink for one entity's event stream.
 #[async_trait::async_trait]
-pub trait Exporter<T>: Send + Sync
+pub trait Exporter<T>: Send
 where
     T: Serialize + Send + EntityEvent,
 {
-    async fn push(&self, event: Event<T>) -> ExporterResult<()>;
-    async fn force_flush(&self) -> ExporterResult<()>;
+    /// Export one event.
+    async fn push(&mut self, event: Event<T>) -> ExporterResult<()>;
+
+    /// Make a best-effort to flush any buffered events, then release any internal resources.
+    ///
+    /// Calling [`Self::push`] will result in an error after calling this.
+    async fn shutdown(&mut self) -> ExporterResult<()>;
 }
 
 pub trait Importer<T>: Iterator<Item = Event<T>>

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -263,7 +263,7 @@ impl Context {
 
         debug!("constructing exporter for stream `{}`", T::NAME);
         let kind = config.clone().resolve(self.id);
-        let exporter = create_exporter::<T>(kind).await?;
+        let mut exporter = create_exporter::<T>(kind).await?;
 
         let cancellation_token = CancellationToken::new();
         let cloned_token = cancellation_token.clone();
@@ -291,9 +291,9 @@ impl Context {
                     else => break,
                 }
             }
-            // Flush once on shutdown, however the loop exited.
-            if let Err(e) = exporter.force_flush().await {
-                warn!("failed to flush exporter: {e}");
+            // Tear down once, however the loop exited.
+            if let Err(e) = exporter.shutdown().await {
+                warn!("failed to shut down exporter: {e}");
             }
         });
 

--- a/crates/instrumentation/tests/collector_roundtrip.rs
+++ b/crates/instrumentation/tests/collector_roundtrip.rs
@@ -93,8 +93,8 @@ fn collector_client_flushes_all_events_on_drop() {
         for _ in 0..EVENTS {
             observer.emit(Uuid::now_v7(), TestEvent);
         }
-        // Dropping the observer flushes the collector client (force_flush ->
-        // shutdown) and tears down its tasks — this is what must not panic.
+        // Dropping the observer shuts down the collector client and tears down
+        // its tasks — this is what must not panic.
     }
     drop(ctx);
 


### PR DESCRIPTION
Closes #245.

The forwarder owns each exporter and calls it serially, so the `&self` receivers and mutexes were unnecessary.

- `push` / `force_flush` → `&mut self`; `force_flush` renamed to `shutdown` (terminal drain + release).
- Removed the filesystem `BufWriter` mutexes and the collector client's join-handle mutexes.
- `push` after `shutdown` now returns `ExporterError::Shutdown`.
- `ExporterError` reduced to `Shutdown` + opaque `Other(Box<dyn Error + Send + Sync>)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)