### PR TITLE
feat(py, experimental): add PyO3 event-model bindings over the builder stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,6 +2076,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-py"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
+ "quent-constraints",
+ "quent-instrumentation-build",
+ "quent-schema",
+]
+
+[[package]]
 name = "quent-qe-bridge"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "crates/fsm",
     "crates/instrumentation-build",
     "crates/instrumentation-build/example",
+    "crates/py",
 ]
 
 # default-members excludes any crate that activates `quent-time/__test-clock-override`.

--- a/crates/py/.gitignore
+++ b/crates/py/.gitignore
@@ -1,3 +1,6 @@
 # maturin build artifacts (compiled extension placed into the source tree)
 *.so
 *.pyd
+
+# generated instrumentation from the example
+example/generated/

--- a/crates/py/.gitignore
+++ b/crates/py/.gitignore
@@ -1,0 +1,3 @@
+# maturin build artifacts (compiled extension placed into the source tree)
+*.so
+*.pyd

--- a/crates/py/Cargo.toml
+++ b/crates/py/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "quent-py"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+name = "_quent"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { workspace = true, features = ["abi3-py311", "extension-module"] }
+quent-schema = { path = "../schema" }
+quent-constraints = { path = "../constraints" }
+quent-instrumentation-build = { path = "../instrumentation-build" }

--- a/crates/py/example/model.py
+++ b/crates/py/example/model.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Author the demo event model in Python and generate the instrumentation.
+
+Run with the `quent` module installed (``maturin develop -m crates/py/Cargo.toml``):
+
+    python crates/py/example/model.py
+"""
+
+from pathlib import Path
+
+import quent
+
+m = quent.Model("demo")
+
+
+@quent.record(m)
+class Endpoint:
+    host: "string"
+    port: "u16"
+
+
+@quent.record(m)
+class Meta:
+    tags: "list<string>"
+    extra: "dynamic"
+
+
+@quent.entity(m)
+class Connection:
+    opened = quent.once(peer="Endpoint", session="uuid")
+    data = quent.multi(bytes="u64", meta="option<Meta>")
+    closed = quent.once()
+
+
+def main() -> None:
+    out = Path(__file__).parent / "generated"
+    out.mkdir(exist_ok=True)
+
+    # Validates through the full Rust constraint stack, then runs
+    # quent-instrumentation-build.
+    path = m.generate_rust(str(out))
+    print(f"instrumentation library written to {path}\n")
+    print(Path(path).read_text())
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/py/pyproject.toml
+++ b/crates/py/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["maturin>=1.10,<2"]
+build-backend = "maturin"
+
+[project]
+name = "quent"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.maturin]
+manifest-path = "Cargo.toml"
+module-name = "quent._quent"
+python-source = "python"

--- a/crates/py/python/quent/__init__.py
+++ b/crates/py/python/quent/__init__.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pythonic event-model authoring on top of the Rust builder + validation stack.
+
+Two styles are available:
+
+- Imperative (the low-level bindings)::
+
+    m = quent.Model("demo")
+    m.record("Endpoint", host="string", port="u16")
+    conn = m.entity("Connection")
+    conn.once("opened", peer="Endpoint", session="uuid")
+
+- Declarative (the sugar in this module)::
+
+    @quent.record(m)
+    class Endpoint:
+        host: "string"
+        port: "u16"
+
+    @quent.entity(m)
+    class Connection:
+        opened = quent.once(peer="Endpoint", session="uuid")
+        data = quent.multi(bytes="u64", meta="option<Meta>")
+"""
+
+from quent._quent import Entity, Model
+
+__all__ = ["Model", "Entity", "once", "multi", "record", "entity"]
+
+
+class _Event:
+    """An event descriptor produced by :func:`once` / :func:`multi`."""
+
+    def __init__(self, cardinality: str, payload: dict[str, str]):
+        self.cardinality = cardinality
+        self.payload = payload
+
+
+def once(**payload: str) -> _Event:
+    """A once (zero-or-one) event whose payload is `name=type` kwargs."""
+    return _Event("once", payload)
+
+
+def multi(**payload: str) -> _Event:
+    """A multi (zero-or-more) event whose payload is `name=type` kwargs."""
+    return _Event("multi", payload)
+
+
+def record(model: Model):
+    """Class decorator: declare a record from annotated `name: "type"` fields."""
+
+    def deco(cls):
+        fields = {}
+        for name, ann in getattr(cls, "__annotations__", {}).items():
+            if not isinstance(ann, str):
+                raise TypeError(f"field {name!r} type must be a string type expression")
+            fields[name] = ann
+        model.record(cls.__name__, **fields)
+        return cls
+
+    return deco
+
+
+def entity(model: Model):
+    """Class decorator: declare an entity from `once()` / `multi()` members."""
+
+    def deco(cls):
+        handle = model.entity(cls.__name__)
+        for name, value in vars(cls).items():
+            if isinstance(value, _Event):
+                emit = handle.once if value.cardinality == "once" else handle.multi
+                emit(name, **value.payload)
+        return cls
+
+    return deco

