### PR TITLE
feat(ui): auto-expand info panel when DAG node is selected

### DIFF
--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -13,10 +13,8 @@ export const DAGNodeInfoPanel = () => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
-    if (!selectedNodeData) {
-      setIsExpanded(false);
-    }
-  }, [selectedNodeData]);
+    setIsExpanded(!!selectedNodeData);
+  }, [selectedNodeData?.nodeId]);
 
   return (
     <div className="border-t bg-card flex-shrink-0">


### PR DESCRIPTION
# Description

In order to make the info panel more discover-able, auto-expand the info panel whenever a user selects a DAG node. If a user clicks outside of the node into blank space on the DAG the panel will automatically collapse (so users can do that instead of having to close the panel via the interaction button there).

## Related Issues

Closes #281 

## Testing

1. Click DAG node, panel should auto-expand
2. Click on DAG outside of a node, panel should collapse
3. All other interactions remain the same

## Screenshots

https://github.com/user-attachments/assets/29f6bfab-74f6-4e77-a1c6-36784f97c8c9

