### PR TITLE
feat(ui): layout direction control

### DIFF
--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -38,6 +38,7 @@ import {
   useEffectiveHighlightedNodeIds,
   useSetSelectedNodeData,
   useSetDagDisplayedNodeIds,
+  useSelectedDagLayoutDirection,
 } from '@quent/hooks';
 import { calculateLayout, NODE_LAYOUT_WIDTH } from './layout';
 import type { DAGData } from '../services/query-plan/types';
@@ -276,6 +277,7 @@ const FlowLayout = ({
   const setDagDisplayedNodeIds = useSetDagDisplayedNodeIds();
   const setSelectedNodeData = useSetSelectedNodeData();
   const selectedNodeIds = useSelectedNodeIds();
+  const [layoutDirection] = useSelectedDagLayoutDirection();
   const hasUserInteracted = useRef(false);
 
   // Sync controlled selectedNodeIds into the atom when provided
@@ -404,7 +406,7 @@ const FlowLayout = ({
 
     const applyLayout = async () => {
       const { flowNodes, flowEdges } = convertToReactFlow();
-      const layoutResult = await calculateLayout(flowNodes, flowEdges);
+      const layoutResult = await calculateLayout(flowNodes, flowEdges, layoutDirection);
 
       setNodes(layoutResult.nodes);
       setEdges(layoutResult.edges);
@@ -414,7 +416,7 @@ const FlowLayout = ({
     };
 
     applyLayout();
-  }, [data, convertToReactFlow, fitView, setNodes, setEdges]);
+  }, [data, convertToReactFlow, fitView, setNodes, setEdges, layoutDirection]);
 
   return (
     <ReactFlow

--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -20,6 +20,7 @@ import {
   useEdgesState,
   useReactFlow,
   getSmoothStepPath,
+  Position,
   type Node,
   type Edge,
   type EdgeProps,
@@ -157,11 +158,12 @@ const VariableWidthEdge = ({
   const arrowWidth = strokeWidth * ARROW_WIDTH_MULTIPLIER + ARROW_WIDTH_BASE;
   const arrowDepth = arrowWidth * ARROW_DEPTH_RATIO;
   const markerId = `arrow-${id}`;
+  const targetYOffset = targetPosition === Position.Bottom ? arrowDepth : -arrowDepth;
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
     sourceY,
     targetX,
-    targetY: targetY - arrowDepth,
+    targetY: targetY + targetYOffset,
     sourcePosition,
     targetPosition,
   });
@@ -325,6 +327,7 @@ const FlowLayout = ({
           metadata: node.metadata as QueryPlanNodeData['metadata'],
           hasIncoming: nodesWithIncoming.has(node.id),
           hasOutgoing: nodesWithOutgoing.has(node.id),
+          layoutDirection,
           isDark,
           baseColor: operatorColorMap.get(node.type.toLowerCase()),
         },
@@ -349,7 +352,7 @@ const FlowLayout = ({
     }));
 
     return { flowNodes, flowEdges };
-  }, [data, isDark, operatorColorMap]);
+  }, [data, isDark, operatorColorMap, layoutDirection]);
 
   const handleNodeClick = useCallback(
     (_event: MouseEvent, node: Node<QueryPlanNodeData>): void => {

--- a/ui/packages/@quent/components/src/dag/DAGControls.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGControls.tsx
@@ -7,11 +7,17 @@ import {
   useSelectedEdgeWidthField,
   useSelectedEdgeColorField,
   useSelectedNodeLabelField,
+  useSelectedDagLayoutDirection,
   useNodeColorPalette,
   useEdgeColorPalette,
 } from '@quent/hooks';
-import { NODE_LABEL_FIELD, type NodeLabelField } from '@quent/utils';
-import { Palette, Spline, Brush, Type } from 'lucide-react';
+import {
+  NODE_LABEL_FIELD,
+  DAG_LAYOUT_DIRECTION,
+  type NodeLabelField,
+  type DagLayoutDirection,
+} from '@quent/utils';
+import { Palette, Spline, Brush, Type, ArrowUpDown } from 'lucide-react';
 import { PalettePicker } from './PalettePicker';
 
 interface DAGControlsProps {
@@ -27,12 +33,18 @@ const NODE_LABEL_OPTIONS: SelectFieldOption[] = [
   { value: NODE_LABEL_FIELD.TYPE, label: 'Type' },
 ];
 
+const LAYOUT_DIRECTION_OPTIONS: SelectFieldOption[] = [
+  { value: DAG_LAYOUT_DIRECTION.BOTTOM_TO_TOP, label: 'Bottom to top' },
+  { value: DAG_LAYOUT_DIRECTION.TOP_TO_BOTTOM, label: 'Top to bottom' },
+];
+
 /** DAG visual control toolbar: node color, edge width, edge color, node label field selectors. */
 export const DAGControls = ({ operatorStatFields, portStatFields, isDark }: DAGControlsProps) => {
   const [colorField, setColorField] = useSelectedColorField();
   const [edgeWidthField, setEdgeWidthField] = useSelectedEdgeWidthField();
   const [edgeColorField, setEdgeColorField] = useSelectedEdgeColorField();
   const [nodeLabelField, setNodeLabelField] = useSelectedNodeLabelField();
+  const [layoutDirection, setLayoutDirection] = useSelectedDagLayoutDirection();
   const [nodePalette, setNodePalette] = useNodeColorPalette();
   const [edgePalette, setEdgePalette] = useEdgeColorPalette();
 
@@ -87,6 +99,16 @@ export const DAGControls = ({ operatorStatFields, portStatFields, isDark }: DAGC
           value={nodeLabelField}
           onValueChange={v => v && setNodeLabelField(v as NodeLabelField)}
           placeholder="Name"
+          clearable={false}
+          triggerClassName="h-6 text-xs"
+        />
+        <SelectField
+          label="Layout direction"
+          icon={ArrowUpDown}
+          options={LAYOUT_DIRECTION_OPTIONS}
+          value={layoutDirection}
+          onValueChange={v => v && setLayoutDirection(v as DagLayoutDirection)}
+          placeholder="Bottom to top"
           clearable={false}
           triggerClassName="h-6 text-xs"
         />

--- a/ui/packages/@quent/components/src/dag/layout.test.ts
+++ b/ui/packages/@quent/components/src/dag/layout.test.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+import { DAG_LAYOUT_DIRECTION } from '@quent/utils';
+import { calculateLayout } from './layout';
+
+// Linear chain: Scan (source) -> Filter -> Root (sink), matching trace edge
+// direction (child.out -> parent.in).
+const nodes: Node<Record<string, unknown>>[] = [
+  { id: 'scan', position: { x: 0, y: 0 }, data: {} },
+  { id: 'filter', position: { x: 0, y: 0 }, data: {} },
+  { id: 'root', position: { x: 0, y: 0 }, data: {} },
+];
+const edges: Edge[] = [
+  { id: 'e1', source: 'scan', target: 'filter' },
+  { id: 'e2', source: 'filter', target: 'root' },
+];
+
+describe('calculateLayout', () => {
+  it('defaults to bottom-to-top: sources render below the root', async () => {
+    const result = await calculateLayout(nodes, edges);
+    const yById = new Map(result.nodes.map(n => [n.id, n.position.y]));
+    expect(yById.get('root')).toBeLessThan(yById.get('filter')!);
+    expect(yById.get('filter')).toBeLessThan(yById.get('scan')!);
+  });
+
+  it('top-to-bottom: sources render above the root', async () => {
+    const result = await calculateLayout(nodes, edges, DAG_LAYOUT_DIRECTION.TOP_TO_BOTTOM);
+    const yById = new Map(result.nodes.map(n => [n.id, n.position.y]));
+    expect(yById.get('scan')).toBeLessThan(yById.get('filter')!);
+    expect(yById.get('filter')).toBeLessThan(yById.get('root')!);
+  });
+
+  it('leaves rendered edges pointing from source to sink regardless of direction', async () => {
+    const result = await calculateLayout(nodes, edges);
+    expect(result.edges).toEqual(edges);
+  });
+});

--- a/ui/packages/@quent/components/src/dag/layout.ts
+++ b/ui/packages/@quent/components/src/dag/layout.ts
@@ -3,6 +3,7 @@
 
 import { graph, sugiyama } from 'd3-dag';
 import type { Node, Edge } from '@xyflow/react';
+import { DAG_LAYOUT_DIRECTION, type DagLayoutDirection } from '@quent/utils';
 
 export const NODE_LAYOUT_WIDTH = 200;
 const NODE_LAYOUT_HEIGHT = 60;
@@ -18,18 +19,21 @@ const NODE_SIZE = [NODE_LAYOUT_WIDTH + NODE_SPACING, NODE_LAYOUT_HEIGHT + LAYER_
 
 export async function calculateLayout<TData extends Record<string, unknown>>(
   nodes: Node<TData>[],
-  edges: Edge[]
+  edges: Edge[],
+  direction: DagLayoutDirection = DAG_LAYOUT_DIRECTION.BOTTOM_TO_TOP
 ): Promise<{ nodes: Node<TData>[]; edges: Edge[] }> {
   const grf = graph<string, undefined>();
   const nodeById = new Map<string, ReturnType<typeof grf.node>>();
   for (const n of nodes) nodeById.set(n.id, grf.node(n.id));
+  // sugiyama layers link sources above targets, so flip links to put the root on top
+  const flip = direction === DAG_LAYOUT_DIRECTION.BOTTOM_TO_TOP;
   for (const e of edges) {
     const src = nodeById.get(e.source);
     const tgt = nodeById.get(e.target);
-    if (src && tgt) grf.link(src, tgt, undefined);
+    if (src && tgt) grf.link(flip ? tgt : src, flip ? src : tgt, undefined);
   }
 
-  // sugiyama is synchronous and top-to-bottom by default
+  // sugiyama is synchronous and layers sources at the shallowest depth by default
   sugiyama().nodeSize(NODE_SIZE)(grf);
 
   // d3-dag reports node centers; ReactFlow expects top-left

--- a/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
+++ b/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
@@ -13,7 +13,9 @@ import {
   WHITE,
   BLACK,
   NODE_LABEL_FIELD,
+  DAG_LAYOUT_DIRECTION,
   type Operator,
+  type DagLayoutDirection,
 } from '@quent/utils';
 import {
   useSelectedNodeLabelField,
@@ -34,6 +36,8 @@ export interface QueryPlanNodeData extends Record<string, unknown> {
   metadata?: { rawNode?: Operator };
   hasIncoming?: boolean;
   hasOutgoing?: boolean;
+  /** Which edge of the node incoming/outgoing handles attach to; flips with the DAG layout direction. */
+  layoutDirection?: DagLayoutDirection;
   /**
    * Whether dark mode is active. Forwarded by `DAGChart` via the node's data
    * payload so the renderer can derive heatmap colors without coupling to a
@@ -140,6 +144,12 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
 
   const isActiveHighlight = isHighlighted && !isSelected;
 
+  const isBottomToTop =
+    (data.layoutDirection ?? DAG_LAYOUT_DIRECTION.BOTTOM_TO_TOP) ===
+    DAG_LAYOUT_DIRECTION.BOTTOM_TO_TOP;
+  const incomingHandlePosition = isBottomToTop ? Position.Bottom : Position.Top;
+  const outgoingHandlePosition = isBottomToTop ? Position.Top : Position.Bottom;
+
   const onMouseEnter = useCallback(() => {
     setIsHoveredLocal(true);
     if (operatorId) {
@@ -178,7 +188,7 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
       }
     >
       {data.hasIncoming && (
-        <Handle type="target" position={Position.Top} className="w-2 h-2 opacity-0" />
+        <Handle type="target" position={incomingHandlePosition} className="w-2 h-2 opacity-0" />
       )}
 
       <DataText
@@ -205,7 +215,7 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
       )}
 
       {data.hasOutgoing && (
-        <Handle type="source" position={Position.Bottom} className="w-2 h-2 opacity-0" />
+        <Handle type="source" position={outgoingHandlePosition} className="w-2 h-2 opacity-0" />
       )}
     </div>
   );

--- a/ui/packages/@quent/hooks/src/atoms/dagControls.ts
+++ b/ui/packages/@quent/hooks/src/atoms/dagControls.ts
@@ -10,9 +10,10 @@ import type {
   EdgeWidthConfig,
   EdgeColoring,
   NodeLabelField,
+  DagLayoutDirection,
   StatValue,
 } from '@quent/utils';
-import { NODE_LABEL_FIELD } from '@quent/utils';
+import { NODE_LABEL_FIELD, DAG_LAYOUT_DIRECTION } from '@quent/utils';
 import type { ContinuousPaletteName } from '@quent/utils';
 
 /**
@@ -134,3 +135,8 @@ export const nodeColorPaletteAtom = atom<ContinuousPaletteName>('blue');
 
 /** Continuous color palette used for edge coloring */
 export const edgeColorPaletteAtom = atom<ContinuousPaletteName>('teal');
+
+/** Direction the DAG layout flows — defaults to sources at the bottom, result at the top */
+export const selectedDagLayoutDirectionAtom = atom<DagLayoutDirection>(
+  DAG_LAYOUT_DIRECTION.BOTTOM_TO_TOP
+);

--- a/ui/packages/@quent/hooks/src/dag/dagControlSelectors.ts
+++ b/ui/packages/@quent/hooks/src/dag/dagControlSelectors.ts
@@ -15,6 +15,7 @@ import {
   edgeColoringAtom,
   edgeColorPaletteAtom,
   selectedNodeLabelFieldAtom,
+  selectedDagLayoutDirectionAtom,
   selectedNodeDataAtom,
   highlightedNodeIdsAtom,
   effectiveHighlightedNodeIdsAtom,
@@ -61,6 +62,10 @@ export function useEdgeColorPalette() {
 
 export function useSelectedNodeLabelField() {
   return useAtom(selectedNodeLabelFieldAtom);
+}
+
+export function useSelectedDagLayoutDirection() {
+  return useAtom(selectedDagLayoutDirectionAtom);
 }
 
 export function useSelectedNodeData() {

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -76,6 +76,7 @@ export {
   useEdgeColoring,
   useEdgeColorPalette,
   useSelectedNodeLabelField,
+  useSelectedDagLayoutDirection,
   useSelectedNodeData,
   useSetSelectedNodeData,
   useHighlightedNodeIds,

--- a/ui/packages/@quent/utils/src/dagTypes.ts
+++ b/ui/packages/@quent/utils/src/dagTypes.ts
@@ -50,6 +50,15 @@ export const NODE_LABEL_FIELD = {
 
 export type NodeLabelField = (typeof NODE_LABEL_FIELD)[keyof typeof NODE_LABEL_FIELD];
 
+export const DAG_LAYOUT_DIRECTION = {
+  /** Sources (e.g. Scan) at the bottom, flowing up toward the result. Conventional for query profiling. */
+  BOTTOM_TO_TOP: 'bottom-to-top',
+  /** Sources at the top, flowing down toward the result. */
+  TOP_TO_BOTTOM: 'top-to-bottom',
+} as const;
+
+export type DagLayoutDirection = (typeof DAG_LAYOUT_DIRECTION)[keyof typeof DAG_LAYOUT_DIRECTION];
+
 export type StatValue = string | number | boolean | null | string[];
 
 export interface DAGNode {

--- a/ui/packages/@quent/utils/src/index.ts
+++ b/ui/packages/@quent/utils/src/index.ts
@@ -53,7 +53,7 @@ export { EntityTypeKey } from './entityTypes';
 export type { EntityTypeValue, SingleEntity, EntityRefKey } from './entityTypes';
 
 // DAG coloring types (shared between @quent/hooks and @quent/components)
-export { NODE_LABEL_FIELD } from './dagTypes';
+export { NODE_LABEL_FIELD, DAG_LAYOUT_DIRECTION } from './dagTypes';
 export type {
   ContinuousNodeColoring,
   CategoricalNodeColoring,
@@ -63,6 +63,7 @@ export type {
   CategoricalEdgeColoring,
   EdgeColoring,
   NodeLabelField,
+  DagLayoutDirection,
   StatValue,
   DAGNode,
   DAGEdge,


### PR DESCRIPTION
# Description

Changes the default layout to be from bottom-to-top, as opposed to top-to-bottom based on comment in linked issue. Adds a dropdown under the "Settings" tab that allows users to control the layout direction of the DAG and switch back if desired.

## Related Issues

Resolves: #280

## Testing

1. Ensure query plans now flow from bottom to top by default
2. Go into "Settings" and switch plan direction, ensuring it renders accordingly
3. Ensure everything looks normal and other settings function as expected in both direction modes

## Screenshots

<img width="3790" height="2030" alt="Screenshot_20260706_124344" src="https://github.com/user-attachments/assets/1c5d2784-6a0e-4c99-b448-89928f3742a2" />

<img width="3790" height="2030" alt="Screenshot_20260706_124415" src="https://github.com/user-attachments/assets/0164cf30-b2ec-494f-b718-844fe43120b5" />

