### PR TITLE
chore: GH-283: Create dependabot.yml for GHA/Node/Rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - cooldown:
+      default-days: 14
+    directory: "/"
+    open-pull-requests-limit: 5
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+  - cooldown:
+      default-days: 14
+    directory: "/"
+    open-pull-requests-limit: 5
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+  - cooldown:
+      default-days: 14
+    directory: "/"
+    open-pull-requests-limit: 5
+    package-ecosystem: "cargo"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes: https://github.com/rapidsai/github-infrastructure/issues/283

Let's add a `.github/dependabot.yml` so that @dependabot knows to auto-generate upgrade PRs for the following ecosystems:
- GitHub Actions
- Node
- Rust