### PR TITLE
refactor(analyzer): convert FsmCollection to associated-type form

### DIFF
--- a/crates/analyzer/src/fsm/collection.rs
+++ b/crates/analyzer/src/fsm/collection.rs
@@ -9,66 +9,43 @@ use rustc_hash::FxHashMap as HashMap;
 use uuid::Uuid;
 
 use crate::{
-    fsm::{Fsm, Transition},
+    fsm::Fsm,
     resource::{Usage, Using},
 };
 
-/// Trait for types that hold a collection of [`Fsm`]s.
-pub trait FsmCollection<F, T>
-where
-    F: Fsm<TransitionType = T>,
-    T: Transition,
-{
-    fn fsms<'a>(&'a self) -> impl Iterator<Item = &'a F> + 'a
-    where
-        F: 'a;
+/// Trait for types that hold a collection of [`Fsm`]s of a single type.
+///
+/// An application with several FSM kinds unifies them under one [`Self::Fsm`]
+/// type (e.g. an enum) so a single collection spans all of them.
+pub trait FsmCollection {
+    /// The FSM type held by this collection.
+    type Fsm: Fsm;
 
-    fn contains_fsm_type(&self, type_name: &str) -> bool;
+    fn fsms(&self) -> impl Iterator<Item = &Self::Fsm>;
 }
 
 /// An in-memory collection of [`Fsm`]s.
