### PR TITLE
feat(qdl, experimental): add minimal QDL parser lowering to a Schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +115,15 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "arbitrary"
@@ -307,6 +322,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chumsky"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14377e276b2c8300513dff55ba4cc4142b44e5d6de6d00eb5b2307d650bb4ec1"
+dependencies = [
+ "hashbrown 0.15.5",
+ "regex-automata 0.3.9",
+ "serde",
+ "stacker",
+ "unicode-ident",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "ciborium"
@@ -926,6 +955,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1311,7 +1342,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.14",
 ]
 
 [[package]]
@@ -1704,6 +1735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2114,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "quent-qdl"
+version = "0.1.0"
+dependencies = [
+ "chumsky",
+ "quent-constraints",
+ "quent-schema",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "quent-qdl-example"
+version = "0.1.0"
+dependencies = [
+ "quent-attributes",
+ "quent-instrumentation-build",
+ "quent-qdl",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -2455,8 +2518,19 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.9",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -2467,8 +2541,14 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.9",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -2766,6 +2846,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "str_stack"
@@ -3194,7 +3287,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex-automata 0.4.14",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ members = [
     "crates/fsm",
     "crates/instrumentation-build",
     "crates/instrumentation-build/example",
+    "crates/qdl",
+    "crates/qdl/example",
 ]
 
 # default-members excludes any crate that activates `quent-time/__test-clock-override`.

--- a/crates/qdl/Cargo.toml
+++ b/crates/qdl/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "quent-qdl"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+quent-schema = { path = "../schema" }
+quent-constraints = { path = "../constraints" }
+chumsky = "0.10"
+thiserror = { workspace = true }
+
+[[bin]]
+name = "qdl-check"
+path = "src/bin/check.rs"

--- a/crates/qdl/example/Cargo.toml
+++ b/crates/qdl/example/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "quent-qdl-example"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+quent-attributes = { path = "../../attributes" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true, features = ["serde"] }
+
+[build-dependencies]
+quent-qdl = { path = ".." }
+quent-instrumentation-build = { path = "../../instrumentation-build" }

--- a/crates/qdl/example/build.rs
+++ b/crates/qdl/example/build.rs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Loads the QDL model and generates the instrumentation library into `OUT_DIR`.
+
+use std::path::Path;
+
+use quent_instrumentation_build::{GenerateInfo, Options, generate};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model = Path::new(env!("CARGO_MANIFEST_DIR")).join("model.qdl");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", model.display());
+
+    // QDL source -> quent_schema::Schema.
+    let schema = quent_qdl::load(&model)?;
+
+    // Schema -> generated Rust instrumentation source.
+    let opts = Options {
+        event_derives: &["Debug"],
+        record_derives: &["Debug"],
+        ..Default::default()
+    };
+    let GenerateInfo { path, warnings } = generate(&schema, &opts)?;
+
+    if !warnings.is_empty() {
+        println!("cargo:warning={}", warnings.join("\n"));
+    }
+    println!(
+        "cargo:warning=instrumentation library written to {}",
+        path.display()
+    );
+
+    Ok(())
+}

--- a/crates/qdl/example/model.qdl
+++ b/crates/qdl/example/model.qdl
@@ -1,0 +1,27 @@
+// The event model, authored in QDL and compiled to instrumentation at build time.
+
+model demo;
+
+/// A network endpoint.
+record Endpoint {
+    host: String,
+    port: u16,
+}
+
+record Meta {
+    tags: Vec<String>,
+    extra: Dynamic,
+}
+
+/// A client connection.
+entity Connection {
+    once opened: {
+        peer: Endpoint,
+        session: Uuid,
+    },
+    multi data: {
+        bytes: u64,
+        meta: Option<Meta>,
+    },
+    once closed: {},
+}

--- a/crates/qdl/example/src/main.rs
+++ b/crates/qdl/example/src/main.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Uses the instrumentation library generated from `model.qdl` at build time.
+
+pub mod demo {
+    include!(concat!(env!("OUT_DIR"), "/demo.rs"));
+}
+
+fn main() {
+    let opened = demo::ConnectionEvent::Opened {
+        peer: demo::Endpoint {
+            host: "localhost".to_owned(),
+            port: 8080,
+        },
+        session: uuid::Uuid::nil(),
+    };
+    dbg!(opened);
+}

