### PR TITLE
feat(open)!: detect the artifact format inside the viewer importer

### DIFF
--- a/crates/exporter/src/lib.rs
+++ b/crates/exporter/src/lib.rs
@@ -111,6 +111,33 @@ impl TryFrom<&str> for FileSystemFormat {
     }
 }
 
+#[cfg(filesystem)]
+impl FileSystemFormat {
+    /// Detect the format of a context directory from the first recognized
+    /// `*.<ext>` event stream in any of its per-entity subdirectories. Returns
+    /// `None` if no readable stream with a known extension is present.
+    pub fn detect(context_dir: &std::path::Path) -> Option<Self> {
+        for entry in std::fs::read_dir(context_dir).ok()?.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let Ok(files) = std::fs::read_dir(entry.path()) else {
+                continue;
+            };
+            for file in files.flatten() {
+                if let Some(format) = std::path::Path::new(&file.file_name())
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .and_then(|ext| Self::try_from(ext).ok())
+                {
+                    return Some(format);
+                }
+            }
+        }
+        None
+    }
+}
+
 /// Options for exporting events to the filesystem in the given `format`, under
 /// the directory `root`, together with a `model.qmi` provenance sidecar.
 #[cfg(filesystem)]

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -341,10 +341,14 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
             #[doc = #doc_import]
             pub fn import_events(
                 dir: &std::path::Path,
-                format: quent_model::exporter::FileSystemFormat,
             ) -> quent_model::exporter::ImporterResult<
                 Box<dyn Iterator<Item = quent_model::Event<#event_type>>>,
             > {
+                // Detect the on-disk serialization format from the streams present;
+                // an empty/unrecognized context yields no events.
+                let Some(format) = quent_model::exporter::FileSystemFormat::detect(dir) else {
+                    return Ok(Box::new(std::iter::empty()));
+                };
                 let mut streams: Vec<
                     Box<dyn Iterator<Item = quent_model::Event<#event_type>>>,
                 > = Vec::new();

--- a/crates/open/src/error.rs
+++ b/crates/open/src/error.rs
@@ -35,13 +35,6 @@ pub enum OpenError {
     )]
     NothingTrusted,
 
-    /// No recognized event stream extension was found, so the artifact format is
-    /// unknown.
-    #[error(
-        "could not determine the artifact format under '{root}': no ndjson, msgpack, or postcard event streams found"
-    )]
-    UnknownFormat { root: PathBuf },
-
     /// The sidecar lacks git remote/commit provenance needed to fetch a crate for
     /// the viewer build.
     #[error(

--- a/crates/open/src/lib.rs
+++ b/crates/open/src/lib.rs
@@ -62,7 +62,7 @@ use std::path::PathBuf;
 use quent_build_info::{ArtifactInfo, SIDECAR_FILE_NAME};
 
 pub use crate::error::{OpenError, Result};
-pub use crate::spec::{Format, GitPin, ViewerSpec, discover_contexts};
+pub use crate::spec::{GitPin, ViewerSpec, discover_contexts};
 pub use crate::trust::{Trust, canonicalize_remote};
 pub use crate::viewer::ViewerGroup;
 
@@ -115,7 +115,7 @@ pub async fn run(loader: impl Loader, options: OpenOptions) -> Result<()> {
 }
 
 /// Group `contexts` into one viewer per distinct build spec (same analyzer + pinned
-/// commits + format), gate each source on [trust](OpenOptions::trust), then build
+/// commits), gate each source on [trust](OpenOptions::trust), then build
 /// and serve the approved viewers in parallel. Contexts that can't be opened (no
 /// analyzer package, unreadable sidecar) are skipped with a warning rather than
 /// aborting.
@@ -134,7 +134,7 @@ pub async fn open(contexts: Vec<PathBuf>, options: OpenOptions) -> Result<()> {
                 path: context.join(SIDECAR_FILE_NAME),
                 source,
             })
