### PR TITLE
ci: disable label checker bot

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -3,6 +3,6 @@
 
 auto_merger: true
 branch_checker: true
-label_checker: true
+label_checker: false
 release_drafter: false
 forward_merger: false


### PR DESCRIPTION
# Description

Disable the label checker. Redundant because we already use Conventional Commits.