### PR TITLE
feat(model-macros)!: structured `model!` syntax (name/root/entities)

### DIFF
--- a/crates/model-macros/src/lib.rs
+++ b/crates/model-macros/src/lib.rs
@@ -63,14 +63,14 @@ pub fn derive_resizable_resource(input: TokenStream) -> TokenStream {
 
 /// Composes a model's entities into a model type and event enum.
 ///
+/// Fields may appear in any order; `name` and `root` are required, `entities` is
+/// optional.
+///
 /// ```ignore
 /// model! {
-///     App {
-///         root: Cluster,
-///         Worker,
-///         Thread,
-///         Task,
-///     }
+///     name: App,
+///     root: Cluster,
+///     entities: { Worker, Thread, Task },
 /// }
 /// ```
 #[proc_macro]

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -3,15 +3,16 @@
 
 //! `model!` proc macro implementation.
 //!
-//! Syntax:
+//! Syntax (fields in any order; `name` + `root` required, `entities` optional):
 //! ```ignore
 //! model! {
-//!     Simulator {
-//!         root: ResourceRoot,
+//!     name: Simulator,
+//!     root: ResourceRoot,
+//!     entities: {
 //!         quent_query_engine_model::Engine,
 //!         task::Task,
 //!         quent_stdlib::memory::Memory,
-//!     }
+//!     },
 //! }
 //! ```
 //!
@@ -31,43 +32,62 @@ struct DefineModelInput {
 
 impl Parse for DefineModelInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let name: Ident = input.parse()?;
+        // Labeled `key: value` fields in any order: `name`/`root` required,
+        // `entities` optional (a brace-delimited, comma-separated path list).
+        let mut name: Option<Ident> = None;
+        let mut root: Option<Path> = None;
+        let mut components: Option<Vec<Path>> = None;
 
-        let content;
-        syn::braced!(content in input);
-
-        // First entry must be `root: Path`
-        if content.is_empty() {
-            return Err(syn::Error::new_spanned(
-                name,
-                "model! requires at least a root resource group: `root: MyRoot`",
-            ));
-        }
-        let root_kw: Ident = content.parse()?;
-        if root_kw != "root" {
-            return Err(syn::Error::new_spanned(
-                root_kw,
-                "first entry must be `root: <RootResourceGroup>`",
-            ));
-        }
-        content.parse::<Token![:]>()?;
-        let root: Path = content.parse()?;
-        if content.peek(Token![,]) {
-            content.parse::<Token![,]>()?;
-        }
-
-        let mut components = Vec::new();
-        while !content.is_empty() {
-            components.push(content.parse::<Path>()?);
-            if content.peek(Token![,]) {
-                content.parse::<Token![,]>()?;
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![:]>()?;
+            let dup = || syn::Error::new_spanned(&key, format!("duplicate `{key}`"));
+            match key.to_string().as_str() {
+                "name" => {
+                    if name.replace(input.parse()?).is_some() {
+                        return Err(dup());
+                    }
+                }
+                "root" => {
+                    if root.replace(input.parse()?).is_some() {
+                        return Err(dup());
+                    }
+                }
+                "entities" => {
+                    if components.is_some() {
+                        return Err(dup());
+                    }
+                    let content;
+                    syn::braced!(content in input);
+                    let mut entities = Vec::new();
+                    while !content.is_empty() {
+                        entities.push(content.parse::<Path>()?);
+                        if content.peek(Token![,]) {
+                            content.parse::<Token![,]>()?;
+                        }
+                    }
+                    components = Some(entities);
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        &key,
+                        format!(
+                            "unknown `model!` field `{other}`; expected `name`, `root`, or `entities`"
+                        ),
+                    ));
+                }
+            }
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
             }
         }
 
+        let name = name.ok_or_else(|| input.error("`model!` requires a `name: <Ident>` field"))?;
+        let root = root.ok_or_else(|| input.error("`model!` requires a `root: <Path>` field"))?;
         Ok(DefineModelInput {
             name,
             root,
-            components,
+            components: components.unwrap_or_default(),
         })
     }
 }

--- a/crates/model/tests/compile_fail/model_duplicate_components.rs
+++ b/crates/model/tests/compile_fail/model_duplicate_components.rs
@@ -13,11 +13,12 @@ quent_model::entity! {
 }
 
 quent_model::model! {
-    App {
-        root: Root,
+    name: App,
+    root: Root,
+    entities: {
         Thing,
         Thing,
-    }
+    },
 }
 
 fn main() {}

--- a/crates/model/tests/compile_fail/model_duplicate_components.stderr
+++ b/crates/model/tests/compile_fail/model_duplicate_components.stderr
@@ -1,5 +1,5 @@
 error: duplicate component name `Thing` — two components resolve to the same event enum variant
-  --> tests/compile_fail/model_duplicate_components.rs:19:9
+  --> tests/compile_fail/model_duplicate_components.rs:20:9
    |
-19 |         Thing,
+20 |         Thing,
    |         ^^^^^

