### PR TITLE
feat(open): expose quent-open as a library with a Loader extension point

### DIFF
--- a/crates/open/src/lib.rs
+++ b/crates/open/src/lib.rs
@@ -1,16 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! `quent-open` opens local Quent benchmark artifacts in an application-specific
-//! viewer. See <https://github.com/rapidsai/quent/issues/234>.
+//! Open local Quent benchmark artifacts in an application-specific viewer.
+//! See <https://github.com/rapidsai/quent/issues/234>.
 //!
-//! Given a context directory, it reads the `model.qmi` provenance sidecar,
-//! generates a small viewer crate pinned to the recorded quent + analyzer commits,
-//! builds and serves it, and opens a browser.
+//! Given a context directory, read `model.qmi`, generate a viewer crate pinned
+//! to the recorded quent/analyzer commits, build and serve it, and open a browser.
 //!
-//! Building the viewer fetches the recorded git sources and compiles the embedded
-//! UI, which runs `pnpm`/`node` on first build (cached afterwards); these must be
-//! available on `PATH`.
+//! The first viewer build fetches git sources and compiles the embedded UI,
+//! invoking `pnpm`/`node`; these must be on `PATH`.
 //!
 //! # Library: custom loaders
 //!
@@ -156,9 +154,9 @@ pub async fn open(contexts: Vec<PathBuf>, options: OpenOptions) -> Result<()> {
         return Err(OpenError::NoContexts);
     }
 