-pub struct InMemoryFsms<F, T>
-where
-    F: Fsm<TransitionType = T>,
-    T: Transition,
-{
+pub struct InMemoryFsms<F: Fsm> {
     pub fsms: HashMap<Uuid, F>,
     pub fsm_type_names: HashSet<String>,
 }
 
-impl<F, T> FsmCollection<F, T> for InMemoryFsms<F, T>
-where
-    F: Fsm<TransitionType = T>,
-    T: Transition,
-{
-    fn fsms<'a>(&'a self) -> impl Iterator<Item = &'a F> + 'a
-    where
-        T: 'a,
-    {
-        self.fsms.values()
-    }
+impl<F: Fsm> FsmCollection for InMemoryFsms<F> {
+    type Fsm = F;
 
-    fn contains_fsm_type(&self, type_name: &str) -> bool {
-        self.fsm_type_names.contains(type_name)
+    fn fsms(&self) -> impl Iterator<Item = &F> {
+        self.fsms.values()
     }
 }
 
-impl<F, T> Using for InMemoryFsms<F, T>
-where
-    F: Fsm<TransitionType = T> + Using,
-    T: Transition,
-{
+impl<F: Fsm + Using> Using for InMemoryFsms<F> {
     fn usages<'a>(&'a self) -> impl Iterator<Item = impl Usage<'a>> {
         self.fsms.values().flat_map(|fsm| fsm.usages())
     }
 }
 
 #[cfg(test)]
-impl<F, T> InMemoryFsms<F, T>
-where
-    F: Fsm<TransitionType = T>,
-    T: Transition,
-{
+impl<F: Fsm> InMemoryFsms<F> {
     pub(crate) fn new() -> Self {
         Self {
             fsms: Default::default(),

--- a/crates/analyzer/src/fsm/runtime.rs
+++ b/crates/analyzer/src/fsm/runtime.rs
@@ -300,7 +300,7 @@ impl RtFsmsBuilder {
             .push(transition);
     }
 
-    pub fn try_build(self) -> AnalyzerResult<InMemoryFsms<RtFsm, RtFsmTransition>> {
+    pub fn try_build(self) -> AnalyzerResult<InMemoryFsms<RtFsm>> {
         // Build all FSMs.
         let mut fsms: HashMap<Uuid, RtFsm> =
             HashMap::with_capacity_and_hasher(self.fsms.capacity(), Default::default());

--- a/crates/analyzer/src/timeline/binned/resource.rs
+++ b/crates/analyzer/src/timeline/binned/resource.rs
@@ -213,7 +213,7 @@ mod tests {
         build_root_and_memory(&mut resources, resource_id);
         let resources = resources.try_build().unwrap();
 
-        let mut fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        let mut fsms = InMemoryFsms::<RtFsm>::new();
 
         // Produce triangle-ish memory utilization using 4 FSMs
         for i in 0..4 {
@@ -296,7 +296,7 @@ mod tests {
         build_root_and_memory(&mut resources, resource_b_id);
         let resources = resources.try_build().unwrap();
 
-        let mut fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        let mut fsms = InMemoryFsms::<RtFsm>::new();
 
         // Produce triangle-ish memory utilization using 4 FSMs
         for i in 0..4 {
@@ -382,7 +382,7 @@ mod tests {
         builder.push_group_raw(ROOT_RESOURCE_ID, "test", "test", None);
         let mut resources = builder.try_build().unwrap();
 
-        let mut fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        let mut fsms = InMemoryFsms::<RtFsm>::new();
 
         // Add a resource with 2 capacities.
         resources.insert_type(ResourceTypeDecl::new(
@@ -484,7 +484,7 @@ mod tests {
         build_root_and_memory(&mut resources, resource_id);
         let resources = resources.try_build().unwrap();
 
-        let mut fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        let mut fsms = InMemoryFsms::<RtFsm>::new();
 
         // Produce triangle-ish memory utilization using 4 FSMs with 2 usage states
         for i in 0..4 {
@@ -605,7 +605,7 @@ mod tests {
         build_root_and_memory(&mut resources, resource_b_id);
         let resources = resources.try_build().unwrap();
 
-        let mut fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        let mut fsms = InMemoryFsms::<RtFsm>::new();
 
         // Produce the same utilization as previous test but spread it out across two leaf resources.
         for i in 0..4 {
@@ -771,7 +771,7 @@ mod tests {
             .unwrap()
         };
 
-        let mut outside_fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        let mut outside_fsms = InMemoryFsms::<RtFsm>::new();
         outside_fsms.insert(make_fsm(0, 500));
         outside_fsms.insert(make_fsm(2500, 3000));
 
@@ -780,7 +780,7 @@ mod tests {
         outside_builder.try_extend(outside_fsms.usages()).unwrap();
         assert!(!outside_builder.build().long_entities.contains(&resource_id));
 
-        let mut inside_fsms = InMemoryFsms::<RtFsm, RtFsmTransition>::new();
+        let mut inside_fsms = InMemoryFsms::<RtFsm>::new();
         inside_fsms.insert(make_fsm(500, 1500));
         inside_fsms.insert(make_fsm(1100, 1900));
 

--- a/examples/simulator/analyzer/src/model.rs
+++ b/examples/simulator/analyzer/src/model.rs
@@ -132,23 +132,11 @@ impl SimulatorModel {
     }
 }
 
-impl
-    FsmCollection<
-        Task,
-        quent_analyzer::fsm::events::TransitionEvent<
-            quent_simulator_instrumentation::task::TaskTransition,
-        >,
-    > for SimulatorModel
-{
-    fn fsms<'a>(&'a self) -> impl Iterator<Item = &'a Task> + 'a
-    where
-        Task: 'a,
-    {
-        self.tasks.values()
-    }
+impl FsmCollection for SimulatorModel {
+    type Fsm = Task;
 
-    fn contains_fsm_type(&self, type_name: &str) -> bool {
-        !self.tasks.is_empty() && type_name == "task"
+    fn fsms(&self) -> impl Iterator<Item = &Task> {
+        self.tasks.values()
     }
 }
 


### PR DESCRIPTION
# Description

Replace `FsmCollection<F, T>` with a single associated `type Fsm`, and drop the
uncalled `contains_fsm_type`. Lets a collection expose exactly one FSM type and
unblocks bounding generic code on it. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issues

Part of #214, split off from #240