### PR TITLE
feat(open): discover all exports and serve one viewer per model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,6 +2225,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/open/Cargo.toml
+++ b/crates/open/Cargo.toml
@@ -21,6 +21,7 @@ syn = { version = "2", features = ["full", "parsing"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "net", "process", "rt-multi-thread", "time"] }
 toml = "0.8"
+walkdir = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/open/src/error.rs
+++ b/crates/open/src/error.rs
@@ -59,6 +59,14 @@ pub enum OpenError {
     #[error("the viewer exited unexpectedly (status {status})")]
     ViewerExited { status: String },
 
+    /// No context directories (with a `model.qmi`) were found under the paths.
+    #[error("no Quent context directories (with a model.qmi) found under the given paths")]
+    NoContexts,
+
+    /// One or more viewers failed to build or serve.
+    #[error("{count} viewer(s) failed")]
+    ViewersFailed { count: usize },
+
     /// An I/O error occurred (reading artifacts, spawning the viewer, etc.).
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/open/src/error.rs
+++ b/crates/open/src/error.rs
@@ -59,7 +59,7 @@ pub enum OpenError {
     #[error("the viewer exited unexpectedly (status {status})")]
     ViewerExited { status: String },
 
-    /// No context directories (with a `model.qmi`) were found under the paths.
+    /// No context directories with `model.qmi` were found under the paths.
     #[error("no Quent context directories (with a model.qmi) found under the given paths")]
     NoContexts,
 

--- a/crates/open/src/main.rs
+++ b/crates/open/src/main.rs
@@ -30,7 +30,7 @@ use crate::viewer::ViewerGroup;
 #[command(name = "quent-open")]
 #[command(about = "Open local Quent artifacts in an application-specific viewer")]
 struct Cli {
-    /// Do not open a browser (a viewer's URL is always printed when it is ready).
+    /// Do not open a browser; print each viewer URL when ready.
     #[arg(long, global = true)]
     no_browser: bool,
 
@@ -61,11 +61,10 @@ async fn main() -> Result<()> {
     }
 }
 
-/// Discover all context directories under `paths` (recursively), group them into
-/// one viewer per distinct build spec (same analyzer + pinned commits + format),
-/// then build and serve those viewers in parallel. Contexts that can't be opened
-/// (no analyzer package, unreadable sidecar) are skipped with a warning rather
-/// than aborting.
+/// Recursively discover contexts under `paths`, group them by build spec (same
+/// analyzer + pinned commits + format), then build and serve viewers in parallel.
+/// Contexts that can't be opened (no analyzer package, unreadable sidecar) are
+/// warned and skipped.
 async fn run_local(cli: &Cli, paths: &[PathBuf]) -> Result<()> {
     let contexts = spec::discover_contexts(paths)?;
 

--- a/crates/open/src/main.rs
+++ b/crates/open/src/main.rs
@@ -15,34 +15,24 @@ mod spec;
 mod viewer;
 mod wrapper;
 
+use std::collections::BTreeMap;
 use std::net::IpAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use quent_build_info::{ArtifactInfo, SIDECAR_FILE_NAME};
 
 use crate::error::{OpenError, Result};
 use crate::spec::ViewerSpec;
+use crate::viewer::ViewerGroup;
 
 #[derive(Debug, Parser)]
 #[command(name = "quent-open")]
-#[command(about = "Open local Quent benchmark artifacts in an application-specific viewer")]
+#[command(about = "Open local Quent artifacts in an application-specific viewer")]
 struct Cli {
-    /// Config file path. Defaults to ./quent-open.toml, then ~/.config/quent/open.toml.
-    #[arg(long, global = true)]
-    config: Option<PathBuf>,
-
-    /// Do not open a browser.
+    /// Do not open a browser (a viewer's URL is always printed when it is ready).
     #[arg(long, global = true)]
     no_browser: bool,
-
-    /// Print the opened viewer URL.
-    #[arg(long, global = true)]
-    print_url: bool,
-
-    /// Force a specific viewer by name from the config (skips automatic matching).
-    #[arg(long, global = true)]
-    viewer: Option<String>,
 
     /// Host/interface the viewer binds (`0.0.0.0` exposes it to other hosts).
     #[arg(long, global = true, default_value = "127.0.0.1")]
@@ -71,49 +61,42 @@ async fn main() -> Result<()> {
     }
 }
 
-/// Open local artifacts in a viewer.
-///
-/// Reads each context directory's `model.qmi` sidecar, then resolves the viewer
-/// build spec (analyzer package, pinned git sources, artifact format). Each path
-/// is treated as a context directory; resolving a sidecar from a nested per-entity
-/// subdirectory is not supported.
-///
-/// For each context directory: generate a viewer crate from the spec, build it,
-/// serve the artifacts, and open a browser. Serving blocks until the viewer
-/// exits, so multiple paths are opened one after another.
+/// Discover all context directories under `paths` (recursively), group them into
+/// one viewer per distinct build spec (same analyzer + pinned commits + format),
+/// then build and serve those viewers in parallel. Contexts that can't be opened
+/// (no analyzer package, unreadable sidecar) are skipped with a warning rather
+/// than aborting.
 async fn run_local(cli: &Cli, paths: &[PathBuf]) -> Result<()> {
-    for path in paths {
-        let info = ArtifactInfo::read_sidecar(path).map_err(|source| OpenError::Sidecar {
-            path: path.join(SIDECAR_FILE_NAME),
-            source,
-        })?;
-        report_artifact(path, &info);
-        let spec = ViewerSpec::from_artifact(path, &info)?;
-        report_spec(&spec);
-        viewer::open(&spec, cli.no_browser, cli.print_url, cli.host).await?;
-    }
-    Ok(())
-}
+    let contexts = spec::discover_contexts(paths)?;
 
-/// Print the resolved viewer build spec for `spec`.
-fn report_spec(spec: &ViewerSpec) {
-    println!(
-        "  viewer:   {}::Viewer ({})",
-        spec.analyzer_crate(),
-        spec.format.extension()
-    );
-}
-
-/// Print the provenance discovered for `path`. The model `source` is what later
-/// drives checking out and building a viewer for the producing crate.
-fn report_artifact(path: &Path, info: &ArtifactInfo) {
-    let model = &info.model;
-    println!("{}", path.display());
-    println!("  model:    {} ({})", model.name, model.type_path);
-    println!("  package:  {}", model.package);
-    if let Some(analyzer) = &model.analyzer_package {
-        println!("  analyzer: {analyzer}");
+    // One group per build spec; contexts sharing a spec share a viewer.
+    let mut groups: BTreeMap<String, ViewerGroup> = BTreeMap::new();
+    for context in contexts {
+        let spec = match ArtifactInfo::read_sidecar(&context)
+            .map_err(|source| OpenError::Sidecar {
+                path: context.join(SIDECAR_FILE_NAME),
+                source,
+            })
+            .and_then(|info| ViewerSpec::from_artifact(&context, &info))
+        {
+            Ok(spec) => spec,
+            Err(e) => {
+                eprintln!("skipping {}: {e}", context.display());
+                continue;
+            }
+        };
+        groups
+            .entry(spec.group_key())
+            .or_insert_with(|| ViewerGroup {
+                spec: spec.clone(),
+                contexts: Vec::new(),
+            })
+            .contexts
+            .push(context);
     }
-    println!("  quent:    {}", info.quent);
-    println!("  source:   {}", model.source);
+
+    if groups.is_empty() {
+        return Err(OpenError::NoContexts);
+    }
+    viewer::open_all(groups.into_values().collect(), cli.no_browser, cli.host).await
 }

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -20,12 +20,13 @@ pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut found = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for path in paths {
-        // `WalkDir` does not follow symlinks by default (cycle-safe); `filter_entry`
-        // prunes hidden directories while keeping an explicitly-passed root.
-        let walk = WalkDir::new(path)
+        // `WalkDir` does not descend into symlinked directories (cycle-safe);
+        // `filter_entry` prunes hidden directories while keeping an explicitly-passed
+        // root.
+        let mut walk = WalkDir::new(path)
             .into_iter()
             .filter_entry(|entry| entry.depth() == 0 || !is_hidden(entry));
-        for entry in walk {
+        while let Some(entry) = walk.next() {
             // Report (don't silently drop) traversal errors so a permission-denied
             // subtree can't quietly shrink the discovered set; keep walking the rest.
             let entry = match entry {
@@ -35,11 +36,17 @@ pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
                     continue;
                 }
             };
-            if entry.file_type().is_dir() && entry.path().join(SIDECAR_FILE_NAME).is_file() {
+            // `Path::is_dir` follows symlinks, so a context reached via a symlinked
+            // argument (or directory) is still recognized, even though the walk
+            // itself never descends through the link.
+            if entry.path().is_dir() && entry.path().join(SIDECAR_FILE_NAME).is_file() {
                 let canonical = entry.path().canonicalize()?;
                 if seen.insert(canonical.clone()) {
                     found.push(canonical);
                 }
+                // A context is a leaf: skip its entity dirs and event streams so
+                // discovery scales with the directory tree, not the payload size.
+                walk.skip_current_dir();
             }
         }
     }
@@ -168,13 +175,16 @@ impl ViewerSpec {
     /// Unambiguous build identity: analyzer package, format, and both git
     /// remotes + full commits. Used to group/dedup contexts into viewers.
     pub fn group_key(&self) -> String {
-        // Unit separator between fields so values can't run together.
+        // Key on the Cargo-normalized remotes so equivalent spellings (e.g.
+        // scp-style vs `ssh://`) — which produce one dependency — share a build
+        // instead of splitting into separate viewers. Unit separator between
+        // fields so values can't run together.
         [
             self.analyzer_package.as_str(),
             self.format.extension(),
-            &self.quent.remote,
+            self.quent.cargo_url().as_str(),
             &self.quent.commit,
-            &self.analyzer.remote,
+            self.analyzer.cargo_url().as_str(),
             &self.analyzer.commit,
         ]
         .join("\u{1f}")
@@ -284,6 +294,49 @@ mod tests {
         // Passing a context directory directly yields just it.
         let direct = discover_contexts(&[root.join("a")]).unwrap();
         assert_eq!(direct.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovers_context_through_symlinked_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_context(&tmp.path().join("real"));
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(tmp.path().join("real"), &link).unwrap();
+
+        // A symlink pointing straight at a context must still be recognized.
+        let found = discover_contexts(&[link]).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].file_name().unwrap(), "real");
+    }
+
+    #[test]
+    fn group_key_normalizes_equivalent_remotes() {
+        let scp = ViewerSpec {
+            format: Format::Ndjson,
+            analyzer_package: "p".into(),
+            quent: GitPin {
+                remote: "git@github.com:org/quent.git".into(),
+                commit: "c".into(),
+            },
+            analyzer: GitPin {
+                remote: "git@github.com:org/a.git".into(),
+                commit: "d".into(),
+            },
+        };
+        let ssh = ViewerSpec {
+            quent: GitPin {
+                remote: "ssh://git@github.com/org/quent.git".into(),
+                commit: "c".into(),
+            },
+            analyzer: GitPin {
+                remote: "ssh://git@github.com/org/a.git".into(),
+                commit: "d".into(),
+            },
+            ..scp.clone()
+        };
+        assert_eq!(scp.group_key(), ssh.group_key());
+        assert_eq!(scp.cache_key(), ssh.cache_key());
     }
 
     #[cfg(unix)]

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -25,7 +25,16 @@ pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
         let walk = WalkDir::new(path)
             .into_iter()
             .filter_entry(|entry| entry.depth() == 0 || !is_hidden(entry));
-        for entry in walk.flatten() {
+        for entry in walk {
+            // Report (don't silently drop) traversal errors so a permission-denied
+            // subtree can't quietly shrink the discovered set; keep walking the rest.
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    eprintln!("warning: skipping unreadable path during discovery: {error}");
+                    continue;
+                }
+            };
             if entry.file_type().is_dir() && entry.path().join(SIDECAR_FILE_NAME).is_file() {
                 let canonical = entry.path().canonicalize()?;
                 if seen.insert(canonical.clone()) {

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -46,10 +46,11 @@ pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
                 }
                 // A context is a leaf: skip its entity dirs and event streams so
                 // discovery scales with the directory tree, not the payload size.
-                // Only for a genuinely-descended directory — for a symlinked
-                // context `skip_current_dir` would instead drop the symlink's
-                // (un-walked) siblings.
-                if entry.file_type().is_dir() {
+                // Skip only for directories `WalkDir` actually descends into: a
+                // real directory, or the root (followed even when it is a symlink).
+                // A non-root symlinked context isn't descended, and skipping it
+                // would instead drop the symlink's (un-walked) siblings.
+                if entry.depth() == 0 || entry.file_type().is_dir() {
                     walk.skip_current_dir();
                 }
             }
@@ -179,6 +180,19 @@ impl ViewerSpec {
 
     /// Unambiguous build identity: analyzer package, format, and both git
     /// remotes + full commits. Used to group/dedup contexts into viewers.
+    /// Short label distinguishing this build from other groups (package, format,
+    /// and short pins) so concurrent viewers with equal context counts are
+    /// still tellable apart.
+    pub fn describe(&self) -> String {
+        format!(
+            "{} ({}, quent@{} analyzer@{})",
+            self.analyzer_package,
+            self.format.extension(),
+            short_commit(&self.quent.commit),
+            short_commit(&self.analyzer.commit),
+        )
+    }
+
     pub fn group_key(&self) -> String {
         // Key on the Cargo-normalized remotes so equivalent spellings (e.g.
         // scp-style vs `ssh://`) — which produce one dependency — share a build

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -46,7 +46,12 @@ pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
                 }
                 // A context is a leaf: skip its entity dirs and event streams so
                 // discovery scales with the directory tree, not the payload size.
-                walk.skip_current_dir();
+                // Only for a genuinely-descended directory — for a symlinked
+                // context `skip_current_dir` would instead drop the symlink's
+                // (un-walked) siblings.
+                if entry.file_type().is_dir() {
+                    walk.skip_current_dir();
+                }
             }
         }
     }
@@ -308,6 +313,27 @@ mod tests {
         let found = discover_contexts(&[link]).unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].file_name().unwrap(), "real");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_context_does_not_hide_siblings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        make_context(&root.join("target"));
+        make_context(&root.join("sibling"));
+        // A non-root symlink straight to a context must not let `skip_current_dir`
+        // prune the symlink's (un-walked) siblings.
+        std::os::unix::fs::symlink(root.join("target"), root.join("link")).unwrap();
+
+        let found = discover_contexts(&[root.to_path_buf()]).unwrap();
+        let mut names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        // `link` canonicalizes to `target`, so the set is {sibling, target}.
+        assert_eq!(names, vec!["sibling", "target"]);
     }
 
     #[test]

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -8,55 +8,41 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 use quent_build_info::{ArtifactInfo, BuildInfo, SIDECAR_FILE_NAME};
+use walkdir::WalkDir;
 
 use crate::error::{OpenError, Result};
 
-/// Recursively discover context directories containing `model.qmi` under `paths`.
-/// Treat contexts as leaves; skip hidden dirs and symlinks to avoid cycles.
-/// Canonicalize and deduplicate results while preserving discovery order.
+/// Recursively discover context directories (those containing a `model.qmi`
+/// sidecar) under the given `paths`. Hidden directories (dotfiles, e.g. `.git`)
+/// are skipped and symlinks are not followed (so the walk stays cycle-safe).
+/// Results are canonicalized and deduplicated, preserving discovery order.
 pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut found = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for path in paths {
-        collect_contexts(path, &mut found, &mut seen)?;
+        // `WalkDir` does not follow symlinks by default (cycle-safe); `filter_entry`
+        // prunes hidden directories while keeping an explicitly-passed root.
+        let walk = WalkDir::new(path)
+            .into_iter()
+            .filter_entry(|entry| entry.depth() == 0 || !is_hidden(entry));
+        for entry in walk.flatten() {
+            if entry.file_type().is_dir() && entry.path().join(SIDECAR_FILE_NAME).is_file() {
+                let canonical = entry.path().canonicalize()?;
+                if seen.insert(canonical.clone()) {
+                    found.push(canonical);
+                }
+            }
+        }
     }
     Ok(found)
 }
 
-fn collect_contexts(
-    dir: &Path,
-    found: &mut Vec<PathBuf>,
-    seen: &mut std::collections::HashSet<PathBuf>,
-) -> Result<()> {
-    if !dir.is_dir() {
-        return Ok(());
-    }
-    if dir.join(SIDECAR_FILE_NAME).is_file() {
-        let canonical = dir.canonicalize()?;
-        if seen.insert(canonical.clone()) {
-            found.push(canonical);
-        }
-        return Ok(()); // a context is a leaf; do not descend into its entity dirs
-    }
-    for entry in std::fs::read_dir(dir)?.flatten() {
-        // `file_type()` does not follow symlinks, so symlinked dirs are not
-        // recursed into and the walk stays cycle-safe.
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if !file_type.is_dir() {
-            continue;
-        }
-        let child = entry.path();
-        let hidden = child
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.starts_with('.'));
-        if !hidden {
-            collect_contexts(&child, found, seen)?;
-        }
-    }
-    Ok(())
+/// Whether a walked entry is hidden (its file name starts with `.`).
+fn is_hidden(entry: &walkdir::DirEntry) -> bool {
+    entry
+        .file_name()
+        .to_str()
+        .is_some_and(|name| name.starts_with('.'))
 }
 
 /// Serialization format of an artifact's event streams.
@@ -286,7 +272,7 @@ mod tests {
         names.sort();
         assert_eq!(names, vec!["a", "b"]);
 
-        // Passing a context directly yields just it (no descent into entity dirs).
+        // Passing a context directory directly yields just it.
         let direct = discover_contexts(&[root.join("a")]).unwrap();
         assert_eq!(direct.len(), 1);
     }

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -4,11 +4,63 @@
 //! Build a [`ViewerSpec`] from a context's `model.qmi`: pinned git sources,
 //! analyzer package, and artifact format for generating/building a viewer.
 
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
-use quent_build_info::{ArtifactInfo, BuildInfo};
+use quent_build_info::{ArtifactInfo, BuildInfo, SIDECAR_FILE_NAME};
 
 use crate::error::{OpenError, Result};
+
+/// Recursively discover context directories (those containing a `model.qmi`
+/// sidecar) under the given `paths`. A directory that is itself a context is not
+/// descended into; hidden directories (dotfiles, e.g. `.git`) and symlinks (to
+/// avoid cycles) are skipped during the walk. Results are canonicalized and
+/// deduplicated, preserving discovery order.
+pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut found = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for path in paths {
+        collect_contexts(path, &mut found, &mut seen)?;
+    }
+    Ok(found)
+}
+
+fn collect_contexts(
+    dir: &Path,
+    found: &mut Vec<PathBuf>,
+    seen: &mut std::collections::HashSet<PathBuf>,
+) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    if dir.join(SIDECAR_FILE_NAME).is_file() {
+        let canonical = dir.canonicalize()?;
+        if seen.insert(canonical.clone()) {
+            found.push(canonical);
+        }
+        return Ok(()); // a context is a leaf; do not descend into its entity dirs
+    }
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        // `file_type()` does not traverse symlinks, so a symlinked directory is
+        // neither hidden-checked away nor recursed into — this keeps the walk
+        // cycle-safe (a symlink back to an ancestor can't loop).
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let child = entry.path();
+        let hidden = child
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with('.'));
+        if !hidden {
+            collect_contexts(&child, found, seen)?;
+        }
+    }
+    Ok(())
+}
 
 /// Serialization format of an artifact's event streams.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -83,11 +135,10 @@ impl GitPin {
     }
 }
 
