### PR TITLE
feat(instrumentation): remove serde bound from event exporter and importer traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "quent-events",
- "serde",
  "thiserror 2.0.18",
 ]
 

--- a/crates/exporter/callback/src/lib.rs
+++ b/crates/exporter/callback/src/lib.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 
 use quent_events::{EntityEvent, Event};
 use quent_exporter_types::{Exporter, ExporterResult};
-use serde::Serialize;
 
 /// One exported event, type-erased so a single callback can receive events of
 /// any entity type. `event` is a boxed `Event<T>` for the entity named by
@@ -49,7 +48,7 @@ impl CallbackExporter {
 #[async_trait::async_trait]
 impl<T> Exporter<T> for CallbackExporter
 where
-    T: Serialize + Send + EntityEvent + 'static,
+    T: Send + EntityEvent + 'static,
 {
     async fn push(&mut self, event: Event<T>) -> ExporterResult<()> {
         (self.callback.0)(RecordedEvent {
@@ -72,7 +71,6 @@ mod tests {
 
     use super::*;
 
-    #[derive(Serialize)]
     struct Alpha {
         a: u32,
     }
@@ -80,7 +78,6 @@ mod tests {
         const NAME: &'static str = "alpha";
     }
 
-    #[derive(Serialize)]
     struct Beta {
         b: String,
     }

--- a/crates/exporter/types/Cargo.toml
+++ b/crates/exporter/types/Cargo.toml
@@ -6,5 +6,4 @@ publish.workspace = true
 [dependencies]
 async-trait.workspace = true
 quent-events = { path = "../../events" }
-serde.workspace = true
 thiserror.workspace = true

--- a/crates/exporter/types/src/lib.rs
+++ b/crates/exporter/types/src/lib.rs
@@ -4,7 +4,6 @@
 //! Basic traits for exporter / importer implementations
 
 use quent_events::{EntityEvent, Event};
-use serde::Deserialize;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -80,11 +79,7 @@ where
     async fn shutdown(&mut self) -> ExporterResult<()>;
 }
 
-pub trait Importer<T>: Iterator<Item = Event<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-}
+pub trait Importer<T>: Iterator<Item = Event<T>> {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/exporter/types/src/lib.rs
+++ b/crates/exporter/types/src/lib.rs
@@ -4,7 +4,7 @@
 //! Basic traits for exporter / importer implementations
 
 use quent_events::{EntityEvent, Event};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -69,7 +69,7 @@ pub fn resolve_import_path(
 #[async_trait::async_trait]
 pub trait Exporter<T>: Send
 where
-    T: Serialize + Send + EntityEvent,
+    T: Send + EntityEvent,
 {
     /// Export one event.
     async fn push(&mut self, event: Event<T>) -> ExporterResult<()>;

--- a/crates/instrumentation/src/lib.rs
+++ b/crates/instrumentation/src/lib.rs
@@ -324,7 +324,7 @@ impl Context {
 #[doc(hidden)]
 pub struct Observer<T>
 where
-    T: Serialize + Send + EntityEvent + 'static,
+    T: Send + EntityEvent + 'static,
 {
     events_sender: EventSender<T>,
     cancellation_token: CancellationToken,
@@ -337,7 +337,7 @@ where
 
 impl<T> Observer<T>
 where
-    T: Serialize + Send + EntityEvent + 'static,
+    T: Send + EntityEvent + 'static,
 {
     /// Construct a no-op observer that discards events and holds no runtime
     /// resources whatesoever.
@@ -363,7 +363,7 @@ where
 
 impl<T> Drop for Observer<T>
 where
-    T: Serialize + Send + EntityEvent + 'static,
+    T: Send + EntityEvent + 'static,
 {
     fn drop(&mut self) {
         self.cancellation_token.cancel();


### PR DESCRIPTION
One part of #250, moving towards making the instrumentation stack serde-free, unless a serde-required exporter is selected. This just removes the bound from the exporter and importer traits.