### PR TITLE
fix(ci): only fail on high+ CVEs

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           cache: true
       - run: pixi run pnpm --dir ui install --frozen-lockfile
-      - run: pixi run pnpm --dir ui audit
+      - run: pixi run pnpm --dir ui audit --audit-level=high
 
   build:
     name: Build

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "routes:generate": "tsr generate",
     "typecheck": "tsr generate && tsc --noEmit",
-    "ci:check": "pnpm routes:generate && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:run && pnpm audit",
+    "ci:check": "pnpm format:check && pnpm routes:generate && pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm audit --audit-level=high && pnpm test:e2e && pnpm build",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -13,3 +13,16 @@ allowBuilds:
   esbuild: true
   msw: true
   protobufjs: true
+
+# Advisories that `pnpm audit` should drop from its failure list.
+# Each entry MUST be paired with a same-key comment explaining why it is safe
+# to ignore and what the exit criteria for removing it are.
+auditConfig:
+  ignoreGhsas:
+    # GHSA-fgmj-fm8m-jvvx / CVE-2026-45249 — echarts <6.1.0 XSS via the Lines-
+    # series default tooltip. Requires (a) `type: 'lines'`, (b) no custom
+    # `tooltip.formatter`, (c) raw HTML in `series.data[i].name`. Quent uses
+    # `type: 'line'`, `custom`, and `sankey` — no `type: 'lines'` anywhere —
+    # so the vulnerable code path is unreachable. Remove this entry when we
+    # bump to echarts 6.1.0 (pending v5→v6 migration).
+    - GHSA-fgmj-fm8m-jvvx


### PR DESCRIPTION
# Description
Only fail CI audit on high+ severity CVEs, explicitly ignore the [echart cve](https://github.com/advisories/GHSA-fgmj-fm8m-jvvx) until 6.1.0 upgrade fixes are made.

<!-- What does this PR do and why? -->

## Related Issues
N/A
<!-- Link related issues: closes #123, relates to #456 -->

## Testing
CI pnpm audit should pass
<!--
Describe what you ran locally.

Rust changes:
- pixi run cargo fmt --all
- pixi run cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- pixi run cargo test --workspace --all-features --locked --all-targets

UI changes:
- cd ui
- pnpm ci:check
-->

## Screenshots

<!-- For UI changes, include screenshots or videos when possible. -->