--- a/crates/py/src/lib.rs
+++ b/crates/py/src/lib.rs
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Low-level PyO3 bindings over the `quent-schema` builders.
+//!
+//! These wrap the real builder + validation stack, so identifier and
+//! duplicate-name errors surface as Python `ValueError`s and the schema is
+//! validated through `quent-constraints`. The Pythonic declarative layer lives
+//! in `quent/__init__.py`.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use quent_instrumentation_build::{Options, generate};
+use quent_schema::builder::{
+    BuilderError, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder,
+};
+use quent_schema::{Annotations, Cardinality, DataType, Field, Identifier, Schema};
+
+fn ident(name: &str) -> PyResult<Identifier> {
+    Identifier::try_new(name)
+        .map_err(|e| PyValueError::new_err(format!("invalid identifier {name:?}: {e}")))
+}
+
+fn builder_err(e: BuilderError) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+/// Parse the type mini-language: scalars, `option<T>`, `list<T>`, `dynamic`,
+/// and bare names (resolved as record references during validation).
+fn parse_type(expr: &str) -> PyResult<DataType> {
+    let s = expr.trim();
+    if let Some(inner) = wrapped(s, "option") {
+        return Ok(DataType::Option(Box::new(parse_type(inner)?)));
+    }
+    if let Some(inner) = wrapped(s, "list") {
+        return Ok(DataType::List(Box::new(parse_type(inner)?)));
+    }
+    Ok(match s {
+        "bool" => DataType::Bool,
+        "uuid" => DataType::Uuid,
+        "string" => DataType::String,
+        "u8" => DataType::U8,
+        "u16" => DataType::U16,
+        "u32" => DataType::U32,
+        "u64" => DataType::U64,
+        "i8" => DataType::I8,
+        "i16" => DataType::I16,
+        "i32" => DataType::I32,
+        "i64" => DataType::I64,
+        "f32" => DataType::F32,
+        "f64" => DataType::F64,
+        "dynamic" => DataType::DynamicRecord,
+        "" => return Err(PyValueError::new_err("empty type expression")),
+        other => DataType::Record(ident(other)?),
+    })
+}
+
+fn wrapped<'s>(s: &'s str, head: &str) -> Option<&'s str> {
+    s.strip_prefix(head)?
+        .trim_start()
+        .strip_prefix('<')?
+        .strip_suffix('>')
+}
+
+/// Build payload/record fields from a kwargs dict of `name -> type expression`,
+/// preserving insertion order.
+fn fields_from_kwargs(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Vec<Field>> {
+    let mut fields = Vec::new();
+    if let Some(dict) = kwargs {
+        for (key, value) in dict.iter() {
+            let name: String = key.extract()?;
+            let ty: String = value.extract()?;
+            fields.push(Field::new(
+                ident(&name)?,
+                parse_type(&ty)?,
+                Annotations::default(),
+            ));
+        }
+    }
+    Ok(fields)
+}
+
+/// An entity under construction. Events are validated as they are added.
+#[pyclass]
+struct Entity {
+    name: String,
+    events: Vec<quent_schema::Event>,
+}
+
+#[pymethods]
+impl Entity {
+    #[pyo3(signature = (name, **payload))]
+    fn once(&mut self, name: &str, payload: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        self.add_event(name, Cardinality::Once, payload)
+    }
+
+    #[pyo3(signature = (name, **payload))]
+    fn multi(&mut self, name: &str, payload: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        self.add_event(name, Cardinality::Multi, payload)
+    }
+}
+
+impl Entity {
+    fn add_event(
+        &mut self,
+        name: &str,
+        cardinality: Cardinality,
+        payload: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<()> {
+        let mut builder = EventBuilder::new(ident(name)?, cardinality);
+        for field in fields_from_kwargs(payload)? {
+            builder = builder.field(field).map_err(builder_err)?;
+        }
+        self.events.push(builder.build());
+        Ok(())
+    }
+}
+
+/// A model under construction.
+#[pyclass]
+struct Model {
+    name: String,
+    records: Vec<quent_schema::Record>,
+    entities: Vec<Py<Entity>>,
+}
+
+#[pymethods]
+impl Model {
+    #[new]
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            records: Vec::new(),
+            entities: Vec::new(),
+        }
+    }
+
+    /// Declare a record. Fields are `name=type` kwargs.
+    #[pyo3(signature = (name, **fields))]
+    fn record(&mut self, name: &str, fields: Option<&Bound<'_, PyDict>>) -> PyResult<()> {
+        let mut builder = RecordBuilder::new(ident(name)?);
+        for field in fields_from_kwargs(fields)? {
+            builder = builder.field(field).map_err(builder_err)?;
+        }
+        self.records.push(builder.build());
+        Ok(())
+    }
+
+    /// Declare an entity, returning a live handle to add events to.
+    fn entity(&mut self, py: Python<'_>, name: &str) -> PyResult<Py<Entity>> {
+        let entity = Py::new(
+            py,
+            Entity {
+                name: name.to_string(),
+                events: Vec::new(),
+            },
+        )?;
+        self.entities.push(entity.clone_ref(py));
+        Ok(entity)
+    }
+
+    /// Validate the model through the full constraint stack. Raises on failure.
+    fn validate(&self, py: Python<'_>) -> PyResult<()> {
+        self.build_schema(py).map(|_| ())
+    }
+
+    /// Generate the Rust instrumentation library into `out_dir`; returns the
+    /// written path.
+    fn generate_rust(&self, py: Python<'_>, out_dir: &str) -> PyResult<String> {
+        let schema = self.build_schema(py)?;
+        let opts = Options {
+            event_derives: &["Debug"],
+            record_derives: &["Debug"],
+            out_dir: out_dir.into(),
+            file_name: None,
+        };
+        let info = generate(&schema, &opts).map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Ok(info.path.display().to_string())
+    }
+}
+
+impl Model {
+    fn build_schema(&self, py: Python<'_>) -> PyResult<Schema> {
+        let mut schema = SchemaBuilder::new(ident(&self.name)?);
+        schema = schema
+            .records(self.records.iter().cloned())
+            .map_err(builder_err)?;
+        for entity in &self.entities {
+            let entity = entity.borrow(py);
+            let built = EntityBuilder::new(ident(&entity.name)?)
+                .events(entity.events.iter().cloned())
+                .map_err(builder_err)?
+                .build();
+            schema = schema.entity(built).map_err(builder_err)?;
+        }
+        let schema = schema.build();
+        let report = quent_constraints::validate::<()>(&schema);
+        if let Err(e) = report.base_constraints {
+            return Err(PyValueError::new_err(e.to_string()));
+        }
+        Ok(schema)
+    }
+}
+
+#[pymodule]
+fn _quent(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Model>()?;
+    m.add_class::<Entity>()?;
+    Ok(())
+}

