### PR TITLE
chore(deny): ignore dev-only quick-xml advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,13 @@ ignore = [
     # atomic-polyfill is unmaintained (pulled in via postcard -> heapless),
     # no safe upgrade is available.
     "RUSTSEC-2023-0089",
+    # quick-xml DoS advisories (quadratic duplicate-attribute parse; unbounded
+    # namespace allocation). Only reachable as a dev/bench dependency (pprof ->
+    # inferno flamegraphs, pinned to quick-xml 0.26), parsing developer-generated
+    # data, not untrusted input or shipped artifacts. Drop once pprof/inferno bump
+    # to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]


### PR DESCRIPTION
`cargo deny check` is failing on two newly-published quick-xml DoS advisories, **RUSTSEC-2026-0194** (quadratic duplicate-attribute parse) and **RUSTSEC-2026-0195** (unbounded namespace-declaration allocation).

quick-xml (0.26) is only reachable as a **dev/bench dependency** — `pprof`'s `flamegraph` feature → `inferno`, which pins quick-xml 0.26 — so it parses developer-generated flamegraph data, never untrusted input, and isn't in any shipped artifact. There's no in-semver upgrade (0.26 → 0.41 is breaking; it needs a `pprof`/`inferno` bump).

Ignore both in `deny.toml`, with a note to drop them once pprof/inferno move to quick-xml ≥ 0.41. Follows the existing `RUSTSEC-2023-0089` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)