### PR TITLE
feat(resource): add quent-resource constraint metadata types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-resource"
+version = "0.1.0"
+dependencies = [
+ "quent-schema",
+ "serde",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
 name = "quent-schema"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,10 +2247,10 @@ dependencies = [
 name = "quent-resource"
 version = "0.1.0"
 dependencies = [
+ "indexmap",
  "quent-schema",
  "serde",
  "serde_json",
- "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "crates/ref-target",
     "crates/ref-tree",
     "crates/fsm",
+    "crates/resource",
     "crates/instrumentation-build",
     "crates/instrumentation-build/example",
 ]

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -8,4 +8,4 @@ publish.workspace = true
 quent-schema = { path = "../schema", features = ["serde"] }
 serde = { workspace = true }
 serde_json.workspace = true
-smallvec.workspace = true
+indexmap = { workspace = true, features = ["serde"] }

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "quent-resource"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+quent-schema = { path = "../schema", features = ["serde"] }
+serde = { workspace = true }
+serde_json.workspace = true
+smallvec.workspace = true

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The Quent built-in resource constraint.
+
+use quent_schema::{Annotations, Identifier};
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+/// The data a `quent.resource.v1` constraint carries.
+///
+/// A resource is an entity with a finite supply that other entities claim
+/// against. The same constraint is placed on several schema elements. Each
+/// variant says what role the annotated element plays.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Resource {
+    /// Placed on a resource entity, declaring it a resource exposing
+    /// `capacities`. An empty list denotes a unit resource: one claimed for
+    /// mutual exclusion, with no quantified dimension.
+    Definition { capacities: SmallVec<[Capacity; 1]> },
+    /// Placed on the record type conveying a usage of resource `resource`. The
+    /// usage is held for the duration of a state of the FSM entity claiming it.
+    Usage { resource: Identifier },
+    /// Placed on the record type conveying the bounds of resource `resource`.
+    /// This record is used within the resource's own FSM.
+    Bounds { resource: Identifier },
+}
+
+impl Resource {
+    /// The constraint name under which this data is carried.
+    pub const NAME: &'static str = "quent.resource.v1";
+
+    /// The resource role declared on `annotations`, if any.
+    pub fn from_annotations(annotations: &Annotations) -> Option<Self> {
+        serde_json::from_str(annotations.constraint(Self::NAME)?.data()?).ok()
+    }
+}
+
+/// A named, quantified dimension of a resource that usages claim against.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capacity {
+    /// Unique within the resource.
+    name: Identifier,
+    kind: CapacityKind,
+}
+
+impl Capacity {
+    pub fn new(name: Identifier, kind: CapacityKind) -> Self {
+        Self { name, kind }
+    }
+
+    pub fn name(&self) -> &Identifier {
+        &self.name
+    }
+
+    pub fn kind(&self) -> CapacityKind {
+        self.kind
+    }
+}
+
+/// How a claimed quantity relates to the span over which it is held.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapacityKind {
+    /// A quantity held for the duration of a usage span, e.g. bytes of memory.
+    Occupancy,
+    /// A total quantity processed over a usage span, e.g. messages over a
+    /// channel. Dividing it by the span's duration yields a perceived rate, not
+    /// the true rate, which Quent cannot observe.
+    Rate,
+}

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -5,44 +5,8 @@
 
 use quent_schema::{Annotations, Identifier};
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
 