-/// Everything needed to generate and build a viewer for one context directory.
+/// Everything needed to generate and build a viewer (the contexts it serves are
+/// tracked separately, since one viewer can serve several same-spec contexts).
 #[derive(Debug, Clone)]
 pub struct ViewerSpec {
-    /// The context directory holding the per-entity event streams.
-    pub root: PathBuf,
     /// Event serialization format, detected from the on-disk streams.
     pub format: Format,
     /// Cargo package of the analyzer crate providing `Viewer` (`QuentViewer`).
@@ -109,7 +160,6 @@ impl ViewerSpec {
                     model: info.model.name.clone(),
                 })?;
         Ok(Self {
-            root: root.to_path_buf(),
             format: detect_format(root)?,
             analyzer_package,
             quent: GitPin::from_build_info(&info.quent, "quent")?,
@@ -123,15 +173,35 @@ impl ViewerSpec {
         self.analyzer_package.replace('-', "_")
     }
 
-    /// Stable directory name for caching this viewer's generated crate and build,
-    /// keyed on everything that affects the build output.
+    /// Full, unambiguous identity of a build — every input that affects its
+    /// output (analyzer package, format, and both git pins incl. their remotes
+    /// and full commits). Use this to group/dedup contexts into viewers.
+    pub fn group_key(&self) -> String {
+        // Unit separator between fields so values can't run together.
+        [
+            self.analyzer_package.as_str(),
+            self.format.extension(),
+            &self.quent.remote,
+            &self.quent.commit,
+            &self.analyzer.remote,
+            &self.analyzer.commit,
+        ]
+        .join("\u{1f}")
+    }
+
+    /// Filesystem-safe cache directory name for this viewer's generated crate and
+    /// build. A readable prefix plus a hash of [`group_key`](Self::group_key), so
+    /// distinct builds never share a directory even when their short commits or
+    /// packages match.
     pub fn cache_key(&self) -> String {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.group_key().hash(&mut hasher);
         format!(
-            "{}-{}-{}-{}",
+            "{}-{}-{}-{:016x}",
             self.analyzer_package,
             short_commit(&self.analyzer.commit),
-            short_commit(&self.quent.commit),
             self.format.extension(),
+            hasher.finish(),
         )
     }
 }
@@ -199,6 +269,46 @@ mod tests {
         dir
     }
 
+    fn make_context(dir: &Path) {
+        std::fs::create_dir_all(dir.join("engine")).unwrap();
+        std::fs::write(dir.join("engine").join("events.ndjson"), b"").unwrap();
+        std::fs::write(dir.join(SIDECAR_FILE_NAME), b"{}").unwrap();
+    }
+
+    #[test]
+    fn discover_finds_nested_contexts_and_skips_hidden() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        make_context(&root.join("a"));
+        make_context(&root.join("nested/b"));
+        make_context(&root.join(".hidden/c")); // under a dotdir: must be skipped
+
+        let found = discover_contexts(&[root.to_path_buf()]).unwrap();
+        let mut names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a", "b"]);
+
+        // Passing a context directly yields just it (no descent into entity dirs).
+        let direct = discover_contexts(&[root.join("a")]).unwrap();
+        assert_eq!(direct.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovery_does_not_follow_symlink_cycles() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        make_context(&root.join("a"));
+        // A symlink back to the root would loop a naive recursive walk.
+        std::os::unix::fs::symlink(root, root.join("loop")).unwrap();
+
+        let found = discover_contexts(&[root.to_path_buf()]).unwrap(); // must terminate
+        assert_eq!(found.len(), 1);
+    }
+
     #[test]
     fn detects_format_from_entity_subdir() {
         let ctx = ctx_with_stream("engine", "events.msgpack");
@@ -245,16 +355,36 @@ mod tests {
     }
 
     #[test]
-    fn spec_derives_crate_ident_and_cache_key() {
+    fn spec_derives_crate_ident_and_keys() {
         let ctx = ctx_with_stream("engine", "events.ndjson");
         let info = artifact_with(Some("quent-simulator-analyzer"), "feedface99887766");
         let spec = ViewerSpec::from_artifact(ctx.path(), &info).unwrap();
         assert_eq!(spec.analyzer_crate(), "quent_simulator_analyzer");
         assert_eq!(spec.format, Format::Ndjson);
-        // commit is truncated to 12 chars in the key.
-        assert_eq!(
-            spec.cache_key(),
-            "quent-simulator-analyzer-feedface9988-0123456789ab-ndjson"
+        assert!(
+            spec.cache_key()
+                .starts_with("quent-simulator-analyzer-feedface9988-ndjson-")
         );
+    }
+
+    #[test]
+    fn keys_distinguish_full_pins_not_just_short_commit() {
+        let ctx = ctx_with_stream("engine", "events.ndjson");
+        // Same package, format, and 12-char commit prefix, but different full
+        // analyzer commits — must NOT collide.
+        let a =
+            ViewerSpec::from_artifact(ctx.path(), &artifact_with(Some("p"), "abcabcabcabc1111"))
+                .unwrap();
+        let b =
+            ViewerSpec::from_artifact(ctx.path(), &artifact_with(Some("p"), "abcabcabcabc2222"))
+                .unwrap();
+        assert_ne!(a.group_key(), b.group_key());
+        assert_ne!(a.cache_key(), b.cache_key());
+        // Identical inputs group together and are deterministic.
+        let a2 =
+            ViewerSpec::from_artifact(ctx.path(), &artifact_with(Some("p"), "abcabcabcabc1111"))
+                .unwrap();
+        assert_eq!(a.group_key(), a2.group_key());
+        assert_eq!(a.cache_key(), a2.cache_key());
     }
 }

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -11,11 +11,9 @@ use quent_build_info::{ArtifactInfo, BuildInfo, SIDECAR_FILE_NAME};
 
 use crate::error::{OpenError, Result};
 
-/// Recursively discover context directories (those containing a `model.qmi`
-/// sidecar) under the given `paths`. A directory that is itself a context is not
-/// descended into; hidden directories (dotfiles, e.g. `.git`) and symlinks (to
-/// avoid cycles) are skipped during the walk. Results are canonicalized and
-/// deduplicated, preserving discovery order.
+/// Recursively discover context directories containing `model.qmi` under `paths`.
+/// Treat contexts as leaves; skip hidden dirs and symlinks to avoid cycles.
+/// Canonicalize and deduplicate results while preserving discovery order.
 pub fn discover_contexts(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut found = Vec::new();
     let mut seen = std::collections::HashSet::new();
@@ -41,9 +39,8 @@ fn collect_contexts(
         return Ok(()); // a context is a leaf; do not descend into its entity dirs
     }
     for entry in std::fs::read_dir(dir)?.flatten() {
-        // `file_type()` does not traverse symlinks, so a symlinked directory is
-        // neither hidden-checked away nor recursed into — this keeps the walk
-        // cycle-safe (a symlink back to an ancestor can't loop).
+        // `file_type()` does not follow symlinks, so symlinked dirs are not
+        // recursed into and the walk stays cycle-safe.
         let Ok(file_type) = entry.file_type() else {
             continue;
         };
@@ -135,8 +132,8 @@ impl GitPin {
     }
 }
 
-/// Everything needed to generate and build a viewer (the contexts it serves are
-/// tracked separately, since one viewer can serve several same-spec contexts).
+/// Viewer build inputs; contexts are tracked separately because one viewer can
+/// serve multiple same-spec contexts.
 #[derive(Debug, Clone)]
 pub struct ViewerSpec {
     /// Event serialization format, detected from the on-disk streams.
@@ -173,9 +170,8 @@ impl ViewerSpec {
         self.analyzer_package.replace('-', "_")
     }
 
-    /// Full, unambiguous identity of a build — every input that affects its
-    /// output (analyzer package, format, and both git pins incl. their remotes
-    /// and full commits). Use this to group/dedup contexts into viewers.
+    /// Unambiguous build identity: analyzer package, format, and both git
+    /// remotes + full commits. Used to group/dedup contexts into viewers.
     pub fn group_key(&self) -> String {
         // Unit separator between fields so values can't run together.
         [
@@ -189,10 +185,9 @@ impl ViewerSpec {
         .join("\u{1f}")
     }
 
-    /// Filesystem-safe cache directory name for this viewer's generated crate and
-    /// build. A readable prefix plus a hash of [`group_key`](Self::group_key), so
-    /// distinct builds never share a directory even when their short commits or
-    /// packages match.
+    /// Filesystem-safe cache dir for this generated crate/build: readable prefix
+    /// plus [`group_key`](Self::group_key) hash, so distinct builds never share a
+    /// directory even when short commits or package names match.
     pub fn cache_key(&self) -> String {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         self.group_key().hash(&mut hasher);

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -164,8 +164,13 @@ async fn cargo_build(crate_dir: &Path) -> Result<PathBuf> {
         .await?;
     let status = child.wait().await?;
     if !status.success() {
+        // Compiler diagnostics are rendered into the JSON stream; cargo's own
+        // output (build scripts, the final error summary) is on stderr in the
+        // log. Include both in full so the cause is never truncated away.
+        let mut detail = rendered_diagnostics(&json);
+        detail.push_str(&std::fs::read_to_string(&log_path).unwrap_or_default());
         return Err(OpenError::Build {
-            status: format!("{status}; last output:\n{}", log_tail(&log_path)),
+            status: format!("{status}\n{detail}"),
         });
     }
     wrapper_executable(&json).ok_or_else(|| OpenError::Build {
@@ -187,10 +192,19 @@ fn wrapper_executable(stdout: &[u8]) -> Option<PathBuf> {
 }
 
 /// Last 20 lines of a build log, for surfacing why a build failed.
-fn log_tail(path: &Path) -> String {
-    let text = std::fs::read_to_string(path).unwrap_or_default();
-    let lines: Vec<&str> = text.lines().collect();
-    lines[lines.len().saturating_sub(20)..].join("\n")
+/// Concatenate the human-rendered compiler diagnostics from cargo's JSON message
+/// stream (`--message-format=json-render-diagnostics` carries them here rather
+/// than on stderr).
+fn rendered_diagnostics(stdout: &[u8]) -> String {
+    let Ok(text) = std::str::from_utf8(stdout) else {
+        return String::new();
+    };
+    text.lines()
+        .filter_map(|line| {
+            let msg: serde_json::Value = serde_json::from_str(line).ok()?;
+            msg["message"]["rendered"].as_str().map(str::to_owned)
+        })
+        .collect()
 }
 
 /// Stage a clean output root, symlinking each `context` under its UUID name.
@@ -211,9 +225,11 @@ fn stage_output_root(crate_dir: &Path, contexts: &[PathBuf]) -> Result<PathBuf> 
                 "context path has no final component",
             ))
         })?;
-        // Two trees can hold copies of the same context id; they dedup to distinct
-        // canonical paths but one link name. Keep the first and skip the rest
-        // rather than failing the whole viewer on the colliding link.
+        // A context id (the dir name) is unique within one export, so this only
+        // fires when the same context is reached via two distinct paths — a copied
+        // context, or overlapping `paths` args that each contain it. Those dedup to
+        // distinct canonical paths but one link name; keep the first and skip the
+        // rest rather than aborting the whole viewer on the colliding link.
         if !linked.insert(name.to_owned()) {
             eprintln!(
                 "warning: ignoring duplicate context id `{}` at {}",

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Build and serve viewers for discovered contexts. Contexts sharing a build
-//! spec (same analyzer + pinned commits + format) share one viewer; distinct
-//! viewers build in parallel and are announced as they become ready.
+//! spec (same analyzer + pinned commits + format) share one viewer. Builds run
+//! one at a time — they compile the full quent stack, including a `pnpm` UI
+//! build in the shared git checkout, so concurrent `cargo` invocations would
+//! race — then the built viewers are served in parallel.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener as StdTcpListener};
 use std::path::{Path, PathBuf};
@@ -25,9 +27,18 @@ pub struct ViewerGroup {
     pub contexts: Vec<PathBuf>,
 }
 
-/// Build and serve groups in parallel, announcing each URL when ready, each bound
-/// on `host`. Open a browser only for a single viewer. Block until all viewers
-/// exit (e.g. Ctrl-C); failed builds do not stop others.
+/// A built viewer ready to serve: its binary, cache dir, and the contexts it covers.
+struct BuiltViewer {
+    bin: PathBuf,
+    crate_dir: PathBuf,
+    contexts: Vec<PathBuf>,
+    label: String,
+}
+
+/// Build each group's viewer (serially, see module docs), then serve the built
+/// viewers in parallel — each bound on `host`, announcing its URL when ready.
+/// Open a browser only for a single viewer. Block until all viewers exit (e.g.
+/// Ctrl-C); a failed build or viewer does not stop the others.
 pub async fn open_all(groups: Vec<ViewerGroup>, no_browser: bool, host: IpAddr) -> Result<()> {
     let total: usize = groups.iter().map(|g| g.contexts.len()).sum();
     println!(
@@ -36,12 +47,22 @@ pub async fn open_all(groups: Vec<ViewerGroup>, no_browser: bool, host: IpAddr) 
     );
     let open_browser = !no_browser && groups.len() == 1;
 
-    let mut set = JoinSet::new();
+    let mut failures = 0usize;
+    let mut built = Vec::new();
     for group in groups {
-        set.spawn(async move { open_one(group, open_browser, host).await });
+        match build_one(group).await {
+            Ok(viewer) => built.push(viewer),
+            Err(e) => {
+                failures += 1;
+                eprintln!("viewer build failed: {e}");
+            }
+        }
     }
 
-    let mut failures = 0usize;
+    let mut set = JoinSet::new();
+    for viewer in built {
+        set.spawn(async move { serve_one(viewer, open_browser, host).await });
+    }
     while let Some(joined) = set.join_next().await {
         match joined {
             Ok(Ok(())) => {}
@@ -62,8 +83,8 @@ pub async fn open_all(groups: Vec<ViewerGroup>, no_browser: bool, host: IpAddr) 
     }
 }
 
-/// Build one group's viewer and serve all its contexts.
-async fn open_one(group: ViewerGroup, open_browser: bool, host: IpAddr) -> Result<()> {
+/// Generate and build one group's viewer crate.
+async fn build_one(group: ViewerGroup) -> Result<BuiltViewer> {
     let ViewerGroup { spec, contexts } = group;
     let label = format!("{} ({} context(s))", spec.analyzer_package, contexts.len());
     println!("building: {label}");
@@ -71,6 +92,22 @@ async fn open_one(group: ViewerGroup, open_browser: bool, host: IpAddr) -> Resul
     let crate_dir = build_dir(&spec)?;
     wrapper::generate(&spec, &crate_dir)?;
     let bin = cargo_build(&crate_dir).await?;
+    Ok(BuiltViewer {
+        bin,
+        crate_dir,
+        contexts,
+        label,
+    })
+}
+
+/// Serve one built viewer over all its contexts.
+async fn serve_one(viewer: BuiltViewer, open_browser: bool, host: IpAddr) -> Result<()> {
+    let BuiltViewer {
+        bin,
+        crate_dir,
+        contexts,
+        label,
+    } = viewer;
     let output_root = stage_output_root(&crate_dir, &contexts)?;
     let result = serve(&output_root, &bin, &label, open_browser, host).await;
     // Best-effort cleanup of this run's staged root; keep the cached build.
@@ -91,8 +128,10 @@ fn build_dir(spec: &ViewerSpec) -> Result<PathBuf> {
 
 /// Run `cargo build --release` in `crate_dir` and return the built binary path,
 /// read from Cargo's JSON output so a custom target dir/triple is handled. Build
-/// diagnostics go to `<crate_dir>/build.log` so parallel builds don't interleave;
-/// on failure the log's tail is folded into the error.
+/// diagnostics go to `<crate_dir>/build.log`; on failure the log's tail is folded
+/// into the error. The target dir is pinned under `crate_dir` so a user's global
+/// `CARGO_TARGET_DIR`/`build.target-dir` can't collide one viewer's binary with
+/// another's.
 ///
 /// The first build fetches the pinned git sources and compiles the embedded UI,
 /// which invokes `pnpm`/`node`; both must be on `PATH`. Subsequent builds reuse
@@ -107,6 +146,7 @@ async fn cargo_build(crate_dir: &Path) -> Result<PathBuf> {
             "--message-format=json-render-diagnostics",
         ])
         .current_dir(crate_dir)
+        .env("CARGO_TARGET_DIR", crate_dir.join("target"))
         .stdout(Stdio::piped())
         .stderr(Stdio::from(log))
         .spawn()

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Generate, build, and serve the viewer crate for a [`ViewerSpec`], then open a
-//! browser at the served URL.
+//! Build and serve viewers for discovered contexts. Contexts sharing a build
+//! spec (same analyzer + pinned commits + format) share one viewer; distinct
+//! viewers build in parallel and are announced as they become ready.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener as StdTcpListener};
 use std::path::{Path, PathBuf};
@@ -12,65 +13,69 @@ use std::time::Duration;
 use backon::{ConstantBuilder, Retryable};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
+use tokio::task::JoinSet;
 
 use crate::error::{OpenError, Result};
 use crate::spec::ViewerSpec;
 use crate::wrapper::{self, ADDR_ENV, ROOT_ENV, WRAPPER_PACKAGE};
 
-/// Generate, build, and serve the viewer for `spec`, bound on `host`. Blocks
-/// serving until the viewer process exits (e.g. Ctrl-C). Opens a browser unless
-/// `no_browser`.
-pub async fn open(
-    spec: &ViewerSpec,
-    no_browser: bool,
-    print_url: bool,
-    host: IpAddr,
-) -> Result<()> {
-    let crate_dir = build_dir(spec)?;
-    wrapper::generate(spec, &crate_dir)?;
+/// Viewer to build: representative [`ViewerSpec`] plus all contexts sharing it.
+pub struct ViewerGroup {
+    pub spec: ViewerSpec,
+    pub contexts: Vec<PathBuf>,
+}
+
+/// Build and serve groups in parallel, announcing each URL when ready, each bound
+/// on `host`. Open a browser only for a single viewer. Block until all viewers
+/// exit (e.g. Ctrl-C); failed builds do not stop others.
+pub async fn open_all(groups: Vec<ViewerGroup>, no_browser: bool, host: IpAddr) -> Result<()> {
+    let total: usize = groups.iter().map(|g| g.contexts.len()).sum();
+    println!(
+        "discovered {total} context(s) -> {} viewer(s)",
+        groups.len()
+    );
+    let open_browser = !no_browser && groups.len() == 1;
+
+    let mut set = JoinSet::new();
+    for group in groups {
+        set.spawn(async move { open_one(group, open_browser, host).await });
+    }
+
+    let mut failures = 0usize;
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                failures += 1;
+                eprintln!("viewer failed: {e}");
+            }
+            Err(e) => {
+                failures += 1;
+                eprintln!("viewer task error: {e}");
+            }
+        }
+    }
+    if failures > 0 {
+        Err(OpenError::ViewersFailed { count: failures })
+    } else {
+        Ok(())
+    }
+}
+
+/// Build one group's viewer and serve all its contexts.
+async fn open_one(group: ViewerGroup, open_browser: bool, host: IpAddr) -> Result<()> {
+    let ViewerGroup { spec, contexts } = group;
+    let label = format!("{} ({} context(s))", spec.analyzer_package, contexts.len());
+    println!("building: {label}");
+
+    let crate_dir = build_dir(&spec)?;
+    wrapper::generate(&spec, &crate_dir)?;
     let bin = cargo_build(&crate_dir).await?;
-    let output_root = stage_output_root(&crate_dir, &spec.root)?;
-    let result = serve(&output_root, &bin, no_browser, print_url, host).await;
-    // Best-effort cleanup of this run's staged root (the cached build is kept).
+    let output_root = stage_output_root(&crate_dir, &contexts)?;
+    let result = serve(&output_root, &bin, &label, open_browser, host).await;
+    // Best-effort cleanup of this run's staged root; keep the cached build.
     let _ = std::fs::remove_dir_all(&output_root);
     result
-}
-
-/// Stage a clean output root containing only the requested `context`, symlinked
-/// under its own UUID name. The server scans an output root of `<context-uuid>/`
-/// directories; isolating to one context serves exactly what was asked and avoids
-/// tripping over sibling contexts that may use a different format.
-///
-/// The root is unique per process so concurrent runs sharing a cached build dir
-/// do not clobber each other's staged root.
-fn stage_output_root(crate_dir: &Path, context: &Path) -> Result<PathBuf> {
-    let context = context.canonicalize()?;
-    let name = context.file_name().ok_or_else(|| {
-        OpenError::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "context path has no final component",
-        ))
-    })?;
-    let root = crate_dir.join(format!("serve-root-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(&root)?;
-    symlink_dir(&context, &root.join(name))?;
-    Ok(root)
-}
-
-/// Symlink the context directory into the staged output root.
-#[cfg(unix)]
-fn symlink_dir(src: &Path, link: &Path) -> Result<()> {
-    std::os::unix::fs::symlink(src, link)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn symlink_dir(_src: &Path, _link: &Path) -> Result<()> {
-    Err(OpenError::Io(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "serving local artifacts requires symlink support",
-    )))
 }
 
 /// Cache dir for this viewer's generated crate/build, keyed by
@@ -85,13 +90,16 @@ fn build_dir(spec: &ViewerSpec) -> Result<PathBuf> {
 }
 
 /// Run `cargo build --release` in `crate_dir` and return the built binary path,
-/// read from Cargo's JSON output so a custom target dir/triple is handled.
-/// Diagnostics stream to stderr so the user still sees build progress.
+/// read from Cargo's JSON output so a custom target dir/triple is handled. Build
+/// diagnostics go to `<crate_dir>/build.log` so parallel builds don't interleave;
+/// on failure the log's tail is folded into the error.
 ///
 /// The first build fetches the pinned git sources and compiles the embedded UI,
 /// which invokes `pnpm`/`node`; both must be on `PATH`. Subsequent builds reuse
 /// the cached `crate_dir`.
 async fn cargo_build(crate_dir: &Path) -> Result<PathBuf> {
+    let log_path = crate_dir.join("build.log");
+    let log = std::fs::File::create(&log_path)?;
     let mut child = Command::new("cargo")
         .args([
             "build",
@@ -100,7 +108,7 @@ async fn cargo_build(crate_dir: &Path) -> Result<PathBuf> {
         ])
         .current_dir(crate_dir)
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::from(log))
         .spawn()
         .map_err(|source| OpenError::Spawn {
             what: "cargo build".into(),
@@ -117,7 +125,7 @@ async fn cargo_build(crate_dir: &Path) -> Result<PathBuf> {
     let status = child.wait().await?;
     if !status.success() {
         return Err(OpenError::Build {
-            status: status.to_string(),
+            status: format!("{status}; last output:\n{}", log_tail(&log_path)),
         });
     }
     wrapper_executable(&json).ok_or_else(|| OpenError::Build {
@@ -138,13 +146,57 @@ fn wrapper_executable(stdout: &[u8]) -> Option<PathBuf> {
     })
 }
 
-/// Spawn the built viewer serving `output_root` bound to `host`, print/open its
-/// URL, and run until it exits.
+/// Last 20 lines of a build log, for surfacing why a build failed.
+fn log_tail(path: &Path) -> String {
+    let text = std::fs::read_to_string(path).unwrap_or_default();
+    let lines: Vec<&str> = text.lines().collect();
+    lines[lines.len().saturating_sub(20)..].join("\n")
+}
+
+/// Stage a clean output root, symlinking each `context` under its UUID name.
+/// The server scans `<context-uuid>/` directories; isolating requested contexts
+/// serves exactly them and avoids unrelated siblings that may use another format.
+/// The root is per process so concurrent runs sharing a cached build do not
+/// clobber each other.
+fn stage_output_root(crate_dir: &Path, contexts: &[PathBuf]) -> Result<PathBuf> {
+    let root = crate_dir.join(format!("serve-root-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root)?;
+    for context in contexts {
+        let context = context.canonicalize()?;
+        let name = context.file_name().ok_or_else(|| {
+            OpenError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "context path has no final component",
+            ))
+        })?;
+        symlink_dir(&context, &root.join(name))?;
+    }
+    Ok(root)
+}
+
+/// Symlink a context directory into the staged output root.
+#[cfg(unix)]
+fn symlink_dir(src: &Path, link: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(src, link)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn symlink_dir(_src: &Path, _link: &Path) -> Result<()> {
+    Err(OpenError::Io(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "serving local artifacts requires symlink support",
+    )))
+}
+
+/// Spawn the viewer for `output_root` bound on `host`, announce its URL once it
+/// accepts connections, and run until exit.
 async fn serve(
     output_root: &Path,
     bin: &Path,
-    no_browser: bool,
-    print_url: bool,
+    label: &str,
+    open_browser: bool,
     host: IpAddr,
 ) -> Result<()> {
     let addr = free_port(host)?;
@@ -166,15 +218,13 @@ async fn serve(
             source,
         })?;
 
-    if print_url {
-        println!("{url}");
-    }
-    if !no_browser {
-        // Wait for the server to accept connections before opening the browser.
-        wait_until_ready(reachable).await;
-        if let Err(e) = open::that(&url) {
+    if wait_until_ready(reachable).await {
+        println!("ready: {label}  {url}");
+        if open_browser && let Err(e) = open::that(&url) {
             eprintln!("could not open a browser ({e}); open {url} manually");
         }
+    } else {
+        eprintln!("warning: {label} did not start listening at {url} within the timeout");
     }
 
     let status = child.wait().await?;
@@ -193,14 +243,14 @@ fn free_port(host: IpAddr) -> Result<SocketAddr> {
     Ok(listener.local_addr()?)
 }
 
-/// Poll `addr` until it accepts a connection (server up) or a few seconds pass,
-/// retrying on a fixed interval.
-async fn wait_until_ready(addr: SocketAddr) {
-    let _ = (|| async { tokio::net::TcpStream::connect(addr).await })
+/// Poll `addr` until it accepts a connection, returning `false` on timeout.
+async fn wait_until_ready(addr: SocketAddr) -> bool {
+    (|| async { tokio::net::TcpStream::connect(addr).await })
         .retry(
             ConstantBuilder::default()
                 .with_delay(Duration::from_millis(100))
                 .with_max_times(50),
         )
-        .await;
+        .await
+        .is_ok()
 }

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -202,6 +202,7 @@ fn stage_output_root(crate_dir: &Path, contexts: &[PathBuf]) -> Result<PathBuf> 
     let root = crate_dir.join(format!("serve-root-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);
     std::fs::create_dir_all(&root)?;
+    let mut linked = std::collections::HashSet::new();
     for context in contexts {
         let context = context.canonicalize()?;
         let name = context.file_name().ok_or_else(|| {
@@ -210,6 +211,17 @@ fn stage_output_root(crate_dir: &Path, contexts: &[PathBuf]) -> Result<PathBuf> 
                 "context path has no final component",
             ))
         })?;
+        // Two trees can hold copies of the same context id; they dedup to distinct
+        // canonical paths but one link name. Keep the first and skip the rest
+        // rather than failing the whole viewer on the colliding link.
+        if !linked.insert(name.to_owned()) {
+            eprintln!(
+                "warning: ignoring duplicate context id `{}` at {}",
+                name.to_string_lossy(),
+                context.display()
+            );
+            continue;
+        }
         symlink_dir(&context, &root.join(name))?;
     }
     Ok(root)

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -86,7 +86,7 @@ pub async fn open_all(groups: Vec<ViewerGroup>, no_browser: bool, host: IpAddr) 
 /// Generate and build one group's viewer crate.
 async fn build_one(group: ViewerGroup) -> Result<BuiltViewer> {
     let ViewerGroup { spec, contexts } = group;
-    let label = format!("{} ({} context(s))", spec.analyzer_package, contexts.len());
+    let label = format!("{} — {} context(s)", spec.describe(), contexts.len());
     println!("building: {label}");
 
     let crate_dir = build_dir(&spec)?;

--- a/crates/open/src/wrapper.rs
+++ b/crates/open/src/wrapper.rs
@@ -160,11 +160,9 @@ fn main_rs(spec: &ViewerSpec) -> String {
 mod tests {
     use super::*;
     use crate::spec::{Format, GitPin, ViewerSpec};
-    use std::path::PathBuf;
 
     fn spec() -> ViewerSpec {
         ViewerSpec {
-            root: PathBuf::from("/data/ctx"),
             format: Format::Msgpack,
             analyzer_package: "quent-simulator-analyzer".into(),
             quent: GitPin {


### PR DESCRIPTION
`local` recursively discovers all context dirs, groups them by build spec (one viewer per distinct model), builds in parallel, and streams each URL as it's ready; opens a browser only when there's a single viewer.

Part 6/7. Stacked on #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)