### PR TITLE
feat(open): validate provenance and gate untrusted sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +938,45 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gix-path"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+
+[[package]]
+name = "gix-url"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "glob"
@@ -2215,6 +2264,7 @@ dependencies = [
  "cargo-manifest",
  "clap",
  "dirs",
+ "gix-url",
  "open",
  "prettyplease",
  "quent-build-info",

--- a/crates/open/Cargo.toml
+++ b/crates/open/Cargo.toml
@@ -12,6 +12,7 @@ backon = "1"
 cargo-manifest = "0.21"
 clap = { version = "4.5.58", features = ["derive", "env"] }
 dirs = "6"
+gix-url = "0.36"
 open = "5"
 prettyplease = "0.2"
 quent-build-info = { path = "../build-info" }

--- a/crates/open/src/error.rs
+++ b/crates/open/src/error.rs
@@ -25,6 +25,17 @@ pub enum OpenError {
     )]
     NoAnalyzer { model: String },
 
+    /// A provenance field was malformed (and could otherwise inject into the
+    /// generated build files).
+    #[error("invalid {field} in provenance: {value:?}")]
+    InvalidProvenance { field: String, value: String },
+
+    /// Every discovered viewer's source was untrusted (and not approved).
+    #[error(
+        "no trusted sources to build; re-run with --trust <remote> or --trust-all, or add to the allowlist"
+    )]
+    NothingTrusted,
+
     /// No recognized event stream extension was found, so the artifact format is
     /// unknown.
     #[error(

--- a/crates/open/src/error.rs
+++ b/crates/open/src/error.rs
@@ -25,8 +25,7 @@ pub enum OpenError {
     )]
     NoAnalyzer { model: String },
 
-    /// A provenance field was malformed (and could otherwise inject into the
-    /// generated build files).
+    /// A malformed provenance field could inject into generated build files.
     #[error("invalid {field} in provenance: {value:?}")]
     InvalidProvenance { field: String, value: String },
 