-            .and_then(|info| ViewerSpec::from_artifact(&context, &info))
+            .and_then(|info| ViewerSpec::from_artifact(&info))
         {
             Ok(spec) => spec,
             Err(e) => {

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Build a [`ViewerSpec`] from a context's `model.qmi`: pinned git sources,
-//! analyzer package, and artifact format for generating/building a viewer.
+//! Build a [`ViewerSpec`] from a context's `model.qmi`: the pinned git sources
+//! and analyzer package needed to generate/build a viewer. (The serialization
+//! format is detected at import time by the analyzer, not here.)
 
 use std::hash::{Hash, Hasher};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use quent_build_info::{ArtifactInfo, BuildInfo, SIDECAR_FILE_NAME};
 use walkdir::WalkDir;
@@ -65,43 +66,6 @@ fn is_hidden(entry: &walkdir::DirEntry) -> bool {
         .file_name()
         .to_str()
         .is_some_and(|name| name.starts_with('.'))
-}
-
-/// Serialization format of an artifact's event streams.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Format {
-    Ndjson,
-    Msgpack,
-    Postcard,
-}
-
-impl Format {
-    /// File extension of an event stream in this format.
-    pub fn extension(self) -> &'static str {
-        match self {
-            Format::Ndjson => "ndjson",
-            Format::Msgpack => "msgpack",
-            Format::Postcard => "postcard",
-        }
-    }
-
-    /// The `quent_exporter::FileSystemFormat` variant name, for generated code.
-    pub fn variant(self) -> &'static str {
-        match self {
-            Format::Ndjson => "Ndjson",
-            Format::Msgpack => "Msgpack",
-            Format::Postcard => "Postcard",
-        }
-    }
-
-    fn from_extension(ext: &str) -> Option<Self> {
-        match ext {
-            "ndjson" => Some(Format::Ndjson),
-            "msgpack" => Some(Format::Msgpack),
-            "postcard" => Some(Format::Postcard),
-            _ => None,
-        }
-    }
 }
 
 /// A git source pinned to an exact commit, as recorded in the sidecar.
