### PR TITLE
ci(dependabot): point npm updates at real manifest directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
       interval: "weekly"
   - cooldown:
       default-days: 14
-    directory: "/"
+    directories:
+      - "/ui"
+      - "/ui/examples/quent-pivot-table-panel"
+      - "/crates/schema/ts"
     open-pull-requests-limit: 5
     package-ecosystem: "npm"
     schedule:


### PR DESCRIPTION
npm entry targeted `directory: "/"` (no manifest), so no npm PRs opened. Now covers the real npm roots: `/ui`, `/ui/examples/quent-pivot-table-panel`, and `/crates/schema/ts`.

🤖 Written by Claude