--- a/crates/open/src/main.rs
+++ b/crates/open/src/main.rs
@@ -39,13 +39,13 @@ struct Cli {
     #[arg(long, global = true, default_value = "127.0.0.1")]
     host: IpAddr,
 
-    /// Trust a git remote (repeatable) without prompting: a full repo URL for an
-    /// exact repo, or a `github.com/org/*` form to trust a whole org/prefix.
+    /// Trust a git remote without prompting (repeatable): full repo URL, or
+    /// `github.com/org/*` for an org/prefix.
     #[arg(long = "trust", global = true, value_name = "REMOTE")]
     trust: Vec<String>,
 
-    /// Trust every source (skips the trust gate entirely — only for sources you
-    /// already trust, since building runs their code).
+    /// Trust every source, skipping the trust gate; only use for trusted sources,
+    /// because building runs their code.
     #[arg(long, global = true)]
     trust_all: bool,
 
@@ -110,9 +110,9 @@ async fn run_local(cli: &Cli, paths: &[PathBuf]) -> Result<()> {
         return Err(OpenError::NoContexts);
     }
 
-    // Each viewer builds + runs code from its quent and analyzer git remotes, so
-    // gate on trust before building. Authorize each distinct remote once (prompts
-    // are sequential, before the parallel build phase).
+    // Each viewer builds and runs code from its quent/analyzer remotes; require
+    // trust before building. Authorize each distinct remote once, with prompts
+    // before parallel builds.
     let mut trust = trust::Trust::new(&cli.trust, cli.trust_all);
     let mut decided: BTreeMap<String, bool> = BTreeMap::new();
     for group in &groups {

--- a/crates/open/src/main.rs
+++ b/crates/open/src/main.rs
@@ -12,6 +12,7 @@
 
 mod error;
 mod spec;
+mod trust;
 mod viewer;
 mod wrapper;
 
@@ -37,6 +38,16 @@ struct Cli {
     /// Host/interface the viewer binds (`0.0.0.0` exposes it to other hosts).
     #[arg(long, global = true, default_value = "127.0.0.1")]
     host: IpAddr,
+
+    /// Trust a git remote (repeatable) without prompting: a full repo URL for an
+    /// exact repo, or a `github.com/org/*` form to trust a whole org/prefix.
+    #[arg(long = "trust", global = true, value_name = "REMOTE")]
+    trust: Vec<String>,
+
+    /// Trust every source (skips the trust gate entirely — only for sources you
+    /// already trust, since building runs their code).
+    #[arg(long, global = true)]
+    trust_all: bool,
 
     #[command(subcommand)]
     command: OpenCommand,
@@ -94,8 +105,42 @@ async fn run_local(cli: &Cli, paths: &[PathBuf]) -> Result<()> {
             .push(context);
     }
 
+    let groups: Vec<ViewerGroup> = groups.into_values().collect();
     if groups.is_empty() {
         return Err(OpenError::NoContexts);
     }
-    viewer::open_all(groups.into_values().collect(), cli.no_browser, cli.host).await
+
+    // Each viewer builds + runs code from its quent and analyzer git remotes, so
+    // gate on trust before building. Authorize each distinct remote once (prompts
+    // are sequential, before the parallel build phase).
+    let mut trust = trust::Trust::new(&cli.trust, cli.trust_all);
+    let mut decided: BTreeMap<String, bool> = BTreeMap::new();
+    for group in &groups {
+        for pin in [&group.spec.quent, &group.spec.analyzer] {
+            if let std::collections::btree_map::Entry::Vacant(slot) =
+                decided.entry(trust::canonicalize_remote(&pin.remote))
+            {
+                slot.insert(trust.authorize(&pin.remote, &pin.commit));
+            }
+        }
+    }
+    let approved: Vec<ViewerGroup> = groups
+        .into_iter()
+        .filter(|group| {
+            let trusted = [&group.spec.quent, &group.spec.analyzer]
+                .iter()
+                .all(|pin| decided[&trust::canonicalize_remote(&pin.remote)]);
+            if !trusted {
+                eprintln!(
+                    "skipping {}: source not trusted",
+                    group.spec.analyzer_package
+                );
+            }
+            trusted
+        })
+        .collect();
+    if approved.is_empty() {
+        return Err(OpenError::NothingTrusted);
+    }
+    viewer::open_all(approved, cli.no_browser, cli.host).await
 }

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -128,16 +128,69 @@ impl GitPin {
         }
     }
 
-    /// Extract a pin from a [`BuildInfo`], or report which provenance is missing.
+    /// Extract a pin from a [`BuildInfo`], validating the (untrusted) remote and
+    /// commit so they can't inject into the generated `Cargo.toml`.
     fn from_build_info(info: &BuildInfo, what: &str) -> Result<Self> {
         match (&info.remote, &info.commit) {
-            (Some(remote), Some(commit)) => Ok(GitPin {
-                remote: remote.clone(),
-                commit: commit.clone(),
-            }),
+            (Some(remote), Some(commit)) => {
+                validate_remote(remote)?;
+                validate_commit(commit)?;
+                Ok(GitPin {
+                    remote: remote.clone(),
+                    commit: commit.clone(),
+                })
+            }
             _ => Err(OpenError::MissingProvenance { what: what.into() }),
         }
     }
+}
+
+/// A git commit must be a hex object id (sha-1 or sha-256, possibly abbreviated).
+fn validate_commit(commit: &str) -> Result<()> {
+    let ok = (7..=64).contains(&commit.len()) && commit.bytes().all(|b| b.is_ascii_hexdigit());
+    ok.then_some(())
+        .ok_or_else(|| OpenError::InvalidProvenance {
+            field: "commit".into(),
+            value: commit.into(),
+        })
+}
+
+/// A git remote must use an authenticated/integrity-checked transport — `https`
+/// or `ssh` (incl. scp-style `user@host:path`) — and be free of characters that
+/// could break out of the generated TOML string. Unauthenticated `http`/`git`
+/// transports are rejected so a trusted source can't be silently downgraded
+/// (the scheme is dropped during trust canonicalization).
+fn validate_remote(remote: &str) -> Result<()> {
+    let inject = remote
+        .bytes()
+        .any(|b| b.is_ascii_control() || b == b'"' || b == b'\\');
+    // scp-style: `[user@]host:path` — a `:` before any `/`, user optional
+    // (matches git; `cargo_url` rewrites it to an `ssh://` URL).
+    let shaped = matches!(remote.split_once("://"), Some(("https" | "ssh", _)))
+        || (!remote.contains("://")
+            && remote
+                .split_once(':')
+                .is_some_and(|(host, _)| !host.is_empty() && !host.contains('/')));
+    (!inject && shaped)
+        .then_some(())
+        .ok_or_else(|| OpenError::InvalidProvenance {
+            field: "remote".into(),
+            value: remote.into(),
+        })
+}
+
+/// A cargo package name: ASCII alphanumerics, `-`, and `_` only. Keeps the name
+/// safe to interpolate into the manifest and `use <crate>::Viewer`.
+fn validate_package(package: &str) -> Result<()> {
+    let ok = !package.is_empty()
+        && package
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_');
+    ok.then_some(())
+        .ok_or_else(|| OpenError::InvalidProvenance {
+            field: "analyzer_package".into(),
+            value: package.into(),
+        })
 }
 
 /// Viewer build inputs; contexts are tracked separately because one viewer can