@@ -197,8 +161,6 @@ fn validate_package(package: &str) -> Result<()> {
 /// serve multiple same-spec contexts.
 #[derive(Debug, Clone)]
 pub struct ViewerSpec {
-    /// Event serialization format, detected from the on-disk streams.
-    pub format: Format,
     /// Cargo package of the analyzer crate providing `Viewer` (`QuentViewer`).
     pub analyzer_package: String,
     /// Quent framework source, pinned to the build commit.
@@ -208,8 +170,8 @@ pub struct ViewerSpec {
 }
 
 impl ViewerSpec {
-    /// Derive a spec from a sidecar and its context directory.
-    pub fn from_artifact(root: &Path, info: &ArtifactInfo) -> Result<Self> {
+    /// Derive a spec from a sidecar.
+    pub fn from_artifact(info: &ArtifactInfo) -> Result<Self> {
         let analyzer_package =
             info.model
                 .analyzer_package
@@ -219,7 +181,6 @@ impl ViewerSpec {
                 })?;
         validate_package(&analyzer_package)?;
         Ok(Self {
-            format: detect_format(root)?,
             analyzer_package,
             quent: GitPin::from_build_info(&info.quent, "quent")?,
             analyzer: GitPin::from_build_info(&info.model.source, "analyzer source")?,
@@ -232,21 +193,20 @@ impl ViewerSpec {
         self.analyzer_package.replace('-', "_")
     }
 
-    /// Unambiguous build identity: analyzer package, format, and both git
-    /// remotes + full commits. Used to group/dedup contexts into viewers.
-    /// Short label distinguishing this build from other groups (package, format,
-    /// and short pins) so concurrent viewers with equal context counts are
-    /// still tellable apart.
+    /// Short label distinguishing this build from other groups (package and short
+    /// pins) so concurrent viewers with equal context counts are still tellable
+    /// apart.
     pub fn describe(&self) -> String {
         format!(
-            "{} ({}, quent@{} analyzer@{})",
+            "{} (quent@{} analyzer@{})",
             self.analyzer_package,
-            self.format.extension(),
             short_commit(&self.quent.commit),
             short_commit(&self.analyzer.commit),
         )
     }
 
+    /// Unambiguous build identity: analyzer package and both git remotes + full
+    /// commits. Used to group/dedup contexts into viewers.
     pub fn group_key(&self) -> String {
         // Key on the Cargo-normalized remotes so equivalent spellings (e.g.
         // scp-style vs `ssh://`) — which produce one dependency — share a build
@@ -254,7 +214,6 @@ impl ViewerSpec {
         // fields so values can't run together.
         [
             self.analyzer_package.as_str(),
-            self.format.extension(),
             self.quent.cargo_url().as_str(),
             &self.quent.commit,
             self.analyzer.cargo_url().as_str(),
@@ -270,10 +229,9 @@ impl ViewerSpec {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         self.group_key().hash(&mut hasher);
         format!(
-            "{}-{}-{}-{:016x}",
+            "{}-{}-{:016x}",
             self.analyzer_package,
             short_commit(&self.analyzer.commit),
-            self.format.extension(),
             hasher.finish(),
         )
     }
@@ -285,36 +243,11 @@ fn short_commit(commit: &str) -> &str {
     &commit[..end]
 }
 
-/// Detect the artifact format from an `events.<ext>` stream in any per-entity
-/// subdirectory.
-fn detect_format(root: &Path) -> Result<Format> {
-    let entries = std::fs::read_dir(root).map_err(|source| OpenError::Sidecar {
-        path: root.to_path_buf(),
-        source,
-    })?;
-    for entry in entries.flatten() {
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
-        }
-        if let Ok(files) = std::fs::read_dir(entry.path()) {
-            for file in files.flatten() {
-                if let Some(ext) = Path::new(&file.file_name()).extension()
-                    && let Some(format) = ext.to_str().and_then(Format::from_extension)
-                {
-                    return Ok(format);
-                }
-            }
-        }
-    }
-    Err(OpenError::UnknownFormat {
-        root: root.to_path_buf(),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use quent_build_info::ModelInfo;
+    use std::path::Path;
 
     fn artifact_with(analyzer_package: Option<&str>, commit: &str) -> ArtifactInfo {
         let mut model = ModelInfo::unknown();
@@ -332,14 +265,6 @@ mod tests {
             ..BuildInfo::unknown()
         };
         info
-    }
-
-    fn ctx_with_stream(name: &str, file: &str) -> tempfile::TempDir {
-        let dir = tempfile::tempdir().unwrap();
-        let entity = dir.path().join(name);
-        std::fs::create_dir_all(&entity).unwrap();
-        std::fs::write(entity.join(file), b"").unwrap();
-        dir
     }
 
     fn make_context(dir: &Path) {
@@ -407,7 +332,6 @@ mod tests {
     #[test]
     fn group_key_normalizes_equivalent_remotes() {
         let scp = ViewerSpec {
-            format: Format::Ndjson,
             analyzer_package: "p".into(),
             quent: GitPin {
                 remote: "git@github.com:org/quent.git".into(),
@@ -447,21 +371,6 @@ mod tests {
     }
 
     #[test]
-    fn detects_format_from_entity_subdir() {
-        let ctx = ctx_with_stream("engine", "events.msgpack");
-        assert_eq!(detect_format(ctx.path()).unwrap(), Format::Msgpack);
-    }
-
-    #[test]
-    fn unknown_format_when_no_streams() {
-        let ctx = ctx_with_stream("engine", "notes.txt");
-        assert!(matches!(
-            detect_format(ctx.path()),
-            Err(OpenError::UnknownFormat { .. })
-        ));
-    }
-
-    #[test]
     fn validators_accept_good_and_reject_injection() {
         assert!(validate_commit("0123456789abcdef0123456789abcdef01234567").is_ok());
         assert!(validate_commit("deadbeef").is_ok());
@@ -485,10 +394,9 @@ mod tests {
 
     #[test]
     fn spec_requires_analyzer_package() {
-        let ctx = ctx_with_stream("engine", "events.ndjson");
         let info = artifact_with(None, "abc");
         assert!(matches!(
-            ViewerSpec::from_artifact(ctx.path(), &info),
+            ViewerSpec::from_artifact(&info),
             Err(OpenError::NoAnalyzer { .. })
         ));
     }
@@ -515,34 +423,25 @@ mod tests {
 
     #[test]
     fn spec_derives_crate_ident_and_keys() {
-        let ctx = ctx_with_stream("engine", "events.ndjson");
         let info = artifact_with(Some("quent-simulator-analyzer"), "feedface99887766");
-        let spec = ViewerSpec::from_artifact(ctx.path(), &info).unwrap();
+        let spec = ViewerSpec::from_artifact(&info).unwrap();
         assert_eq!(spec.analyzer_crate(), "quent_simulator_analyzer");
-        assert_eq!(spec.format, Format::Ndjson);
         assert!(
             spec.cache_key()
-                .starts_with("quent-simulator-analyzer-feedface9988-ndjson-")
+                .starts_with("quent-simulator-analyzer-feedface9988-")
         );
     }
 
     #[test]
     fn keys_distinguish_full_pins_not_just_short_commit() {
-        let ctx = ctx_with_stream("engine", "events.ndjson");
-        // Same package, format, and 12-char commit prefix, but different full
-        // analyzer commits — must NOT collide.
-        let a =
-            ViewerSpec::from_artifact(ctx.path(), &artifact_with(Some("p"), "abcabcabcabc1111"))
-                .unwrap();
-        let b =
-            ViewerSpec::from_artifact(ctx.path(), &artifact_with(Some("p"), "abcabcabcabc2222"))
-                .unwrap();
+        // Same package and 12-char commit prefix, but different full analyzer
+        // commits — must NOT collide.
+        let a = ViewerSpec::from_artifact(&artifact_with(Some("p"), "abcabcabcabc1111")).unwrap();
+        let b = ViewerSpec::from_artifact(&artifact_with(Some("p"), "abcabcabcabc2222")).unwrap();
         assert_ne!(a.group_key(), b.group_key());
         assert_ne!(a.cache_key(), b.cache_key());
         // Identical inputs group together and are deterministic.
-        let a2 =
-            ViewerSpec::from_artifact(ctx.path(), &artifact_with(Some("p"), "abcabcabcabc1111"))
-                .unwrap();
+        let a2 = ViewerSpec::from_artifact(&artifact_with(Some("p"), "abcabcabcabc1111")).unwrap();
         assert_eq!(a.group_key(), a2.group_key());
         assert_eq!(a.cache_key(), a2.cache_key());
     }

--- a/crates/open/src/spec.rs
+++ b/crates/open/src/spec.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Build a [`ViewerSpec`] from a context's `model.qmi`: the pinned git sources
-//! and analyzer package needed to generate/build a viewer. (The serialization
-//! format is detected at import time by the analyzer, not here.)
+//! and analyzer package needed to generate/build a viewer.
 
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;

--- a/crates/open/src/wrapper.rs
+++ b/crates/open/src/wrapper.rs
@@ -60,8 +60,9 @@ fn cargo_toml(spec: &ViewerSpec) -> String {
             git_dep(quent.clone(), q_rev, &[]),
         ),
         (
+            // All formats enabled so the analyzer can detect the artifact's format at runtime.
             "quent-exporter".to_string(),
-            git_dep(quent, q_rev, &[spec.format.extension()]),
+            git_dep(quent, q_rev, &["ndjson", "msgpack", "postcard"]),
         ),
         (
             spec.analyzer_package.clone(),
@@ -108,13 +109,11 @@ fn cargo_toml(spec: &ViewerSpec) -> String {
 /// bind address come from env so one built binary serves any artifacts.
 fn main_rs(spec: &ViewerSpec) -> String {
     let analyzer_crate = format_ident!("{}", spec.analyzer_crate());
-    let format_variant = format_ident!("{}", spec.format.variant());
     let (root_env, addr_env) = (ROOT_ENV, ADDR_ENV);
     let tokens = quote! {
         use std::net::SocketAddr;
         use std::path::PathBuf;
 
-        use quent_exporter::FileSystemFormat;
         use quent_query_engine_analyzer::ui::QuentViewer;
         use quent_query_engine_server::analyzer_cache::index_query_engines;
         use quent_query_engine_server::analyzer_service_router;
@@ -126,17 +125,15 @@ fn main_rs(spec: &ViewerSpec) -> String {
         async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let root = PathBuf::from(std::env::var(#root_env)?);
             let addr: SocketAddr = std::env::var(#addr_env)?.parse()?;
-            let format = FileSystemFormat::#format_variant;
 
             let import_root = root.clone();
             let importer = move |id: uuid::Uuid| {
                 Ok(<Viewer as QuentViewer>::import_events(
                     &import_root.join(id.to_string()),
-                    format,
                 )?)
             };
             let lister_root = root.clone();
-            let lister = move || index_query_engines(&lister_root, format);
+            let lister = move || index_query_engines(&lister_root);
 
             let router = analyzer_service_router::<Analyzer>(
                 Box::new(importer),
@@ -159,11 +156,10 @@ fn main_rs(spec: &ViewerSpec) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::spec::{Format, GitPin, ViewerSpec};
+    use crate::spec::{GitPin, ViewerSpec};
 
     fn spec() -> ViewerSpec {
         ViewerSpec {
-            format: Format::Msgpack,
             analyzer_package: "quent-simulator-analyzer".into(),
             quent: GitPin {
                 remote: "https://example.com/quent".into(),
@@ -185,10 +181,11 @@ mod tests {
         assert_eq!(server["git"].as_str().unwrap(), "https://example.com/quent");
         assert_eq!(server["rev"].as_str().unwrap(), "quentcommit");
         assert_eq!(server["features"][0].as_str().unwrap(), "ui");
-        assert_eq!(
-            deps["quent-exporter"]["features"][0].as_str().unwrap(),
-            "msgpack"
-        );
+        // The exporter enables all formats so the analyzer detects the artifact's format at runtime.
+        let exporter_features = deps["quent-exporter"]["features"].as_array().unwrap();
+        for format in ["ndjson", "msgpack", "postcard"] {
+            assert!(exporter_features.iter().any(|f| f.as_str() == Some(format)));
+        }
         let analyzer = &deps["quent-simulator-analyzer"];
         assert_eq!(
             analyzer["git"].as_str().unwrap(),
@@ -198,10 +195,10 @@ mod tests {
     }
 
     #[test]
-    fn main_rs_names_viewer_and_format() {
+    fn main_rs_wires_the_viewer() {
         let main = main_rs(&spec());
         assert!(main.contains("use quent_simulator_analyzer::Viewer;"));
-        assert!(main.contains("FileSystemFormat::Msgpack"));
+        assert!(main.contains("import_events"));
         assert!(main.contains("QUENT_OPEN_ADDR")); // bind address is configurable
     }
 }

--- a/domains/query_engine/analyzer/src/ui.rs
+++ b/domains/query_engine/analyzer/src/ui.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use quent_analyzer::AnalyzerResult;
 use quent_events::Event;
-use quent_model::exporter::{FileSystemFormat, ImporterResult};
+use quent_model::exporter::ImporterResult;
 use quent_query_engine_ui as ui;
 use quent_ui::timeline::{
     request::{BulkChunkedTimelineRequest, BulkTimelineRequest, SingleTimelineRequest},
@@ -133,8 +133,5 @@ pub trait QuentViewer {
     /// Reconstruct the model's event stream from one context directory, yielding
     /// events of the [`Analyzer`](Self::Analyzer)'s event type. Wraps the model
     /// marker's generated `import_events`.
-    fn import_events(
-        dir: &Path,
-        format: FileSystemFormat,
-    ) -> ImporterResult<ViewerEventStream<Self::Analyzer>>;
+    fn import_events(dir: &Path) -> ImporterResult<ViewerEventStream<Self::Analyzer>>;
 }

--- a/domains/query_engine/server/src/analyzer_cache.rs
+++ b/domains/query_engine/server/src/analyzer_cache.rs
@@ -88,10 +88,7 @@ impl EngineIndex {
 ///
 /// "Dumb" because it re-scans and rebuilds from scratch on every call — a real
 /// history/indexing service replaces this later.
-pub fn index_query_engines(
-    output_dir: &Path,
-    format: FileSystemFormat,
-) -> ServerResult<EngineIndex> {
+pub fn index_query_engines(output_dir: &Path) -> ServerResult<EngineIndex> {
     let mut index = EngineIndex::default();
     for entry in std::fs::read_dir(output_dir)? {
         let context_dir = entry?.path();
@@ -100,6 +97,10 @@ pub fn index_query_engines(
             .and_then(|s| s.to_str())
             .and_then(|s| Uuid::parse_str(s).ok())
         else {
+            continue;
+        };
+        // Each context's serialization format is detected from its own streams.
+        let Some(format) = FileSystemFormat::detect(&context_dir) else {
             continue;
         };
 

--- a/examples/simulator/analyzer/src/lib.rs
+++ b/examples/simulator/analyzer/src/lib.rs
@@ -64,9 +64,8 @@ impl QuentViewer for Viewer {
 
     fn import_events(
         dir: &std::path::Path,
-        format: quent_model::exporter::FileSystemFormat,
     ) -> quent_model::exporter::ImporterResult<ViewerEventStream<Self::Analyzer>> {
-        Simulator::import_events(dir, format)
+        Simulator::import_events(dir)
     }
 }
 

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -116,14 +116,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Index the exported contexts by engine instance: each engine's telemetry is
     // the engine's own context plus its workers' contexts.
-    let lister = move || index_query_engines(&lister_output_dir, format);
+    let lister = move || index_query_engines(&lister_output_dir);
 
     // Reconstruct one context's umbrella event stream from its per-entity
     // subdirectories; the analyzer cache chains this across all the contexts that
     // make up an engine instance.
     let importer = move |context_id| {
         let dir = importer_output_dir.join(format!("{context_id}"));
-        Ok(Simulator::import_events(&dir, format)?)
+        Ok(Simulator::import_events(&dir)?)
     };
 
     let analyzer = async {


### PR DESCRIPTION
Follow-up to #264 review (johanpel): let the analyzer detect the artifact's serialization format instead of threading it through `quent-open`.

`QuentViewer::import_events` and the `model!`-generated `import_events` now take just the context directory and detect the format from the on-disk streams (new `quent_exporter::FileSystemFormat::detect`). The server's `index_query_engines` detects per-context too. The generated viewer wrapper enables all exporter formats so any artifact opens, and `quent-open` drops `Format`/`detect_format` and the format component of its cache key.

**Breaking:** `QuentViewer::import_events` / `Model::import_events` drop the `format` argument; `index_query_engines` drops its `format` parameter. Downstream `QuentViewer` impls (e.g. sirius) drop the `format` param and call `Model::import_events(dir)`.

**Compatibility:** `quent-open` builds the wrapper against the quent/analyzer commits pinned in `model.qmi` and now emits the one-argument calls, so it can only open artifacts whose pinned commits already include this change. Artifacts pinned to earlier commits (from the pre-release window) won't build a viewer — an accepted consequence of this breaking change; versioning the sidecar/codegen against the pinned API is left as future work.

Off `main`, independent of the merged quent-open work (#265) and the open stack (#266/#273/#276). Whichever of this PR and that stack lands second needs a rebase — both touch `quent-open`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)