### PR TITLE
fix(open): support quent revisions predating the quent-exporter rename

### DIFF
--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -90,8 +90,23 @@ async fn build_one(group: ViewerGroup) -> Result<BuiltViewer> {
     println!("building: {label}");
 
     let crate_dir = build_dir(&spec)?;
-    wrapper::generate(&spec, &crate_dir)?;
-    let bin = cargo_build(&crate_dir).await?;
+    wrapper::generate(&spec, &crate_dir, wrapper::IO_PACKAGE)?;
+    let bin = match cargo_build(&crate_dir).await {
+        // The pinned quent revision predates the `quent-exporter` → `quent-io`
+        // rename (cargo found no `quent-io` package there, failing resolution
+        // before anything compiles); regenerate the wrapper against the legacy
+        // package name and build again.
+        Err(error) if missing_package(&error, wrapper::IO_PACKAGE) => {
+            println!(
+                "note: pinned quent has no `{}` package; retrying with `{}`",
+                wrapper::IO_PACKAGE,
+                wrapper::LEGACY_IO_PACKAGE
+            );
+            wrapper::generate(&spec, &crate_dir, wrapper::LEGACY_IO_PACKAGE)?;
+            cargo_build(&crate_dir).await?
+        }
+        result => result?,
+    };
     Ok(BuiltViewer {
         bin,
         crate_dir,
@@ -113,6 +128,19 @@ async fn serve_one(viewer: BuiltViewer, open_browser: bool, host: IpAddr) -> Res
     // Best-effort cleanup of this run's staged root; keep the cached build.
     let _ = std::fs::remove_dir_all(&output_root);
     result
+}
+
+/// Whether a build failed because the pinned quent revision has no `package` —
+/// i.e. it sits on the other side of the `quent-exporter` → `quent-io` rename.
+/// Matched on cargo's resolution error, which [`cargo_build`] folds into
+/// [`OpenError::Build`].
+fn missing_package(error: &OpenError, package: &str) -> bool {
+    match error {
+        OpenError::Build { status } => {
+            status.contains(&format!("no matching package named `{package}` found"))
+        }
+        _ => false,
+    }
 }
 
 /// Cache dir for this viewer's generated crate/build, keyed by
@@ -349,4 +377,34 @@ async fn wait_until_ready(addr: SocketAddr) -> bool {
         )
         .await
         .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_package_matches_only_cargo_resolution_errors() {
+        // Cargo's resolution error for a quent revision predating `quent-io`.
+        let missing = OpenError::Build {
+            status: "exit status: 101\n\
+                     error: no matching package named `quent-io` found\n\
+                     location searched: Git repository https://example.com/quent\n\
+                     required by package `quent-open-viewer v0.0.0`"
+                .into(),
+        };
+        assert!(missing_package(&missing, wrapper::IO_PACKAGE));
+        // Only the package the wrapper actually asked for triggers the fallback.
+        assert!(!missing_package(&missing, wrapper::LEGACY_IO_PACKAGE));
+
+        // Other build failures and non-build errors must not trigger the fallback.
+        let compile_error = OpenError::Build {
+            status: "error[E0308]: mismatched types".into(),
+        };
+        assert!(!missing_package(&compile_error, wrapper::IO_PACKAGE));
+        assert!(!missing_package(
+            &OpenError::NoCacheDir,
+            wrapper::IO_PACKAGE
+        ));
+    }
 }

--- a/crates/open/src/wrapper.rs
+++ b/crates/open/src/wrapper.rs
@@ -20,6 +20,12 @@ use crate::spec::ViewerSpec;
 /// Name of the generated wrapper package (also the built binary name).
 pub const WRAPPER_PACKAGE: &str = "quent-open-viewer";
 
+/// Cargo package of quent's I/O crate (export/import formats).
+pub const IO_PACKAGE: &str = "quent-io";
+/// Cargo package of the I/O crate before its rename to [`IO_PACKAGE`], for
+/// artifacts pinned to quent revisions that predate the rename.
+pub const LEGACY_IO_PACKAGE: &str = "quent-exporter";
+
 /// Wrapper env var for the output root: a directory of `<context-uuid>/`
 /// context directories.
 pub const ROOT_ENV: &str = "QUENT_OPEN_ROOT";
@@ -27,9 +33,11 @@ pub const ROOT_ENV: &str = "QUENT_OPEN_ROOT";
 pub const ADDR_ENV: &str = "QUENT_OPEN_ADDR";
 
 /// Write the wrapper crate (`Cargo.toml` + `src/main.rs`) into `crate_dir`.
-pub fn generate(spec: &ViewerSpec, crate_dir: &Path) -> Result<()> {
+/// `io_package` is the name of quent's I/O crate at the pinned revision
+/// ([`IO_PACKAGE`], or [`LEGACY_IO_PACKAGE`] for revisions predating the rename).
+pub fn generate(spec: &ViewerSpec, crate_dir: &Path, io_package: &str) -> Result<()> {
     std::fs::create_dir_all(crate_dir.join("src"))?;
-    std::fs::write(crate_dir.join("Cargo.toml"), cargo_toml(spec))?;
+    std::fs::write(crate_dir.join("Cargo.toml"), cargo_toml(spec, io_package))?;
     std::fs::write(crate_dir.join("src/main.rs"), main_rs(spec))?;
     Ok(())
 }
@@ -47,7 +55,7 @@ fn git_dep(url: String, rev: &str, features: &[&str]) -> Dependency {
 /// Wrapper `Cargo.toml`, built with `cargo-manifest`: pin quent crates to
 /// `quent.{remote,commit}` and the analyzer to `analyzer.{remote,commit}`; the
 /// empty `[workspace]` keeps the generated crate out of any parent workspace.
-fn cargo_toml(spec: &ViewerSpec) -> String {
+fn cargo_toml(spec: &ViewerSpec, io_package: &str) -> String {
     let quent = spec.quent.cargo_url();
     let q_rev = spec.quent.commit.as_str();
     let dependencies = BTreeMap::from([
@@ -61,7 +69,7 @@ fn cargo_toml(spec: &ViewerSpec) -> String {
         ),
         (
             // All formats enabled so the analyzer can detect the artifact's format at runtime.
-            "quent-io".to_string(),
+            io_package.to_string(),
             git_dep(quent, q_rev, &["ndjson", "msgpack", "postcard"]),
         ),
         (
@@ -174,7 +182,7 @@ mod tests {
 
     #[test]
     fn cargo_toml_pins_quent_and_analyzer() {
-        let manifest: toml::Value = toml::from_str(&cargo_toml(&spec())).unwrap();
+        let manifest: toml::Value = toml::from_str(&cargo_toml(&spec(), IO_PACKAGE)).unwrap();
         assert!(manifest.get("workspace").is_some(), "standalone workspace");
         let deps = &manifest["dependencies"];
         let server = &deps["quent-query-engine-server"];
@@ -192,6 +200,26 @@ mod tests {
             "https://example.com/analyzer"
         );
         assert_eq!(analyzer["rev"].as_str().unwrap(), "analyzercommit");
+    }
+
+    #[test]
+    fn cargo_toml_supports_the_legacy_io_package() {
+        // Artifacts pinned to quent revisions predating the `quent-exporter` →
+        // `quent-io` rename depend on the legacy package instead, same features.
+        let manifest: toml::Value =
+            toml::from_str(&cargo_toml(&spec(), LEGACY_IO_PACKAGE)).unwrap();
+        let deps = &manifest["dependencies"];
+        assert!(deps.get("quent-io").is_none());
+        let exporter = &deps["quent-exporter"];
+        assert_eq!(
+            exporter["git"].as_str().unwrap(),
+            "https://example.com/quent"
+        );
+        assert_eq!(exporter["rev"].as_str().unwrap(), "quentcommit");
+        let features = exporter["features"].as_array().unwrap();
+        for format in ["ndjson", "msgpack", "postcard"] {
+            assert!(features.iter().any(|f| f.as_str() == Some(format)));
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Description

Since #341 the wrapper crate generated by `quent-open` unconditionally depends on `quent-io`, so opening artifacts built against a quent revision from before the `quent-exporter` → `quent-io` rename fails: cargo cannot resolve `quent-io` at those pinned revisions.

There is nothing to determine the right name from up front: the sidecar records no distinguishing data (the workspace version is `0.1.0` on both sides of the rename), and `quent-open` never fetches the pinned repository itself — cargo does, along with the git authentication that private remotes need. So the wrapper is generated against `quent-io` and, when the build fails with cargo's resolution error for exactly that missing package (``no matching package named `quent-io` found``, which fails fast, before anything compiles), it is regenerated against `quent-exporter` and built again. Any other failure propagates unchanged. Verified against real history: at `aa1e9b1~1` the `quent-io` manifest fails resolution with exactly the matched error and the `quent-exporter` one resolves; at `aa1e9b1` the `quent-io` manifest resolves.

The retry costs old-quent projects one fast failed resolution per run; the cargo error-text match is the only coupling.

## Note on versioning breaking changes going forward

This retry only exists because nothing recorded in the artifact sidecar identifies which side of a breaking rename a pinned revision is on. The workspace version has been `0.1.0` for all of quent's history, so `quent.version` in `model.qmi` carries no information. Going forward we should bump the workspace version whenever a change breaks what `quent-open` generates (crate renames, generated-`main.rs` API changes): every sidecar records the version at build time, so `quent-open` can then select the right wrapper shape deterministically from data it already has — no failing probe builds — and this retry can be reduced to a safety net or removed. Worth capturing in the contributor docs as part of the breaking-change checklist.

## Related Issues

Follow-up to #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)