-/// The data a `quent.resource.v1` constraint carries.
-///
-/// A resource is an entity with one or more capacities that other entities can claim.
-///
-/// This data is placed on several schema elements. Each variant explains the
-/// role of the annotated element.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Resource {
-    /// Placed on a resource entity, declaring it a resource exposing
-    /// `capacities`. An empty list denotes a unit resource.
-    // Common-case: one capacity.
-    Definition { capacities: SmallVec<[Capacity; 1]> },
-    /// Placed on the record type conveying the bounds of resource `resource`.
-    ///
-    /// This record is used within the resource's own FSM.
-    Bounds { resource: Identifier },
-    /// Placed on the record type conveying a usage of resource `resource`.
-    ///
-    /// The usage is perceived as held for the duration of the FSM state of the
-    /// FSM entity claiming it. This record type can only be used on FSM state
-    /// transition events besides exit to ensure the usage is released.
-    Usage { resource: Identifier },
-}
-
-impl Resource {
-    /// The constraint name under which the data is carried.
-    pub const NAME: &'static str = "quent.resource.v1";
-
-    /// Deserialize [`Self`] from `annotations`, if it exists.
-    pub fn from_annotations(annotations: &Annotations) -> Option<Self> {
-        serde_json::from_str(annotations.constraint(Self::NAME)?.data()?).ok()
-    }
-}
-
-/// A named, quantified dimension of a resource that usages claim against.
+/// A named, quantified dimension of a resource that usages claim.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Capacity {
     /// The unique name of the capacity within the resource.
@@ -86,8 +50,68 @@ pub enum CapacityKind {
     /// memory.
     Occupancy,
     /// A total quantity processed over a usage span, e.g. bytes sent over a
-    /// channel. Dividing it by the span's duration yields a perceived rate. The
-    /// true rate may be hidden from Quent (e.g. when the work is performed
-    /// asynchronously).
+    /// channel. Dividing it by the span's duration yields the **perceived**
+    /// rate.
     Rate,
 }
+
+pub type Capacities = indexmap::IndexMap<Identifier, Capacity>;
+
+/// The data a `quent.resource.v1` constraint carries.
+///
+/// A resource is an entity with one or more capacities that other entities can claim.
+///
+/// This data is placed on several schema elements. Each variant explains the
+/// role of the annotated element.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Resource {
+    /// Placed on a resource entity, declaring it a resource providing
+    /// `capacities`.
+    // Common-case: one capacity.
+    Definition(Capacities),
+    /// Placed on the record type conveying the bounds of resource `resource`.
+    ///
+    /// This record is used by a resource's own events.
+    Bounds { resource: Identifier },
+    /// Placed on the record type conveying a usage of resource `resource`.
+    ///
+    /// The usage is perceived as held for the duration of the FSM state of the
+    /// FSM entity claiming it. This record type can only be used on FSM state
+    /// transition events besides exit to ensure the usage is released.
+    Usage { resource: Identifier },
+}
+
+impl Resource {
+    /// The constraint name under which the data is carried.
+    pub const NAME: &'static str = "quent.resource.v1";
+
+    /// Deserialize [`Self`] from `annotations`, if it exists.
+    pub fn from_annotations(annotations: &Annotations) -> Option<Self> {
+        serde_json::from_str(annotations.constraint(Self::NAME)?.data()?).ok()
+    }
+}
+
+/// A Resource is an Entity with certain Capacities that other Entities may
+/// claim through a Usage over some span of time.
+///
+/// Only states of FSM-type entities provide the guarantee that Usages end
+/// (either by transitioning to some next state or the mandatory special exit
+/// state which inherently does not hold attributes), thus only FSM-type
+/// entities can use resources.
+///
+/// ## Requirements
+///
+/// 1. A resource is an entity with at least one [`Capacity`].
+/// 2. The [`Identifier`] of a [`Capacity`] is unique within a resource.
+/// 3. If and only if any of the resource's [`Capacities`] have a bound, the
+///    resource entity has at least one event (the "bounds event") which
+///    declares the bounds of all [`Capacities`] that are bounded.
+/// 4. An entity can use some quantity of a resource's [`Capacities`] if and
+///    only if it is an FSM.
+/// 5. The resource named by a usage or bounds is a declared resource.
+/// 6. A usage claims only [`Capacities`] declared by its resource.
+#[derive(Default)]
+pub struct ResourceConstraint;
+
+// TODO(johanpel): validation

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -9,29 +9,34 @@ use smallvec::SmallVec;
 
 /// The data a `quent.resource.v1` constraint carries.
 ///