--- a/crates/model/tests/compile_fail/model_empty.rs
+++ b/crates/model/tests/compile_fail/model_empty.rs
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// model! with empty body should fail — requires root resource group.
-quent_model::model! {
-    App {}
-}
+// model! with no fields should fail — `name` and `root` are required.
+quent_model::model! {}
 
 fn main() {}

--- a/crates/model/tests/compile_fail/model_empty.stderr
+++ b/crates/model/tests/compile_fail/model_empty.stderr
@@ -1,5 +1,7 @@
-error: model! requires at least a root resource group: `root: MyRoot`
- --> tests/compile_fail/model_empty.rs:6:5
+error: unexpected end of input, `model!` requires a `name: <Ident>` field
+ --> tests/compile_fail/model_empty.rs:5:1
   |
-6 |     App {}
-  |     ^^^
+5 | quent_model::model! {}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `quent_model::model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/model/tests/compile_fail/model_missing_root.rs
+++ b/crates/model/tests/compile_fail/model_missing_root.rs
@@ -1,15 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// model! first entry must be `root: <Type>`.
-quent_model::entity! {
-    Cluster: ResourceGroup<Root = true> {}
-}
-
+// model! requires a `root` field.
 quent_model::model! {
-    App {
-        Cluster,
-    }
+    name: App,
+    entities: { Cluster },
 }
 
 fn main() {}

--- a/crates/model/tests/compile_fail/model_missing_root.stderr
+++ b/crates/model/tests/compile_fail/model_missing_root.stderr
@@ -1,0 +1,10 @@
+error: unexpected end of input, `model!` requires a `root: <Path>` field
+ --> tests/compile_fail/model_missing_root.rs:5:1
+  |
+5 | / quent_model::model! {
+6 | |     name: App,
+7 | |     entities: { Cluster },
+8 | | }
+  | |_^
+  |
+  = note: this error originates in the macro `quent_model::model` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/model/tests/compile_fail/model_no_root_keyword.stderr
+++ b/crates/model/tests/compile_fail/model_no_root_keyword.stderr
@@ -1,5 +1,0 @@
-error: first entry must be `root: <RootResourceGroup>`
-  --> tests/compile_fail/model_no_root_keyword.rs:11:9
-   |
-11 |         Cluster,
-   |         ^^^^^^^

--- a/crates/model/tests/define_model.rs
+++ b/crates/model/tests/define_model.rs
@@ -43,11 +43,12 @@ quent_model::entity! {
 }
 
 quent_model::model! {
-    Test {
-        root: TestRoot,
+    name: Test,
+    root: TestRoot,
+    entities: {
         SimpleFsm,
         SimpleEntity,
-    }
+    },
 }
 
 #[test]

--- a/domains/query_engine/model/src/lib.rs
+++ b/domains/query_engine/model/src/lib.rs
@@ -14,13 +14,14 @@ pub mod query_group;
 pub mod worker;
 
 model! {
-    QueryEngine {
-        root: engine::Engine,
+    name: QueryEngine,
+    root: engine::Engine,
+    entities: {
         query::Query,
         worker::Worker,
         query_group::QueryGroup,
         plan::Plan,
         operator::Operator,
         port::Port,
-    }
+    },
 }

--- a/examples/readme/src/lib.rs
+++ b/examples/readme/src/lib.rs
@@ -217,8 +217,9 @@ fsm! {
 // model! requires at least a root resource group
 // ```
 model! {
-    App {
-        root: Cluster,
+    name: App,
+    root: Cluster,
+    entities: {
         Worker,
         Thread,
         Cache,
@@ -227,7 +228,7 @@ model! {
         FileStats,
         Task,
         Info,
-    }
+    },
 }
 
 // Generates the instrumentation API

--- a/examples/simulator/instrumentation/src/lib.rs
+++ b/examples/simulator/instrumentation/src/lib.rs
@@ -20,8 +20,9 @@ pub use quent_stdlib::{channel, memory, processor};
 pub use task::TaskEvent;
 
 model! {
-    Simulator {
-        root: quent_query_engine_model::engine::Engine,
+    name: Simulator,
+    root: quent_query_engine_model::engine::Engine,
+    entities: {
         quent_query_engine_model::worker::Worker,
         quent_query_engine_model::query_group::QueryGroup,
         quent_query_engine_model::query::Query,
@@ -34,7 +35,7 @@ model! {
         quent_stdlib::memory::Memory,
         quent_stdlib::processor::Processor,
         quent_stdlib::channel::Channel,
-    }
+    },
 }
 
 instrumentation!(Simulator);


### PR DESCRIPTION
Make `model!` explicit and order-flexible: labeled `name:` / `root:` / optional `entities: { … }` fields, instead of `Name { root: …, <bare component list> }`. Separating entities from directives reads more clearly and removes the parse ambiguity a bare list creates.

From @johanpel's review of #261.

**BREAKING:** all `model!` call sites migrate. Updated the in-repo sites (query-engine, readme, simulator) + the compile-fail tests. The quent-open stack (#261–#266) will rebase onto this; #261 then adds `analyzer:` on the new syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)