### PR TITLE
feat(analyzer): add the QuentViewer entry trait

### DIFF
--- a/domains/query_engine/analyzer/src/ui.rs
+++ b/domains/query_engine/analyzer/src/ui.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use quent_analyzer::AnalyzerResult;
 use quent_events::Event;
+use quent_model::exporter::{FileSystemFormat, ImporterResult};
 use quent_query_engine_ui as ui;
 use quent_ui::timeline::{
     request::{BulkChunkedTimelineRequest, BulkTimelineRequest, SingleTimelineRequest},
@@ -104,4 +106,29 @@ pub trait UiAnalyzer {
 
         Ok(BulkChunkedTimelinesResponse { entries })
     }
+}
+
+/// A boxed, owned stream of an analyzer's [`UiAnalyzer::Event`], as produced by
+/// [`QuentViewer::import_events`].
+pub type ViewerEventStream<A> = Box<dyn Iterator<Item = Event<<A as UiAnalyzer>::Event>>>;
+
+/// A model's viewer entry point for `quent-open`: ties the model's event
+/// importer to the [`UiAnalyzer`] that renders it, so a viewer can be built
+/// knowing only the crate that provides this impl (no analyzer type path).
+///
+/// Implement it on a local unit type named `Viewer` at the analyzer crate root —
+/// the conventional path `quent-open` names when it generates a viewer wrapper.
+/// The associated [`Analyzer`](Self::Analyzer) and the model's `import_events`
+/// share an event type, so the wiring is checked at compile time.
+pub trait QuentViewer {
+    /// The analyzer that renders this model's events.
+    type Analyzer: UiAnalyzer + Send + Sync + 'static;
+
+    /// Reconstruct the model's event stream from a single context directory,
+    /// yielding events of the [`Analyzer`](Self::Analyzer)'s event type. Wraps
+    /// the model marker's generated `import_events`.
+    fn import_events(
+        dir: &Path,
+        format: FileSystemFormat,
+    ) -> ImporterResult<ViewerEventStream<Self::Analyzer>>;
 }