-    // Each viewer builds + runs code from its quent and analyzer git remotes, so
-    // gate on trust before building. Authorize each distinct remote once (prompts
-    // are sequential, before the parallel build phase).
+    // Each viewer builds and runs code from its quent/analyzer remotes; require
+    // trust before building. Authorize each distinct remote once, with prompts
+    // before parallel builds.
     let mut decided: BTreeMap<String, bool> = BTreeMap::new();
     for group in &groups {
         for pin in [&group.spec.quent, &group.spec.analyzer] {

--- a/crates/open/src/lib.rs
+++ b/crates/open/src/lib.rs
@@ -58,7 +58,7 @@ mod wrapper;
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::net::IpAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use quent_build_info::{ArtifactInfo, SIDECAR_FILE_NAME};
 
@@ -130,7 +130,11 @@ pub async fn open(contexts: Vec<PathBuf>, options: OpenOptions) -> Result<()> {
     // One group per build spec; contexts sharing a spec share a viewer.
     let mut groups: BTreeMap<String, ViewerGroup> = BTreeMap::new();
     for context in contexts {
-        let spec = match read_artifact_info(&context)
+        let spec = match ArtifactInfo::read_sidecar(&context)
+            .map_err(|source| OpenError::Sidecar {
+                path: context.join(SIDECAR_FILE_NAME),
+                source,
+            })
             .and_then(|info| ViewerSpec::from_artifact(&context, &info))
         {
             Ok(spec) => spec,
@@ -186,14 +190,6 @@ pub async fn open(contexts: Vec<PathBuf>, options: OpenOptions) -> Result<()> {
         return Err(OpenError::NothingTrusted);
     }
     viewer::open_all(approved, no_browser, host).await
-}
-
-/// Read the [`ArtifactInfo`] sidecar from the context directory `dir`.
-fn read_artifact_info(dir: &Path) -> Result<ArtifactInfo> {
-    ArtifactInfo::read_sidecar(dir).map_err(|source| OpenError::Sidecar {
-        path: dir.join(SIDECAR_FILE_NAME),
-        source,
-    })
 }
 
 #[cfg(test)]

--- a/crates/open/src/lib.rs
+++ b/crates/open/src/lib.rs
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `quent-open` opens local Quent benchmark artifacts in an application-specific
+//! viewer. See <https://github.com/rapidsai/quent/issues/234>.
+//!
+//! Given a context directory, it reads the `model.qmi` provenance sidecar,
+//! generates a small viewer crate pinned to the recorded quent + analyzer commits,
+//! builds and serves it, and opens a browser.
+//!
+//! Building the viewer fetches the recorded git sources and compiles the embedded
+//! UI, which runs `pnpm`/`node` on first build (cached afterwards); these must be
+//! available on `PATH`.
+//!
+//! # Library: custom loaders
+//!
+//! The `quent-open` binary opens artifacts on the local filesystem. To open
+//! artifacts from elsewhere — a remote database, an object store, an HTTP API —
+//! implement [`Loader`]: fetch the artifacts (event streams + `model.qmi`) into
+//! context directories on disk, then hand them to [`run`], which groups, gates on
+//! [trust](Trust), builds, and serves them exactly as the local path does.
+//!
+//! ```ignore
+//! use std::path::PathBuf;
+//! use quent_open::{Loader, OpenOptions, Result, Trust, run};
+//!
+//! /// Fetches a telemetry artifact by database id over some API.
+//! struct DbLoader {
+//!     id: String,
+//!     scratch: tempfile::TempDir, // kept alive for the lifetime of the loader
+//! }
+//!
+//! impl Loader for DbLoader {
+//!     async fn load(&self) -> Result<Vec<PathBuf>> {
+//!         // GET the artifact for `self.id`, writing each context (its `model.qmi`
+//!         // plus per-entity event streams) into a UUID-named directory under
+//!         // `self.scratch`, then return those context directories.
+//!         todo!()
+//!     }
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<()> {
+//!     let loader = DbLoader { id: "abc123".into(), scratch: tempfile::tempdir()? };
+//!     let options = OpenOptions {
+//!         no_browser: false,
+//!         host: std::net::Ipv4Addr::LOCALHOST.into(),
+//!         trust: Trust::new(&[], false),
+//!     };
+//!     run(loader, options).await
+//! }
+//! ```
+
+mod error;
+mod spec;
+mod trust;
+mod viewer;
+mod wrapper;
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+
+use quent_build_info::{ArtifactInfo, SIDECAR_FILE_NAME};
+
+pub use crate::error::{OpenError, Result};
+pub use crate::spec::{Format, GitPin, ViewerSpec, discover_contexts};
+pub use crate::trust::{Trust, canonicalize_remote};
+pub use crate::viewer::ViewerGroup;
+
+/// Options controlling how viewers are built, served, and gated on source trust.
+pub struct OpenOptions {
+    /// Print each viewer's URL but do not open a browser.
+    pub no_browser: bool,
+    /// Host/interface the viewers bind (`0.0.0.0` to allow other hosts).
+    pub host: IpAddr,
+    /// Trust policy applied to every source before it is built and run.
+    pub trust: Trust,
+}
+
+/// A source of Quent artifacts for [`run`] to open.
+///
+/// A loader fetches/materializes artifacts as context directories (each holding a
+/// `model.qmi` sidecar plus per-entity event-stream subdirectories) and returns
+/// their paths. Each directory must be named with the context's UUID: the viewer
+/// indexes contexts by a `<uuid>` directory name (skipping any whose name is not a
+/// UUID) and stages them into one serving root by name, so the names must be unique
+/// across the returned set. The exporter already names context directories this
+/// way; a custom loader must preserve it.
+///
+/// [`run`] holds the loader for the whole call, so a loader that owns a scratch
+/// directory (e.g. a [`tempfile::TempDir`]) keeps the fetched artifacts alive while
+/// the viewer serves them.
+///
+/// [`tempfile::TempDir`]: https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html
+pub trait Loader {
+    /// Materialize the artifacts and return their context directories.
+    fn load(&self) -> impl Future<Output = Result<Vec<PathBuf>>>;
+}
+
+/// The built-in loader: discover context directories under local `paths`.
+pub struct LocalLoader {
+    pub paths: Vec<PathBuf>,
+}
+
+impl Loader for LocalLoader {
+    async fn load(&self) -> Result<Vec<PathBuf>> {
+        discover_contexts(&self.paths)
+    }
+}
+
+/// Load artifacts via `loader`, then [`open()`] them. `loader` is held until
+/// serving ends, keeping any scratch storage it owns alive.
+pub async fn run(loader: impl Loader, options: OpenOptions) -> Result<()> {
+    let contexts = loader.load().await?;
+    open(contexts, options).await
+}
+
+/// Group `contexts` into one viewer per distinct build spec (same analyzer + pinned
+/// commits + format), gate each source on [trust](OpenOptions::trust), then build
+/// and serve the approved viewers in parallel. Contexts that can't be opened (no
+/// analyzer package, unreadable sidecar) are skipped with a warning rather than
+/// aborting.
+pub async fn open(contexts: Vec<PathBuf>, options: OpenOptions) -> Result<()> {
+    let OpenOptions {
+        no_browser,
+        host,
+        mut trust,
+    } = options;
+
+    // One group per build spec; contexts sharing a spec share a viewer.
+    let mut groups: BTreeMap<String, ViewerGroup> = BTreeMap::new();
+    for context in contexts {
+        let spec = match read_artifact_info(&context)
+            .and_then(|info| ViewerSpec::from_artifact(&context, &info))
+        {
+            Ok(spec) => spec,
+            Err(e) => {
+                eprintln!("skipping {}: {e}", context.display());
+                continue;
+            }
+        };
+        groups
+            .entry(spec.group_key())
+            .or_insert_with(|| ViewerGroup {
+                spec: spec.clone(),
+                contexts: Vec::new(),
+            })
+            .contexts
+            .push(context);
+    }
+
+    let groups: Vec<ViewerGroup> = groups.into_values().collect();
+    if groups.is_empty() {
+        return Err(OpenError::NoContexts);
+    }
+
+    // Each viewer builds + runs code from its quent and analyzer git remotes, so
+    // gate on trust before building. Authorize each distinct remote once (prompts
+    // are sequential, before the parallel build phase).
+    let mut decided: BTreeMap<String, bool> = BTreeMap::new();
+    for group in &groups {
+        for pin in [&group.spec.quent, &group.spec.analyzer] {
+            if let std::collections::btree_map::Entry::Vacant(slot) =
+                decided.entry(canonicalize_remote(&pin.remote))
+            {
+                slot.insert(trust.authorize(&pin.remote, &pin.commit));
+            }
+        }
+    }
+    let approved: Vec<ViewerGroup> = groups
+        .into_iter()
+        .filter(|group| {
+            let trusted = [&group.spec.quent, &group.spec.analyzer]
+                .iter()
+                .all(|pin| decided[&canonicalize_remote(&pin.remote)]);
+            if !trusted {
+                eprintln!(
+                    "skipping {}: source not trusted",
+                    group.spec.analyzer_package
+                );
+            }
+            trusted
+        })
+        .collect();
+    if approved.is_empty() {
+        return Err(OpenError::NothingTrusted);
+    }
+    viewer::open_all(approved, no_browser, host).await
+}
+
+/// Read the [`ArtifactInfo`] sidecar from the context directory `dir`.
+fn read_artifact_info(dir: &Path) -> Result<ArtifactInfo> {
+    ArtifactInfo::read_sidecar(dir).map_err(|source| OpenError::Sidecar {
+        path: dir.join(SIDECAR_FILE_NAME),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_loader_discovers_contexts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = tmp.path().join("run");
+        std::fs::create_dir_all(ctx.join("engine")).unwrap();
+        std::fs::write(ctx.join("engine").join("events.ndjson"), b"").unwrap();
+        std::fs::write(ctx.join(SIDECAR_FILE_NAME), b"{}").unwrap();
+
+        let paths = vec![tmp.path().to_path_buf()];
+        let found = LocalLoader {
+            paths: paths.clone(),
+        }
+        .load()
+        .await
+        .unwrap();
+        assert_eq!(found, discover_contexts(&paths).unwrap());
+        assert_eq!(found.len(), 1);
+    }
+}

--- a/crates/open/src/lib.rs
+++ b/crates/open/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Open local Quent benchmark artifacts in an application-specific viewer.
-//! See <https://github.com/rapidsai/quent/issues/234>.
 //!
 //! Given a context directory, read `model.qmi`, generate a viewer crate pinned
 //! to the recorded quent/analyzer commits, build and serve it, and open a browser.

--- a/crates/open/src/main.rs
+++ b/crates/open/src/main.rs
@@ -1,37 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Open local Quent artifacts in an application-specific viewer.
-//!
-//! Given a context directory, read `model.qmi`, generate a viewer crate pinned
-//! to the recorded quent/analyzer commits (see [`wrapper`]), build and serve it,
-//! and open a browser.
-//!
-//! The first viewer build fetches git sources and compiles the embedded UI,
-//! invoking `pnpm`/`node`; these must be on `PATH`.
+//! Command-line frontend for `quent-open`: opens local Quent artifacts via the
+//! built-in [`LocalLoader`]. See the crate docs for the library and custom loaders.
 
-mod error;
-mod spec;
-mod trust;
-mod viewer;
-mod wrapper;
-
-use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use quent_build_info::{ArtifactInfo, SIDECAR_FILE_NAME};
-
-use crate::error::{OpenError, Result};
-use crate::spec::ViewerSpec;
-use crate::viewer::ViewerGroup;
+use quent_open::{LocalLoader, OpenOptions, Result, Trust};
 
 #[derive(Debug, Parser)]
 #[command(name = "quent-open")]
 #[command(about = "Open local Quent artifacts in an application-specific viewer")]
 struct Cli {
-    /// Do not open a browser; print each viewer URL when ready.
+    /// Do not open a browser (a viewer's URL is always printed when it is ready).
     #[arg(long, global = true)]
     no_browser: bool,
 
@@ -39,13 +22,13 @@ struct Cli {
     #[arg(long, global = true, default_value = "127.0.0.1")]
     host: IpAddr,
 
-    /// Trust a git remote without prompting (repeatable): full repo URL, or
-    /// `github.com/org/*` for an org/prefix.
+    /// Trust a git remote (repeatable) without prompting: a full repo URL for an
+    /// exact repo, or a `github.com/org/*` form to trust a whole org/prefix.
     #[arg(long = "trust", global = true, value_name = "REMOTE")]
     trust: Vec<String>,
 
-    /// Trust every source, skipping the trust gate; only use for trusted sources,
-    /// because building runs their code.
+    /// Trust every source (skips the trust gate entirely — only for sources you
+    /// already trust, since building runs their code).
     #[arg(long, global = true)]
     trust_all: bool,
 
@@ -57,8 +40,9 @@ struct Cli {
 enum OpenCommand {
     /// Analyze local Quent artifacts directly.
     Local {
-        /// Context directories to analyze; each has a root `model.qmi` sidecar and
-        /// per-entity subdirectories containing event streams.
+        /// Context directories to analyze. A context directory holds a `model.qmi`
+        /// provenance sidecar at its root, plus one per-entity subdirectory per
+        /// entity containing that entity's event stream.
         #[arg(required = true, num_args = 1..)]
         paths: Vec<PathBuf>,
     },
@@ -67,80 +51,12 @@ enum OpenCommand {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    match &cli.command {
-        OpenCommand::Local { paths } => run_local(&cli, paths).await,
+    let options = OpenOptions {
+        no_browser: cli.no_browser,
+        host: cli.host,
+        trust: Trust::new(&cli.trust, cli.trust_all),
+    };
+    match cli.command {
+        OpenCommand::Local { paths } => quent_open::run(LocalLoader { paths }, options).await,
     }
-}
-
-/// Recursively discover contexts under `paths`, group them by build spec (same
-/// analyzer + pinned commits + format), then build and serve viewers in parallel.
-/// Contexts that can't be opened (no analyzer package, unreadable sidecar) are
-/// warned and skipped.
-async fn run_local(cli: &Cli, paths: &[PathBuf]) -> Result<()> {
-    let contexts = spec::discover_contexts(paths)?;
-
-    // One group per build spec; contexts sharing a spec share a viewer.
-    let mut groups: BTreeMap<String, ViewerGroup> = BTreeMap::new();
-    for context in contexts {
-        let spec = match ArtifactInfo::read_sidecar(&context)
-            .map_err(|source| OpenError::Sidecar {
-                path: context.join(SIDECAR_FILE_NAME),
-                source,
-            })
-            .and_then(|info| ViewerSpec::from_artifact(&context, &info))
-        {
-            Ok(spec) => spec,
-            Err(e) => {
-                eprintln!("skipping {}: {e}", context.display());
-                continue;
-            }
-        };
-        groups
-            .entry(spec.group_key())
-            .or_insert_with(|| ViewerGroup {
-                spec: spec.clone(),
-                contexts: Vec::new(),
-            })
-            .contexts
-            .push(context);
-    }
-
-    let groups: Vec<ViewerGroup> = groups.into_values().collect();
-    if groups.is_empty() {
-        return Err(OpenError::NoContexts);
-    }
-
-    // Each viewer builds and runs code from its quent/analyzer remotes; require
-    // trust before building. Authorize each distinct remote once, with prompts
-    // before parallel builds.
-    let mut trust = trust::Trust::new(&cli.trust, cli.trust_all);
-    let mut decided: BTreeMap<String, bool> = BTreeMap::new();
-    for group in &groups {
-        for pin in [&group.spec.quent, &group.spec.analyzer] {
-            if let std::collections::btree_map::Entry::Vacant(slot) =
-                decided.entry(trust::canonicalize_remote(&pin.remote))
-            {
-                slot.insert(trust.authorize(&pin.remote, &pin.commit));
-            }
-        }
-    }
-    let approved: Vec<ViewerGroup> = groups
-        .into_iter()
-        .filter(|group| {
-            let trusted = [&group.spec.quent, &group.spec.analyzer]
-                .iter()
-                .all(|pin| decided[&trust::canonicalize_remote(&pin.remote)]);
-            if !trusted {
-                eprintln!(
-                    "skipping {}: source not trusted",
-                    group.spec.analyzer_package
-                );
-            }
-            trusted
-        })
-        .collect();
-    if approved.is_empty() {
-        return Err(OpenError::NothingTrusted);
-    }
-    viewer::open_all(approved, cli.no_browser, cli.host).await
 }

--- a/crates/open/src/main.rs
+++ b/crates/open/src/main.rs
@@ -14,7 +14,7 @@ use quent_open::{LocalLoader, OpenOptions, Result, Trust};
 #[command(name = "quent-open")]
 #[command(about = "Open local Quent artifacts in an application-specific viewer")]
 struct Cli {
-    /// Do not open a browser (a viewer's URL is always printed when it is ready).
+    /// Do not open a browser; print each viewer URL when ready.
     #[arg(long, global = true)]
     no_browser: bool,
 
@@ -22,13 +22,13 @@ struct Cli {
     #[arg(long, global = true, default_value = "127.0.0.1")]
     host: IpAddr,
 
-    /// Trust a git remote (repeatable) without prompting: a full repo URL for an
-    /// exact repo, or a `github.com/org/*` form to trust a whole org/prefix.
+    /// Trust a git remote without prompting (repeatable): full repo URL, or
+    /// `github.com/org/*` for an org/prefix.
     #[arg(long = "trust", global = true, value_name = "REMOTE")]
     trust: Vec<String>,
 
-    /// Trust every source (skips the trust gate entirely — only for sources you
-    /// already trust, since building runs their code).
+    /// Trust every source, skipping the trust gate; only use for trusted sources,
+    /// because building runs their code.
     #[arg(long, global = true)]
     trust_all: bool,
 
@@ -40,9 +40,8 @@ struct Cli {
 enum OpenCommand {
     /// Analyze local Quent artifacts directly.
     Local {
-        /// Context directories to analyze. A context directory holds a `model.qmi`
-        /// provenance sidecar at its root, plus one per-entity subdirectory per
-        /// entity containing that entity's event stream.
+        /// Context directories to analyze; each has a root `model.qmi` sidecar and
+        /// per-entity subdirectories containing event streams.
         #[arg(required = true, num_args = 1..)]
         paths: Vec<PathBuf>,
     },

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -149,6 +149,8 @@ async fn cargo_build(crate_dir: &Path) -> Result<PathBuf> {
         .env("CARGO_TARGET_DIR", crate_dir.join("target"))
         .stdout(Stdio::piped())
         .stderr(Stdio::from(log))
+        // Reap the build if the caller drops us (library cancellation, Ctrl-C).
+        .kill_on_drop(true)
         .spawn()
         .map_err(|source| OpenError::Spawn {
             what: "cargo build".into(),
@@ -280,6 +282,9 @@ async fn serve(
     let mut child = Command::new(bin)
         .env(ROOT_ENV, output_root)
         .env(ADDR_ENV, addr.to_string())
+        // Don't orphan the viewer (holding its port) if the caller drops us:
+        // Ctrl-C on the CLI, or a cancelled `run`/`open` in a library embedding.
+        .kill_on_drop(true)
         .spawn()
         .map_err(|source| OpenError::Spawn {
             what: "viewer".into(),


### PR DESCRIPTION
Makes the `quent-open` package a library alongside its binary so custom data loaders (e.g. fetch-by-id over a REST API) can reuse the build/serve pipeline.

The library exposes the `Loader` trait (with the built-in `LocalLoader`), `OpenOptions`, and `run`/`open`; the binary becomes a thin frontend driving the local loader. `quent-open local` behaves exactly as before. The shipped binary stays local-only — custom loaders live in separate downstream binaries that depend on the lib (like the sirius analyzer).

A `Loader` returns context directories (each named by its context UUID); `run` materializes via the loader, then groups, gates on trust, builds, and serves them. The REST/database loader itself is downstream user code; this PR ships only the extension point, documented in the crate-level docs.

Part 8/8. Stacked on #266 — shows a cumulative diff until the predecessors merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)