@@ -164,6 +217,7 @@ impl ViewerSpec {
                 .ok_or_else(|| OpenError::NoAnalyzer {
                     model: info.model.name.clone(),
                 })?;
+        validate_package(&analyzer_package)?;
         Ok(Self {
             format: detect_format(root)?,
             analyzer_package,
@@ -405,6 +459,28 @@ mod tests {
             detect_format(ctx.path()),
             Err(OpenError::UnknownFormat { .. })
         ));
+    }
+
+    #[test]
+    fn validators_accept_good_and_reject_injection() {
+        assert!(validate_commit("0123456789abcdef0123456789abcdef01234567").is_ok());
+        assert!(validate_commit("deadbeef").is_ok());
+        assert!(validate_commit("nothex!!").is_err());
+        assert!(validate_commit("abc").is_err()); // too short
+
+        assert!(validate_remote("https://github.com/rapidsai/quent").is_ok());
+        assert!(validate_remote("git@github.com:rapidsai/quent.git").is_ok());
+        assert!(validate_remote("github.com:rapidsai/quent.git").is_ok()); // scp, no user
+        assert!(validate_remote("ssh://git@github.com/rapidsai/quent.git").is_ok());
+        assert!(validate_remote("https://x/y\"\n[dependencies]\nevil=\"1").is_err());
+        assert!(validate_remote("file:///etc/passwd").is_err());
+        // Unauthenticated transports are rejected (no silent downgrade).
+        assert!(validate_remote("http://github.com/rapidsai/quent").is_err());
+        assert!(validate_remote("git://github.com/rapidsai/quent").is_err());
+
+        assert!(validate_package("quent-simulator-analyzer").is_ok());
+        assert!(validate_package("evil\"]\nfoo = { path = \"/").is_err());
+        assert!(validate_package("").is_err());
     }
 
     #[test]

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -128,8 +128,8 @@ impl GitPin {
         }
     }
 
