### PR TITLE
feat: record a model's analyzer package in provenance

### DIFF
--- a/crates/build-info/src/lib.rs
+++ b/crates/build-info/src/lib.rs
@@ -68,6 +68,10 @@ pub struct ModelInfo {
     pub type_path: String,
     /// Git provenance of the crate defining the model.
     pub source: BuildInfo,
+    /// Cargo package providing this model's `QuentViewer` entry (shares the
+    /// model's [`source`](Self::source) git); `None` if the model didn't declare one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub analyzer_package: Option<String>,
 }
 
 impl BuildInfo {
@@ -94,6 +98,7 @@ impl ModelInfo {
             package: "unknown".to_string(),
             type_path: "unknown".to_string(),
             source: BuildInfo::unknown(),
+            analyzer_package: None,
         }
     }
 }
@@ -195,6 +200,11 @@ pub trait ModelSource {
     fn package() -> &'static str;
     /// Git provenance of the crate defining the model.
     fn source() -> BuildInfo;
+    /// Cargo package providing this model's `QuentViewer` entry, if declared via
+    /// `analyzer_package` in `model!` (shares the model's [`source`](Self::source) git).
+    fn analyzer_package() -> Option<&'static str> {
+        None
+    }
 
     /// Assemble the [`ModelInfo`] for this model: the Rust type path and name
     /// from [`std::any::type_name`], the cargo package and source git from the
@@ -208,6 +218,7 @@ pub trait ModelSource {
             package: Self::package().to_string(),
             type_path: type_path.to_string(),
             source: Self::source(),
+            analyzer_package: Self::analyzer_package().map(str::to_string),
         }
     }
 }
@@ -254,6 +265,40 @@ mod tests {
         let bytes = serde_json::to_vec(&info).unwrap();
         let back: ArtifactInfo = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(info, back);
+    }
+
+    #[test]
+    fn analyzer_package_threads_and_roundtrips() {
+        struct WithAnalyzer;
+        impl ModelSource for WithAnalyzer {
+            fn package() -> &'static str {
+                "quent-build-info"
+            }
+            fn source() -> BuildInfo {
+                BuildInfo::unknown()
+            }
+            fn analyzer_package() -> Option<&'static str> {
+                Some("quent-simulator-analyzer")
+            }
+        }
+
+        // `model_info()` carries the declared analyzer package...
+        let info = WithAnalyzer::model_info();
+        assert_eq!(
+            info.analyzer_package.as_deref(),
+            Some("quent-simulator-analyzer")
+        );
+        let back: ModelInfo = serde_json::from_slice(&serde_json::to_vec(&info).unwrap()).unwrap();
+        assert_eq!(info, back);
+
+        // ...and absent by default, omitted from the serialized form.
+        let none = TestModel::model_info();
+        assert_eq!(none.analyzer_package, None);
+        assert!(
+            !serde_json::to_string(&none)
+                .unwrap()
+                .contains("analyzer_package")
+        );
     }
 
     #[test]

--- a/crates/model-macros/src/lib.rs
+++ b/crates/model-macros/src/lib.rs
@@ -71,6 +71,7 @@ pub fn derive_resizable_resource(input: TokenStream) -> TokenStream {
 ///     name: App,
 ///     root: Cluster,
 ///     entities: { Worker, Thread, Task },
+///     analyzer: "my-analyzer", // optional: crate providing the QuentViewer
 /// }
 /// ```
 #[proc_macro]

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -13,6 +13,7 @@
 //!         task::Task,
 //!         quent_stdlib::memory::Memory,
 //!     },
+//!     analyzer: "my-analyzer", // optional: crate providing the QuentViewer
 //! }
 //! ```
 //!
@@ -22,12 +23,15 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
-use syn::{Path, Token};
+use syn::{LitStr, Path, Token};
 
 struct DefineModelInput {
     name: Ident,
     root: Path,
     components: Vec<Path>,
+    /// Optional `analyzer: "<crate>"`: the cargo package providing this model's
+    /// `QuentViewer` entry, recorded in the provenance sidecar.
+    analyzer_package: Option<LitStr>,
 }
 
 impl Parse for DefineModelInput {
@@ -37,6 +41,7 @@ impl Parse for DefineModelInput {
         let mut name: Option<Ident> = None;
         let mut root: Option<Path> = None;
         let mut components: Option<Vec<Path>> = None;
+        let mut analyzer_package: Option<LitStr> = None;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -68,11 +73,16 @@ impl Parse for DefineModelInput {
                     }
                     components = Some(entities);
                 }
+                "analyzer" => {
+                    if analyzer_package.replace(input.parse()?).is_some() {
+                        return Err(dup());
+                    }
+                }
                 other => {
                     return Err(syn::Error::new_spanned(
                         &key,
                         format!(
-                            "unknown `model!` field `{other}`; expected `name`, `root`, or `entities`"
+                            "unknown `model!` field `{other}`; expected `name`, `root`, `entities`, or `analyzer`"
                         ),
                     ));
                 }
@@ -88,6 +98,7 @@ impl Parse for DefineModelInput {
             name,
             root,
             components: components.unwrap_or_default(),
+            analyzer_package,
         })
     }
 }
@@ -272,6 +283,16 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
          with no collector at capture time."
     );
 
+    // Emit a `ModelSource::analyzer_package()` override only when declared.
+    let analyzer_package_method = match &input.analyzer_package {
+        Some(lit) => quote! {
+            fn analyzer_package() -> Option<&'static str> {
+                Some(#lit)
+            }
+        },
+        None => quote! {},
+    };
+
     let output = quote! {
         #[doc = #doc_model]
         pub type #model_type = quent_model::Model<#model_tuple>;
@@ -313,6 +334,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
                     option_env!("QUENT_SOURCE_BUILT_AT"),
                 )
             }
+            #analyzer_package_method
         }
 
         impl #name {
@@ -464,4 +486,29 @@ pub fn expand_instrumentation(input: TokenStream) -> syn::Result<TokenStream> {
     Ok(quote! {
         #impl_macro_name!();
     })
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::DefineModelInput;
+
+    #[test]
+    fn parses_analyzer_field() {
+        let input: DefineModelInput = syn::parse_str(
+            r#"name: App, root: a::Root, entities: { b::Comp }, analyzer: "my-analyzer""#,
+        )
+        .unwrap();
+        assert_eq!(input.components.len(), 1);
+        assert_eq!(
+            input.analyzer_package.map(|l| l.value()),
+            Some("my-analyzer".to_string())
+        );
+    }
+
+    #[test]
+    fn analyzer_is_optional() {
+        let input: DefineModelInput = syn::parse_str("name: App, root: a::Root").unwrap();
+        assert!(input.analyzer_package.is_none());
+        assert!(input.components.is_empty());
+    }
 }


### PR DESCRIPTION
Adds an optional `analyzer_package` to `ModelInfo`/`model.qmi` and a defaulted `ModelSource::analyzer_package()`; `model!` gains an `analyzer_package: "<crate>"` directive recording the crate that provides a model's viewer.

Part 2/7 of the `quent-open` series (#234). Stacked on #260 — review/merge bottom-up (Files-changed includes #260 until it lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)