--- a/crates/qdl/src/ast.rs
+++ b/crates/qdl/src/ast.rs
@@ -1,0 +1,66 @@
+//! Parsed representation of a QDL source file.
+//!
+//! This is the syntactic AST. Names are kept as raw strings here; validity (the
+//! [`quent_schema::Identifier`] grammar, reference resolution) is checked during
+//! lowering.
+
+/// A whole QDL file: a model name and its top-level items.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ast {
+    pub model: String,
+    pub items: Vec<Item>,
+}
+
+/// A top-level declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Item {
+    Record(RecordDef),
+    Entity(EntityDef),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordDef {
+    pub docs: Option<String>,
+    pub name: String,
+    pub fields: Vec<FieldDef>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntityDef {
+    pub docs: Option<String>,
+    pub name: String,
+    pub events: Vec<EventDef>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventDef {
+    pub docs: Option<String>,
+    pub cardinality: Cardinality,
+    pub name: String,
+    pub payload: Vec<FieldDef>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cardinality {
+    Once,
+    Multi,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldDef {
+    pub docs: Option<String>,
+    pub name: String,
+    pub ty: Ty,
+}
+
+/// A field type, prior to resolution against scalars and declared records.
+///
+/// Kept structural: `App` is any `head<arg>` application; whether `head` is a
+/// valid generic (`Option`/`Vec`) is decided during lowering.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ty {
+    /// A scalar, `Dynamic`, or a record reference. Resolved during lowering.
+    Named(String),
+    /// A generic application `head<arg>`, e.g. `Option<Plan>`.
+    App(String, Box<Ty>),
+}

--- a/crates/qdl/src/bin/check.rs
+++ b/crates/qdl/src/bin/check.rs
@@ -1,0 +1,26 @@
+//! `qdl-check`: parse, lower, and validate a QDL file.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let Some(path) = std::env::args().nth(1).map(PathBuf::from) else {
+        eprintln!("usage: qdl-check <file.qdl>");
+        return ExitCode::FAILURE;
+    };
+    match quent_qdl::load(&path) {
+        Ok(schema) => {
+            println!(
+                "ok: model `{}` ({} entities, {} records)",
+                schema.name(),
+                schema.entities().count(),
+                schema.records().count(),
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("{}: {e}", path.display());
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/qdl/src/lib.rs
+++ b/crates/qdl/src/lib.rs
@@ -1,0 +1,69 @@
+//! QDL: a textual source language for [`quent_schema`] application event models.
+//!
+//! This is the minimal subset: a `model` name, `record`s, and `entity`s with
+//! `once`/`multi` events. References, FSMs, resources, and constraints are not
+//! yet supported.
+
+use std::path::Path;
+
+use chumsky::error::Cheap;
+use chumsky::span::Span;
+use chumsky::Parser;
+use quent_schema::Schema;
+
+pub mod ast;
+mod lower;
+mod parser;
+
+pub use lower::LowerError;
+
+/// Failure while loading a QDL source.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("parse error:\n{0}")]
+    Parse(String),
+    #[error(transparent)]
+    Lower(#[from] LowerError),
+    #[error("schema validation failed:\n{0}")]
+    Validate(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Parse and lower QDL source text into a validated [`Schema`].
+///
+/// Runs the always-on base constraints (unresolved record references, recursive
+/// records); it does not run opt-in constraints.
+pub fn load_str(src: &str) -> Result<Schema, Error> {
+    let ast = parser::parser().parse(src).into_result().map_err(|errs| {
+        Error::Parse(
+            errs.iter()
+                .map(|e: &Cheap| {
+                    let (line, col) = line_col(src, e.span().start());
+                    format!("  unexpected input at line {line}:{col}")
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    })?;
+    let schema = lower::lower(&ast)?;
+    let report = quent_constraints::validate::<()>(&schema);
+    if let Err(e) = report.base_constraints {
+        return Err(Error::Validate(e.to_string()));
+    }
+    Ok(schema)
+}
+
+/// Read a QDL file and load it via [`load_str`].
+pub fn load(path: impl AsRef<Path>) -> Result<Schema, Error> {
+    let src = std::fs::read_to_string(path)?;
+    load_str(&src)
+}
+
+/// 1-based line and column for a byte offset into `src`.
+fn line_col(src: &str, offset: usize) -> (usize, usize) {
+    let offset = offset.min(src.len());
+    let line = src[..offset].bytes().filter(|&b| b == b'\n').count() + 1;
+    let col = offset - src[..offset].rfind('\n').map(|i| i + 1).unwrap_or(0) + 1;
+    (line, col)
+}

--- a/crates/qdl/src/lower.rs
+++ b/crates/qdl/src/lower.rs
@@ -1,0 +1,114 @@
+//! Lowering from the QDL [`Ast`] to a [`quent_schema::Schema`].
+
+use quent_schema::builder::{
+    AnnotationsBuilder, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder,
+};
+use quent_schema::{Annotations, Cardinality, DataType, Field, Identifier, Schema};
+
+use crate::ast::{Ast, EntityDef, EventDef, FieldDef, Item, RecordDef, Ty};
+
+/// Failure while lowering a parsed QDL file to a schema.
+#[derive(Debug, thiserror::Error)]
+pub enum LowerError {
+    #[error("invalid identifier \"{name}\": {reason}")]
+    Identifier { name: String, reason: String },
+    #[error("duplicate name: {0}")]
+    Duplicate(String),
+    #[error("type arguments are only allowed on `Option` and `Vec`, found `{0}<...>`")]
+    BadGeneric(String),
+}
+
+fn ident(name: &str) -> Result<Identifier, LowerError> {
+    Identifier::try_new(name).map_err(|e| LowerError::Identifier {
+        name: name.to_string(),
+        reason: e.to_string(),
+    })
+}
+
+fn annotations(docs: &Option<String>) -> Annotations {
+    match docs {
+        Some(d) => AnnotationsBuilder::new().docs(d.clone()).build(),
+        None => Annotations::default(),
+    }
+}
+
+/// Build a [`Schema`] from a parsed file. Does not run constraint validation.
+pub fn lower(ast: &Ast) -> Result<Schema, LowerError> {
+    let mut schema = SchemaBuilder::new(ident(&ast.model)?);
+    for item in &ast.items {
+        match item {
+            Item::Record(r) => schema = schema.record(lower_record(r)?).map_err(dup)?,
+            Item::Entity(e) => schema = schema.entity(lower_entity(e)?).map_err(dup)?,
+        }
+    }
+    Ok(schema.build())
+}
+
+fn dup(e: quent_schema::builder::BuilderError) -> LowerError {
+    LowerError::Duplicate(e.to_string())
+}
+
+fn lower_record(r: &RecordDef) -> Result<quent_schema::Record, LowerError> {
+    let mut builder = RecordBuilder::new(ident(&r.name)?);
+    for f in &r.fields {
+        builder = builder.field(lower_field(f)?).map_err(dup)?;
+    }
+    Ok(builder.annotations(annotations(&r.docs)).build())
+}
+
+fn lower_entity(e: &EntityDef) -> Result<quent_schema::Entity, LowerError> {
+    let mut builder = EntityBuilder::new(ident(&e.name)?);
+    for ev in &e.events {
+        builder = builder.event(lower_event(ev)?).map_err(dup)?;
+    }
+    Ok(builder.annotations(annotations(&e.docs)).build())
+}
+
+fn lower_event(ev: &EventDef) -> Result<quent_schema::Event, LowerError> {
+    let cardinality = match ev.cardinality {
+        crate::ast::Cardinality::Once => Cardinality::Once,
+        crate::ast::Cardinality::Multi => Cardinality::Multi,
+    };
+    let mut builder = EventBuilder::new(ident(&ev.name)?, cardinality);
+    for f in &ev.payload {
+        builder = builder.field(lower_field(f)?).map_err(dup)?;
+    }
+    Ok(builder.annotations(annotations(&ev.docs)).build())
+}
+
+fn lower_field(f: &FieldDef) -> Result<Field, LowerError> {
+    Ok(Field::new(
+        ident(&f.name)?,
+        lower_ty(&f.ty)?,
+        annotations(&f.docs),
+    ))
+}
+
+fn lower_ty(ty: &Ty) -> Result<DataType, LowerError> {
+    Ok(match ty {
+        Ty::App(head, inner) => match head.as_str() {
+            "Option" => DataType::Option(Box::new(lower_ty(inner)?)),
+            "Vec" => DataType::List(Box::new(lower_ty(inner)?)),
+            other => return Err(LowerError::BadGeneric(other.to_string())),
+        },
+        Ty::Named(name) => match name.as_str() {
+            "bool" => DataType::Bool,
+            "Uuid" => DataType::Uuid,
+            "String" => DataType::String,
+            "u8" => DataType::U8,
+            "u16" => DataType::U16,
+            "u32" => DataType::U32,
+            "u64" => DataType::U64,
+            "i8" => DataType::I8,
+            "i16" => DataType::I16,
+            "i32" => DataType::I32,
+            "i64" => DataType::I64,
+            "f32" => DataType::F32,
+            "f64" => DataType::F64,
+            "Dynamic" => DataType::DynamicRecord,
+            // Any other name is a reference to a declared record; existence is
+            // checked by the base constraint validator.
+            other => DataType::Record(ident(other)?),
+        },
+    })
+}

--- a/crates/qdl/src/parser.rs
+++ b/crates/qdl/src/parser.rs
@@ -1,0 +1,150 @@
+//! chumsky parser for the minimal QDL grammar (records and entities only).
+//!
+//! Uses the [`chumsky::error::Cheap`] error type: it carries no references into
+//! the source, so the parser is covariant over the source lifetime and can be
+//! returned as `impl Parser<'a, ...>`. Semantic checks (valid generics,
+//! identifier grammar) happen during lowering, where they get precise messages.
+
+use chumsky::error::Cheap;
+use chumsky::prelude::*;
+
+use crate::ast::{Ast, Cardinality, EntityDef, EventDef, FieldDef, Item, RecordDef, Ty};
+
+/// Parser for a whole QDL file.
+// Nested tuple annotations are required for chumsky's type inference.
+#[allow(clippy::type_complexity)]
+pub fn parser<'a>() -> impl Parser<'a, &'a str, Ast, extra::Err<Cheap>> {
+    // Whitespace and non-doc (`//`) line comments. A `///` doc comment is left
+    // for `docs` to capture, because the char after `//` must not be `/` here.
+    let line_comment = just("//")
+        .then(none_of("/"))
+        .then(none_of("\n").repeated())
+        .ignored();
+    let ws = choice((one_of(" \t\r\n").ignored(), line_comment))
+        .repeated()
+        .ignored();
+
+    // One or more consecutive `///` lines, joined and trimmed.
+    let docs = just("///")
+        .ignore_then(none_of("\n").repeated().collect::<String>())
+        .then_ignore(ws)
+        .repeated()
+        .at_least(1)
+        .collect::<Vec<String>>()
+        .map(|lines| {
+            lines
+                .iter()
+                .map(|l| l.trim())
+                .collect::<Vec<_>>()
+                .join("\n")
+        });
+
+    let ident = text::ascii::ident().padded_by(ws);
+
+    // One generic level (e.g. `Vec<Stage>`, `Option<Plan>`). Deeper nesting is
+    // not part of this minimal subset.
+    let generic_arg = ident.delimited_by(just('<').padded_by(ws), just('>').padded_by(ws));
+    let ty = ident
+        .then(generic_arg.or_not())
+        .map(|(head, arg): (&str, Option<&str>)| match arg {
+            Some(a) => Ty::App(head.to_string(), Box::new(Ty::Named(a.to_string()))),
+            None => Ty::Named(head.to_string()),
+        });
+
+    let field = docs
+        .or_not()
+        .then(ident)
+        .then_ignore(just(':').padded_by(ws))
+        .then(ty)
+        .map(|((d, name), ty): ((Option<String>, &str), Ty)| FieldDef {
+            docs: d,
+            name: name.to_string(),
+            ty,
+        });
+
+    let fields = field
+        .separated_by(just(',').padded_by(ws))
+        .allow_trailing()
+        .collect::<Vec<_>>()
+        .delimited_by(just('{').padded_by(ws), just('}').padded_by(ws));
+
+    let cardinality = choice((
+        text::ascii::keyword("once").to(Cardinality::Once),
+        text::ascii::keyword("multi").to(Cardinality::Multi),
+    ))
+    .padded_by(ws);
+
+    let event = docs
+        .or_not()
+        .then(cardinality)
+        .then(ident)
+        .then_ignore(just(':').padded_by(ws))
+        .then(fields)
+        .map(
+            |(((d, card), name), payload): (
+                ((Option<String>, Cardinality), &str),
+                Vec<FieldDef>,
+            )| EventDef {
+                docs: d,
+                cardinality: card,
+                name: name.to_string(),
+                payload,
+            },
+        );
+
+    let events = event
+        .separated_by(just(',').padded_by(ws))
+        .allow_trailing()
+        .collect::<Vec<_>>()
+        .delimited_by(just('{').padded_by(ws), just('}').padded_by(ws));
+
+    let record_body = text::ascii::keyword("record")
+        .padded_by(ws)
+        .ignore_then(ident)
+        .then(fields)
+        .map(|(name, fields): (&str, Vec<FieldDef>)| {
+            Item::Record(RecordDef {
+                docs: None,
+                name: name.to_string(),
+                fields,
+            })
+        });
+
+    let entity_body = text::ascii::keyword("entity")
+        .padded_by(ws)
+        .ignore_then(ident)
+        .then(events)
+        .map(|(name, events): (&str, Vec<EventDef>)| {
+            Item::Entity(EntityDef {
+                docs: None,
+                name: name.to_string(),
+                events,
+            })
+        });
+
+    let item = docs
+        .or_not()
+        .then(choice((record_body, entity_body)))
+        .map(|(d, item)| match item {
+            Item::Record(mut r) => {
+                r.docs = d;
+                Item::Record(r)
+            }
+            Item::Entity(mut e) => {
+                e.docs = d;
+                Item::Entity(e)
+            }
+        });
+
+    let model = text::ascii::keyword("model")
+        .padded_by(ws)
+        .ignore_then(ident)
+        .then_ignore(just(';').padded_by(ws))
+        .map(|s: &str| s.to_string());
+
+    model
+        .then(item.repeated().collect::<Vec<_>>())
+        .map(|(model, items)| Ast { model, items })
+        .padded_by(ws)
+        .then_ignore(end())
+}

--- a/crates/qdl/tests/minimal.rs
+++ b/crates/qdl/tests/minimal.rs
@@ -1,0 +1,94 @@
+use quent_qdl::load_str;
+
+const MINIMAL: &str = r#"
+// minimal model
+
+model query_engine;
+
+/// A network endpoint.
+record Endpoint {
+    host: String,
+    port: u16,
+}
+
+record Plan {
+    stage_count: u32,
+    stages: Vec<Stage>,
+    estimate: Option<CostEstimate>,
+}
+
+record Stage {
+    name: String,
+    operator_ids: Vec<Uuid>,
+    cost: f64,
+}
+
+record CostEstimate {
+    cpu: f64,
+    mem_bytes: u64,
+}
+
+/// Free-form, runtime-keyed statistics.
+record Stats {
+    rows: u64,
+    extra: Dynamic,
+}
+
+entity Cluster {
+    once up: {
+        region: String,
+    },
+    once down: {},
+}
+
+entity Engine {
+    once started: {
+        listen_on: Endpoint,
+    },
+    multi heartbeat: {
+        load: f32,
+        inflight: u32,
+    },
+    once stopped: {},
+}
+
+entity Query {
+    once submitted: {
+        text: String,
+        plan: Option<Plan>,
+    },
+    multi progress: {
+        stats: Stats,
+    },
+    once finished: {
+        ok: bool,
+        error: Option<String>,
+    },
+}
+"#;
+
+#[test]
+fn loads_minimal_model() {
+    let schema = load_str(MINIMAL).expect("should load");
+    assert_eq!(schema.name(), "query_engine");
+    assert_eq!(schema.records().count(), 5);
+    assert_eq!(schema.entities().count(), 3);
+
+    let engine = schema
+        .entity(&"Engine".parse().unwrap())
+        .expect("Engine entity");
+    assert_eq!(engine.events().count(), 3);
+
+    let endpoint = schema
+        .record(&"Endpoint".parse().unwrap())
+        .expect("Endpoint record");
+    assert_eq!(endpoint.annotations().docs(), Some("A network endpoint."));
+}
+
+#[test]
+fn rejects_reference_to_unknown_record() {
+    let src = "model m; record A { b: Missing, }";
+    let err = load_str(src).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation"), "unexpected error: {msg}");
+}


### PR DESCRIPTION
Add `quent-qdl`, a chumsky-based parser for a minimal subset of QDL (model, records, and entities with once/multi events plus the scalar, Option, Vec, Dynamic, and record-reference types). It lowers to a `quent_schema::Schema` and runs the always-on base constraints (unresolved record references, recursive records). Includes a `qdl-check` binary and an example wiring a `.qdl` file into `quent-instrumentation-build` at build time.

The parser uses chumsky's `Cheap` error type: `Rich`/`Simple` borrow the source and make the parser invariant over its lifetime, which the current toolchain rejects when returned as `impl Parser<'a, ...>`. Diagnostics are therefore span-based (line:col) for now.

# Description

<!-- What does this PR do and why? -->

## Related Issues

<!-- Link related issues: closes #123, relates to #456 -->

## Testing

<!--
Describe what you ran locally.

Rust changes:
- pixi run cargo fmt --all
- pixi run cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- pixi run cargo test --workspace --all-features --locked --all-targets

UI changes:
- cd ui
- pnpm ci:check
-->

## Screenshots

<!-- For UI changes, include screenshots or videos when possible. -->