--- a/crates/py/tests/test_minimal.py
+++ b/crates/py/tests/test_minimal.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import quent
+
+
+def build_demo() -> quent.Model:
+    m = quent.Model("demo")
+
+    @quent.record(m)
+    class Endpoint:
+        host: "string"
+        port: "u16"
+
+    @quent.record(m)
+    class Meta:
+        tags: "list<string>"
+        extra: "dynamic"
+
+    @quent.entity(m)
+    class Connection:
+        opened = quent.once(peer="Endpoint", session="uuid")
+        data = quent.multi(bytes="u64", meta="option<Meta>")
+        closed = quent.once()
+
+    return m
+
+
+def test_imperative_api():
+    m = quent.Model("demo")
+    m.record("Endpoint", host="string", port="u16")
+    conn = m.entity("Connection")
+    conn.once("opened", peer="Endpoint", session="uuid")
+    conn.multi("data", bytes="u64")
+    m.validate()
+
+
+def test_declarative_generates(tmp_path):
+    path = build_demo().generate_rust(str(tmp_path))
+    assert path.endswith("demo.rs")
+    src = (tmp_path / "demo.rs").read_text()
+    assert "enum ConnectionEvent" in src
+    assert "struct Endpoint" in src
+    assert "struct Meta" in src
+
+
+def test_invalid_identifier_raises():
+    m = quent.Model("demo")
+    with pytest.raises(ValueError):
+        m.record("1bad", x="u64")
+
+
+def test_unknown_record_reference_raises():
+    m = quent.Model("demo")
+    e = m.entity("E")
+    e.once("ev", x="Missing")
+    with pytest.raises(ValueError):
+        m.validate()


### PR DESCRIPTION
Add `quent-py`, a PyO3 extension module (`quent`) that wraps the real
`quent-schema` builders, `quent-constraints` validation, and
`quent-instrumentation-build` generation. Identifier and duplicate-name
errors surface as Python `ValueError`s, and `Model.validate()` /
`Model.generate_rust()` run the full Rust stack.

Two authoring styles: an imperative kwargs API (`m.record(...)`,
`m.entity(...).once(...)`) in the bindings, and a declarative class
decorator layer (`@quent.record` / `@quent.entity` with `once()`/`multi()`
members) in `quent/__init__.py`. Built with maturin (abi3-py311); tests
run under pytest.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
    
# Description

<!-- What does this PR do and why? -->

## Related Issues

<!-- Link related issues: closes #123, relates to #456 -->

## Testing

<!--
Describe what you ran locally.

Rust changes:
- pixi run cargo fmt --all
- pixi run cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- pixi run cargo test --workspace --all-features --locked --all-targets

UI changes:
- cd ui
- pnpm ci:check
-->

## Screenshots

<!-- For UI changes, include screenshots or videos when possible. -->