-/// A resource is an entity with a finite supply that other entities claim
-/// against. The same constraint is placed on several schema elements. Each
-/// variant says what role the annotated element plays.
+/// A resource is an entity with one or more capacities that other entities can claim.
+///
+/// This data is placed on several schema elements. Each variant explains the
+/// role of the annotated element.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Resource {
     /// Placed on a resource entity, declaring it a resource exposing
-    /// `capacities`. An empty list denotes a unit resource: one claimed for
-    /// mutual exclusion, with no quantified dimension.
+    /// `capacities`. An empty list denotes a unit resource.
+    // Common-case: one capacity.
     Definition { capacities: SmallVec<[Capacity; 1]> },
-    /// Placed on the record type conveying a usage of resource `resource`. The
-    /// usage is held for the duration of a state of the FSM entity claiming it.
-    Usage { resource: Identifier },
     /// Placed on the record type conveying the bounds of resource `resource`.
+    ///
     /// This record is used within the resource's own FSM.
     Bounds { resource: Identifier },
+    /// Placed on the record type conveying a usage of resource `resource`.
+    ///
+    /// The usage is perceived as held for the duration of the FSM state of the
+    /// FSM entity claiming it. This record type can only be used on FSM state
+    /// transition events besides exit to ensure the usage is released.
+    Usage { resource: Identifier },
 }
 
 impl Resource {
-    /// The constraint name under which this data is carried.
+    /// The constraint name under which the data is carried.
     pub const NAME: &'static str = "quent.resource.v1";
 
-    /// The resource role declared on `annotations`, if any.
+    /// Deserialize [`Self`] from `annotations`, if it exists.
     pub fn from_annotations(annotations: &Annotations) -> Option<Self> {
         serde_json::from_str(annotations.constraint(Self::NAME)?.data()?).ok()
     }
@@ -40,14 +45,24 @@ impl Resource {
 /// A named, quantified dimension of a resource that usages claim against.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Capacity {
-    /// Unique within the resource.
+    /// The unique name of the capacity within the resource.
     name: Identifier,
+    /// The type of capacity.
     kind: CapacityKind,
+    /// Whether the capacity is bounded. If all capacities of a resource are
+    /// unbounded, then no bounds need to be set, so no bound record type should
+    /// exist, and the FSM transition into "operating" shall not have a bounds
+    /// argument.
+    bounded: bool,
 }
 
 impl Capacity {
-    pub fn new(name: Identifier, kind: CapacityKind) -> Self {
-        Self { name, kind }
+    pub fn new(name: Identifier, kind: CapacityKind, bounded: bool) -> Self {
+        Self {
+            name,
+            kind,
+            bounded,
+        }
     }
 
     pub fn name(&self) -> &Identifier {
@@ -57,16 +72,22 @@ impl Capacity {
     pub fn kind(&self) -> CapacityKind {
         self.kind
     }
+
+    pub fn bounded(&self) -> bool {
+        self.bounded
+    }
 }
 
-/// How a claimed quantity relates to the span over which it is held.
+/// How a capacity relates to the span over which it is held.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CapacityKind {
-    /// A quantity held for the duration of a usage span, e.g. bytes of memory.
+    /// A quantity held for the duration of a usage span, e.g. bytes of a
+    /// memory.
     Occupancy,
-    /// A total quantity processed over a usage span, e.g. messages over a
-    /// channel. Dividing it by the span's duration yields a perceived rate, not
-    /// the true rate, which Quent cannot observe.
+    /// A total quantity processed over a usage span, e.g. bytes sent over a
+    /// channel. Dividing it by the span's duration yields a perceived rate. The
+    /// true rate may be hidden from Quent (e.g. when the work is performed
+    /// asynchronously).
     Rate,
 }


### PR DESCRIPTION
# Description

This PR adds the `quent-resource` crate. It only adds the types that are serialized as opaque schema metadata. Validation will follow later.

## Related Issues

#196