--- a/domains/query_engine/analyzer/src/ui.rs
+++ b/domains/query_engine/analyzer/src/ui.rs
@@ -113,13 +113,19 @@ pub trait UiAnalyzer {
 pub type ViewerEventStream<A> = Box<dyn Iterator<Item = Event<<A as UiAnalyzer>::Event>>>;
 
 /// Model viewer entry point for `quent-open`: connects the event importer to
-/// the rendering [`UiAnalyzer`], letting a viewer build from only the crate
-/// providing this impl (no analyzer type path).
+/// the rendering [`UiAnalyzer`].
 ///
-/// Implement on a local unit type named `Viewer` at the analyzer crate root,
-/// the conventional path `quent-open` names in generated wrappers. The
-/// associated [`Analyzer`](Self::Analyzer) and model `import_events` share an
-/// event type, so wiring is compile-time checked.
+/// `quent-open` builds a viewer knowing only the analyzer's *crate name*: it
+/// names `<crate>::Viewer` in the generated wrapper and reaches the analyzer
+/// through the associated [`Analyzer`](Self::Analyzer) type. So the model
+/// records only its analyzer package — never the analyzer's concrete type path,
+/// which the model couldn't name anyway (the marker's instrumentation crate does
+/// not depend on the analyzer crate).
+///
+/// Implement it on a local unit type named `Viewer` at the analyzer crate root
+/// (the path `quent-open` requires). The associated [`Analyzer`](Self::Analyzer)
+/// and the model's `import_events` share an event type, so the wiring is checked
+/// at compile time.
 pub trait QuentViewer {
     /// The analyzer that renders this model's events.
     type Analyzer: UiAnalyzer + Send + Sync + 'static;

--- a/domains/query_engine/analyzer/src/ui.rs
+++ b/domains/query_engine/analyzer/src/ui.rs
@@ -108,25 +108,25 @@ pub trait UiAnalyzer {
     }
 }
 
-/// A boxed, owned stream of an analyzer's [`UiAnalyzer::Event`], as produced by
+/// Boxed owned stream of an analyzer's [`UiAnalyzer::Event`] from
 /// [`QuentViewer::import_events`].
 pub type ViewerEventStream<A> = Box<dyn Iterator<Item = Event<<A as UiAnalyzer>::Event>>>;
 
-/// A model's viewer entry point for `quent-open`: ties the model's event
-/// importer to the [`UiAnalyzer`] that renders it, so a viewer can be built
-/// knowing only the crate that provides this impl (no analyzer type path).
+/// Model viewer entry point for `quent-open`: connects the event importer to
+/// the rendering [`UiAnalyzer`], letting a viewer build from only the crate
+/// providing this impl (no analyzer type path).
 ///
-/// Implement it on a local unit type named `Viewer` at the analyzer crate root —
-/// the conventional path `quent-open` names when it generates a viewer wrapper.
-/// The associated [`Analyzer`](Self::Analyzer) and the model's `import_events`
-/// share an event type, so the wiring is checked at compile time.
+/// Implement on a local unit type named `Viewer` at the analyzer crate root,
+/// the conventional path `quent-open` names in generated wrappers. The
+/// associated [`Analyzer`](Self::Analyzer) and model `import_events` share an
+/// event type, so wiring is compile-time checked.
 pub trait QuentViewer {
     /// The analyzer that renders this model's events.
     type Analyzer: UiAnalyzer + Send + Sync + 'static;
 
-    /// Reconstruct the model's event stream from a single context directory,
-    /// yielding events of the [`Analyzer`](Self::Analyzer)'s event type. Wraps
-    /// the model marker's generated `import_events`.
+    /// Reconstruct the model's event stream from one context directory, yielding
+    /// events of the [`Analyzer`](Self::Analyzer)'s event type. Wraps the model
+    /// marker's generated `import_events`.
     fn import_events(
         dir: &Path,
         format: FileSystemFormat,

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -3,7 +3,7 @@
 
 use quent_events::Event;
 pub use quent_query_engine_analyzer::QueryEngineModel;
-use quent_query_engine_analyzer::ui::UiAnalyzer;
+use quent_query_engine_analyzer::ui::{QuentViewer, UiAnalyzer, ViewerEventStream};
 use quent_query_engine_ui::{OperatorFilter, QueryBundle, QueryEntities, QueryFilter};
 use quent_ui::{
     FiniteStateMachine, ResourceGroupNode, ResourceTree, convert_resource_tree,
@@ -36,7 +36,7 @@ use quent_analyzer::{
         ResourceTimelineByKeyBuilder,
     },
 };
-use quent_simulator_instrumentation::SimulatorEvent;
+use quent_simulator_instrumentation::{Simulator, SimulatorEvent};
 use quent_simulator_ui::EntityRef;
 use quent_time::{SpanNanoSec, TimeNanoSec, TimeUnixNanoSec, to_nanosecs, to_secs};
 use uuid::Uuid;
@@ -52,6 +52,22 @@ pub mod view;
 
 pub struct SimulatorUiAnalyzer {
     pub model: SimulatorModel,
+}
+
+/// `quent-open` viewer entry for the simulator model: renders [`SimulatorEvent`]
+/// streams with [`SimulatorUiAnalyzer`]. The conventional `Viewer` path
+/// `quent-open` names when building a viewer for this analyzer's models.
+pub struct Viewer;
+
+impl QuentViewer for Viewer {
+    type Analyzer = SimulatorUiAnalyzer;
+
+    fn import_events(
+        dir: &std::path::Path,
+        format: quent_model::exporter::FileSystemFormat,
+    ) -> quent_model::exporter::ImporterResult<ViewerEventStream<Self::Analyzer>> {
+        Simulator::import_events(dir, format)
+    }
 }
 
 struct PlainBuilderSlot<'a> {

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -55,7 +55,7 @@ pub struct SimulatorUiAnalyzer {
 }
 
 /// `quent-open` viewer entry for the simulator model: renders [`SimulatorEvent`]
-/// streams with [`SimulatorUiAnalyzer`]. The conventional `Viewer` path
+/// streams with [`SimulatorUiAnalyzer`]. The required `Viewer` path
 /// `quent-open` names when building a viewer for this analyzer's models.
 pub struct Viewer;
 

--- a/examples/simulator/instrumentation/src/lib.rs
+++ b/examples/simulator/instrumentation/src/lib.rs
@@ -36,6 +36,7 @@ model! {
         quent_stdlib::processor::Processor,
         quent_stdlib::channel::Channel,
     },
+    analyzer: "quent-simulator-analyzer",
 }
 
 instrumentation!(Simulator);


### PR DESCRIPTION
Adds `QuentViewer` next to `UiAnalyzer`: a model's viewer entry tying its event importer to the analyzer that renders it, so a viewer can be built knowing only the providing crate. Implements it for the simulator.

Part 3/7 (#234). Stacked on #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)