-    /// Extract a pin from a [`BuildInfo`], validating the (untrusted) remote and
-    /// commit so they can't inject into the generated `Cargo.toml`.
+    /// Extract a pin from [`BuildInfo`], validating the untrusted remote and
+    /// commit so they cannot inject into generated `Cargo.toml`.
     fn from_build_info(info: &BuildInfo, what: &str) -> Result<Self> {
         match (&info.remote, &info.commit) {
             (Some(remote), Some(commit)) => {
@@ -155,17 +155,16 @@ fn validate_commit(commit: &str) -> Result<()> {
         })
 }
 
-/// A git remote must use an authenticated/integrity-checked transport — `https`
-/// or `ssh` (incl. scp-style `user@host:path`) — and be free of characters that
-/// could break out of the generated TOML string. Unauthenticated `http`/`git`
-/// transports are rejected so a trusted source can't be silently downgraded
-/// (the scheme is dropped during trust canonicalization).
+/// A git remote must use an integrity-checked transport (`https`, `ssh`, or
+/// scp-style `user@host:path`) and avoid characters that can escape the
+/// generated TOML string. Reject `http`/`git` so trust canonicalization cannot
+/// silently downgrade a source.
 fn validate_remote(remote: &str) -> Result<()> {
     let inject = remote
         .bytes()
         .any(|b| b.is_ascii_control() || b == b'"' || b == b'\\');
-    // scp-style: `[user@]host:path` — a `:` before any `/`, user optional
-    // (matches git; `cargo_url` rewrites it to an `ssh://` URL).
+    // scp-style `[user@]host:path`: `:` before any `/`, optional user;
+    // `cargo_url` rewrites it to `ssh://`.
     let shaped = matches!(remote.split_once("://"), Some(("https" | "ssh", _)))
         || (!remote.contains("://")
             && remote
@@ -179,8 +178,8 @@ fn validate_remote(remote: &str) -> Result<()> {
         })
 }
 
-/// A cargo package name: ASCII alphanumerics, `-`, and `_` only. Keeps the name
-/// safe to interpolate into the manifest and `use <crate>::Viewer`.
+/// Cargo package name: ASCII alphanumerics, `-`, and `_`; safe for manifest
+/// interpolation and `use <crate>::Viewer`.
 fn validate_package(package: &str) -> Result<()> {
     let ok = !package.is_empty()
         && package

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -114,16 +114,17 @@ pub struct GitPin {
 impl GitPin {
     /// Remote as a Cargo `git = "..."` URL.
     ///
-    /// Rewrite git's scp-style `git@host:path` to `ssh://git@host/path`, which
-    /// Cargo accepts. Leave URLs with a scheme (`https://`, `ssh://`, ...) and
-    /// local paths unchanged; like git, treat a remote as scp-style only when the
-    /// first colon has no earlier slash, so `/tmp/foo:bar` stays a path.
+    /// Cargo rejects git's scp-style `git@host:path`, which `gix-url` parses as
+    /// the SSH alternative form; re-serialize that to `ssh://git@host/path`.
+    /// Other forms (`https://`/`ssh://` URLs, local paths) pass through unchanged.
     pub fn cargo_url(&self) -> String {
-        if self.remote.contains("://") {
-            return self.remote.clone();
-        }
-        match self.remote.split_once(':') {
-            Some((host, path)) if !host.contains('/') => format!("ssh://{host}/{path}"),
+        match gix_url::Url::try_from(self.remote.as_str()) {
+            Ok(mut url)
+                if url.serialize_alternative_form && matches!(url.scheme, gix_url::Scheme::Ssh) =>
+            {
+                url.serialize_alternative_form = false;
+                url.to_bstring().to_string()
+            }
             _ => self.remote.clone(),
         }
     }
@@ -155,23 +156,23 @@ fn validate_commit(commit: &str) -> Result<()> {
         })
 }
 
-/// A git remote must use an integrity-checked transport (`https`, `ssh`, or
-/// scp-style `user@host:path`) and avoid characters that can escape the
-/// generated TOML string. Reject `http`/`git` so trust canonicalization cannot
-/// silently downgrade a source.
+/// A git remote must parse (via `gix-url`) as an integrity-checked transport
+/// (`https`, `ssh`, or scp-style `user@host:path`) with a host. Reject
+/// `http`/`git`/`file` and unknown schemes so trust canonicalization cannot
+/// silently downgrade a source. Special characters in the URL are neutralized by
+/// TOML string escaping when the wrapper manifest is generated; control
+/// characters are rejected outright since a newline would later corrupt the
+/// line-delimited trust allowlist when the remote is persisted.
 fn validate_remote(remote: &str) -> Result<()> {
-    let inject = remote
-        .bytes()
-        .any(|b| b.is_ascii_control() || b == b'"' || b == b'\\');
-    // scp-style `[user@]host:path`: `:` before any `/`, optional user;
-    // `cargo_url` rewrites it to `ssh://`.
-    let shaped = matches!(remote.split_once("://"), Some(("https" | "ssh", _)))
-        || (!remote.contains("://")
-            && remote
-                .split_once(':')
-                .is_some_and(|(host, _)| !host.is_empty() && !host.contains('/')));
-    (!inject && shaped)
-        .then_some(())
+    let printable = !remote.bytes().any(|b| b.is_ascii_control());
+    gix_url::Url::try_from(remote)
+        .ok()
+        .filter(|url| {
+            printable
+                && matches!(url.scheme, gix_url::Scheme::Https | gix_url::Scheme::Ssh)
+                && url.host().is_some_and(|host| !host.is_empty())
+        })
+        .map(|_| ())
         .ok_or_else(|| OpenError::InvalidProvenance {
             field: "remote".into(),
             value: remote.into(),

--- a/crates/open/src/trust.rs
+++ b/crates/open/src/trust.rs
@@ -120,10 +120,12 @@ enum Answer {
     No,
 }
 
-/// Prompt on the terminal whether to build from an untrusted source.
+/// Prompt on the terminal whether to trust an untrusted git remote. Trust is
+/// per-remote (the commit is shown only as context): `[y]es` trusts it for this
+/// run, `[a]lways` persists it to the allowlist.
 fn prompt(remote: &str, commit: &str) -> Answer {
     eprint!(
-        "Build and run code from untrusted source\n  {remote} @ {commit}\n[y]es once / [a]lways / [N]o: "
+        "Build and run code from an untrusted git remote:\n  {remote}\n  at commit {commit}\nTrust this remote? [y]es (this run) / [a]lways / [N]o: "
     );
     let _ = std::io::stderr().flush();
     let mut line = String::new();

--- a/crates/open/src/trust.rs
+++ b/crates/open/src/trust.rs
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Trust policy for the git sources `quent-open` clones, builds, and runs.
+//!
+//! A `model.qmi` from someone else's artifact is attacker-controlled, and opening
+//! it would `cargo build` (build scripts, proc-macros, `pnpm`) and run code from
+//! the remote it names. So a source is built only when it is trusted: a built-in
+//! default (the quent repo, and the remote this tool was built from), an entry in
+//! the allowlist file, a `--trust` flag, or an interactive confirmation.
+
+use std::collections::BTreeSet;
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
+
+/// Resolves whether git remotes are trusted to build.
+pub struct Trust {
+    /// Canonicalized trusted entries: an exact repo (`github.com/rapidsai/quent`)
+    /// or an explicit prefix (`github.com/org/*`) to trust a whole org.
+    allow: BTreeSet<String>,
+    /// Bypass the gate entirely (`--trust-all`).
+    trust_all: bool,
+    /// Path of the persistent allowlist, for the "always" answer to append to.
+    allowlist_file: Option<PathBuf>,
+}
+
+impl Trust {
+    /// Build the policy from the built-in defaults, the persistent allowlist file,
+    /// and the per-run `--trust` remotes / `--trust-all` flag.
+    pub fn new(cli_trust: &[String], trust_all: bool) -> Self {
+        let mut allow = BTreeSet::new();
+        // Built-in: the canonical quent repo and the remote this tool was built
+        // from (so opening your own artifacts built from your fork just works).
+        allow.insert("github.com/rapidsai/quent".to_string());
+        if let Some(remote) = quent_build_info::quent().remote {
+            allow.insert(canonicalize_remote(&remote));
+        }
+        let allowlist_file = allowlist_path();
+        if let Some(path) = &allowlist_file
+            && let Ok(contents) = std::fs::read_to_string(path)
+        {
+            for line in contents.lines() {
+                let line = line.trim();
+                if !line.is_empty() && !line.starts_with('#') {
+                    allow.insert(canonicalize_remote(line));
+                }
+            }
+        }
+        for remote in cli_trust {
+            allow.insert(canonicalize_remote(remote));
+        }
+        Self {
+            allow,
+            trust_all,
+            allowlist_file,
+        }
+    }
+
+    /// Whether `remote` is already trusted (without prompting). A plain entry
+    /// matches one repository exactly; only an explicit `…/*` entry trusts a whole
+    /// org/prefix (so a repo entry can't accidentally trust a different repo under
+    /// a nested group).
+    fn is_trusted(&self, remote: &str) -> bool {
+        if self.trust_all {
+            return true;
+        }
+        let canonical = canonicalize_remote(remote);
+        self.allow
+            .iter()
+            .any(|entry| match entry.strip_suffix("/*") {
+                Some(prefix) => canonical == prefix || canonical.starts_with(&format!("{prefix}/")),
+                None => canonical == *entry,
+            })
+    }
+
+    /// Decide whether `remote` (recorded at `commit`) may be built. Trusted remotes
+    /// pass silently; otherwise prompt on an interactive terminal (`a` persists to
+    /// the allowlist), or refuse when non-interactive.
+    pub fn authorize(&mut self, remote: &str, commit: &str) -> bool {
+        if self.is_trusted(remote) {
+            return true;
+        }
+        if !std::io::stdin().is_terminal() {
+            return false;
+        }
+        match prompt(remote, commit) {
+            Answer::No => false,
+            Answer::Once => {
+                self.allow.insert(canonicalize_remote(remote));
+                true
+            }
+            Answer::Always => {
+                self.allow.insert(canonicalize_remote(remote));
+                self.persist(remote);
+                true
+            }
+        }
+    }
+
+    /// Append a canonical remote to the persistent allowlist (best effort).
+    fn persist(&self, remote: &str) {
+        let Some(path) = &self.allowlist_file else {
+            return;
+        };
+        let canonical = canonicalize_remote(remote);
+        let _ = std::fs::create_dir_all(path.parent().unwrap_or(path));
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = writeln!(file, "{canonical}");
+        }
+    }
+}
+
+enum Answer {
+    Once,
+    Always,
+    No,
+}
+
+/// Prompt on the terminal whether to build from an untrusted source.
+fn prompt(remote: &str, commit: &str) -> Answer {
+    eprint!(
+        "Build and run code from untrusted source\n  {remote} @ {commit}\n[y]es once / [a]lways / [N]o: "
+    );
+    let _ = std::io::stderr().flush();
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return Answer::No;
+    }
+    match line.trim().to_ascii_lowercase().as_str() {
+        "y" | "yes" => Answer::Once,
+        "a" | "always" => Answer::Always,
+        _ => Answer::No,
+    }
+}
+
+/// The persistent allowlist path, `<config_dir>/quent/open/trusted`.
+fn allowlist_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("quent").join("open").join("trusted"))
+}
+
+/// Canonicalize a git remote to a scheme-agnostic `host/path` so the https, ssh,
+/// and scp-style forms of the same repo compare equal. Strips a leading scheme or
+/// `user@`, a trailing `.git`, and lowercases the host.
+pub fn canonicalize_remote(remote: &str) -> String {
+    // Drop the scheme, if any.
+    let rest = remote.split_once("://").map(|(_, r)| r).unwrap_or(remote);
+    // For scp-style `user@host:path`, turn the first `:` into `/`.
+    let rest = if !remote.contains("://") {
+        match rest.split_once(':') {
+            Some((host, path)) if !host.contains('/') => {
+                return canonicalize_host_path(&format!("{host}/{path}"));
+            }
+            _ => rest,
+        }
+    } else {
+        rest
+    };
+    canonicalize_host_path(rest)
+}
+
+fn canonicalize_host_path(host_path: &str) -> String {
+    // Strip any `user@` in the host segment, a trailing `.git`, and a leading `/`.
+    let host_path = host_path.trim_start_matches('/');
+    let (host, path) = match host_path.split_once('/') {
+        Some((h, p)) => (h, p),
+        None => (host_path, ""),
+    };
+    let host = host.rsplit('@').next().unwrap_or(host).to_ascii_lowercase();
+    let path = path
+        .trim_end_matches('/')
+        .strip_suffix(".git")
+        .unwrap_or(path.trim_end_matches('/'));
+    if path.is_empty() {
+        host
+    } else {
+        format!("{host}/{path}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_collapses_url_forms() {
+        let want = "github.com/rapidsai/quent";
+        assert_eq!(
+            canonicalize_remote("https://github.com/rapidsai/quent"),
+            want
+        );
+        assert_eq!(
+            canonicalize_remote("https://github.com/rapidsai/quent.git"),
+            want
+        );
+        assert_eq!(
+            canonicalize_remote("git@github.com:rapidsai/quent.git"),
+            want
+        );
+        assert_eq!(
+            canonicalize_remote("ssh://git@github.com/rapidsai/quent.git"),
+            want
+        );
+        assert_eq!(canonicalize_remote("git@GitHub.com:rapidsai/quent"), want);
+    }
+
+    #[test]
+    fn trust_matches_exact_and_explicit_wildcard() {
+        let trust = Trust {
+            allow: ["github.com/rapidsai/quent".into(), "github.com/me/*".into()]
+                .into_iter()
+                .collect(),
+            trust_all: false,
+            allowlist_file: None,
+        };
+        // Exact repo entry: matches that repo (any URL form), nothing under it.
+        assert!(trust.is_trusted("https://github.com/rapidsai/quent.git"));
+        assert!(!trust.is_trusted("https://github.com/rapidsai/quent-evil"));
+        assert!(!trust.is_trusted("https://github.com/rapidsai/quent/sub"));
+        // Explicit `/*` entry: trusts the whole org/prefix.
+        assert!(trust.is_trusted("git@github.com:me/anything.git"));
+        assert!(!trust.is_trusted("https://github.com/someone/else"));
+    }
+
+    #[test]
+    fn trust_all_bypasses() {
+        let trust = Trust {
+            allow: BTreeSet::new(),
+            trust_all: true,
+            allowlist_file: None,
+        };
+        assert!(trust.is_trusted("https://anywhere.example/x/y"));
+    }
+}

--- a/crates/open/src/trust.rs
+++ b/crates/open/src/trust.rs
@@ -151,10 +151,15 @@ pub fn canonicalize_remote(remote: &str) -> String {
     // `host/org/*` allowlist wildcards aren't URLs — gix reads them as local file
     // paths (no host) — so fall back to splitting the input on the first `/`.
     let (host, path) = match gix_url::Url::try_from(remote) {
-        Ok(url) if url.host().is_some() => (
-            url.host().unwrap_or_default().to_string(),
-            url.path.to_string(),
-        ),
+        Ok(url) if url.host().is_some() => {
+            // Keep a non-default port in the key: a different port can be a
+            // different endpoint, so it must not inherit the default's trust.
+            let host = match url.port {
+                Some(port) => format!("{}:{port}", url.host().unwrap_or_default()),
+                None => url.host().unwrap_or_default().to_string(),
+            };
+            (host, url.path.to_string())
+        }
         _ => match remote.split_once('/') {
             Some((host, path)) => (host.to_string(), path.to_string()),
             None => (remote.to_string(), String::new()),
@@ -194,6 +199,20 @@ mod tests {
             want
         );
         assert_eq!(canonicalize_remote("git@GitHub.com:rapidsai/quent"), want);
+    }
+
+    #[test]
+    fn canonicalize_keeps_non_default_port() {
+        // A non-default port is a distinct endpoint and must not collapse onto the
+        // default-port repo's trust key.
+        assert_eq!(
+            canonicalize_remote("ssh://git@git.example:2222/team/repo.git"),
+            "git.example:2222/team/repo"
+        );
+        assert_ne!(
+            canonicalize_remote("ssh://git@git.example:2222/team/repo"),
+            canonicalize_remote("ssh://git@git.example/team/repo")
+        );
     }
 
     #[test]

--- a/crates/open/src/trust.rs
+++ b/crates/open/src/trust.rs
@@ -143,37 +143,26 @@ fn allowlist_path() -> Option<PathBuf> {
 }
 
 /// Canonicalize a git remote to scheme-agnostic `host/path` so https, ssh, and
-/// scp-style forms of the same repo match. Strip scheme or `user@`, trailing
-/// `.git`, and lowercase the host.
+/// scp-style forms of the same repo match. Lowercase the host and strip a
+/// trailing `.git`.
 pub fn canonicalize_remote(remote: &str) -> String {
-    // Drop the scheme, if any.
-    let rest = remote.split_once("://").map(|(_, r)| r).unwrap_or(remote);
-    // For scp-style `user@host:path`, turn the first `:` into `/`.
-    let rest = if !remote.contains("://") {
-        match rest.split_once(':') {
-            Some((host, path)) if !host.contains('/') => {
-                return canonicalize_host_path(&format!("{host}/{path}"));
-            }
-            _ => rest,
-        }
-    } else {
-        rest
+    // `gix-url` parses real git URLs and scp-style forms into host + path (with
+    // the scheme and `user@` already split off). Bare `host/path` defaults and
+    // `host/org/*` allowlist wildcards aren't URLs — gix reads them as local file
+    // paths (no host) — so fall back to splitting the input on the first `/`.
+    let (host, path) = match gix_url::Url::try_from(remote) {
+        Ok(url) if url.host().is_some() => (
+            url.host().unwrap_or_default().to_string(),
+            url.path.to_string(),
+        ),
+        _ => match remote.split_once('/') {
+            Some((host, path)) => (host.to_string(), path.to_string()),
+            None => (remote.to_string(), String::new()),
+        },
     };
-    canonicalize_host_path(rest)
-}
-
-fn canonicalize_host_path(host_path: &str) -> String {
-    // Strip `user@` from host, trailing `.git`, and leading `/`.
-    let host_path = host_path.trim_start_matches('/');
-    let (host, path) = match host_path.split_once('/') {
-        Some((h, p)) => (h, p),
-        None => (host_path, ""),
-    };
-    let host = host.rsplit('@').next().unwrap_or(host).to_ascii_lowercase();
-    let path = path
-        .trim_end_matches('/')
-        .strip_suffix(".git")
-        .unwrap_or(path.trim_end_matches('/'));
+    let host = host.to_ascii_lowercase();
+    let path = path.trim_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
     if path.is_empty() {
         host
     } else {

--- a/crates/open/src/trust.rs
+++ b/crates/open/src/trust.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Trust policy for the git sources `quent-open` clones, builds, and runs.
+//! Trust policy for git sources `quent-open` clones, builds, and runs.
 //!
-//! A `model.qmi` from someone else's artifact is attacker-controlled, and opening
-//! it would `cargo build` (build scripts, proc-macros, `pnpm`) and run code from
-//! the remote it names. So a source is built only when it is trusted: a built-in
-//! default (the quent repo, and the remote this tool was built from), an entry in
-//! the allowlist file, a `--trust` flag, or an interactive confirmation.
+//! A `model.qmi` from another artifact is attacker-controlled: opening it would
+//! `cargo build` (build scripts, proc-macros, `pnpm`) and run code from the
+//! named remote. Build only trusted sources: built-in defaults (the quent repo
+//! and this tool's build remote), the allowlist file, `--trust`, or interactive
+//! confirmation.
 
 use std::collections::BTreeSet;
 use std::io::{IsTerminal, Write};
@@ -15,22 +15,22 @@ use std::path::PathBuf;
 
 /// Resolves whether git remotes are trusted to build.
 pub struct Trust {
-    /// Canonicalized trusted entries: an exact repo (`github.com/rapidsai/quent`)
-    /// or an explicit prefix (`github.com/org/*`) to trust a whole org.
+    /// Canonicalized trust entries: exact repos (`github.com/rapidsai/quent`) or
+    /// explicit org/prefix wildcards (`github.com/org/*`).
     allow: BTreeSet<String>,
     /// Bypass the gate entirely (`--trust-all`).
     trust_all: bool,
-    /// Path of the persistent allowlist, for the "always" answer to append to.
+    /// Persistent allowlist path for appending "always" answers.
     allowlist_file: Option<PathBuf>,
 }
 
 impl Trust {
-    /// Build the policy from the built-in defaults, the persistent allowlist file,
-    /// and the per-run `--trust` remotes / `--trust-all` flag.
+    /// Build policy from built-in defaults, persistent allowlist, and per-run
+    /// `--trust` / `--trust-all`.
     pub fn new(cli_trust: &[String], trust_all: bool) -> Self {
         let mut allow = BTreeSet::new();
-        // Built-in: the canonical quent repo and the remote this tool was built
-        // from (so opening your own artifacts built from your fork just works).
+        // Built-in: canonical quent repo plus this tool's build remote, so
+        // artifacts from your fork work.
         allow.insert("github.com/rapidsai/quent".to_string());
         if let Some(remote) = quent_build_info::quent().remote {
             allow.insert(canonicalize_remote(&remote));
@@ -56,10 +56,9 @@ impl Trust {
         }
     }
 
-    /// Whether `remote` is already trusted (without prompting). A plain entry
-    /// matches one repository exactly; only an explicit `…/*` entry trusts a whole
-    /// org/prefix (so a repo entry can't accidentally trust a different repo under
-    /// a nested group).
+    /// Whether `remote` is trusted without prompting. Plain entries match one repo
+    /// exactly; only explicit `.../*` entries trust an org/prefix, avoiding
+    /// accidental trust of nested repos.
     fn is_trusted(&self, remote: &str) -> bool {
         if self.trust_all {
             return true;
@@ -73,9 +72,8 @@ impl Trust {
             })
     }
 
-    /// Decide whether `remote` (recorded at `commit`) may be built. Trusted remotes
-    /// pass silently; otherwise prompt on an interactive terminal (`a` persists to
-    /// the allowlist), or refuse when non-interactive.
+    /// Decide whether `remote` at `commit` may be built. Trusted remotes pass;
+    /// otherwise prompt interactively (`a` persists) or refuse non-interactively.
     pub fn authorize(&mut self, remote: &str, commit: &str) -> bool {
         if self.is_trusted(remote) {
             return true;
@@ -144,9 +142,9 @@ fn allowlist_path() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("quent").join("open").join("trusted"))
 }
 
-/// Canonicalize a git remote to a scheme-agnostic `host/path` so the https, ssh,
-/// and scp-style forms of the same repo compare equal. Strips a leading scheme or
-/// `user@`, a trailing `.git`, and lowercases the host.
+/// Canonicalize a git remote to scheme-agnostic `host/path` so https, ssh, and
+/// scp-style forms of the same repo match. Strip scheme or `user@`, trailing
+/// `.git`, and lowercase the host.
 pub fn canonicalize_remote(remote: &str) -> String {
     // Drop the scheme, if any.
     let rest = remote.split_once("://").map(|(_, r)| r).unwrap_or(remote);
@@ -165,7 +163,7 @@ pub fn canonicalize_remote(remote: &str) -> String {
 }
 
 fn canonicalize_host_path(host_path: &str) -> String {
-    // Strip any `user@` in the host segment, a trailing `.git`, and a leading `/`.
+    // Strip `user@` from host, trailing `.git`, and leading `/`.
     let host_path = host_path.trim_start_matches('/');
     let (host, path) = match host_path.split_once('/') {
         Some((h, p)) => (h, p),


### PR DESCRIPTION
Opening an artifact builds+runs the git sources its sidecar names. Validate provenance (hex commit, https/ssh remote, cargo-name package — blocks injection) and gate builds on a trust allowlist (built-ins + `<config>/quent/open/trusted` + `--trust`/`--trust-all`) with confirm-on-unknown (refused non-interactively).

Part 7/7. Stacked on #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)