### PR TITLE
chore(deps): bump crossbeam-epoch from 0.9.18 to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Fixes RUSTSEC-2026-0204: invalid pointer dereference in the fmt::Display impl for Atomic and Shared when formatting null/invalid pointers. Affected range 0.9.0-0.9.19; 0.9.20 is the patched release. Transitive dependency, so only Cargo.lock changes.