### PR TITLE
test(open): gate quent-open backward compatibility in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,42 @@ jobs:
       - run: pixi run cargo test --workspace --all-features --locked --all-targets
       - run: pixi run cargo build --workspace --all-features --locked --release
 
+  # Regression gate for `quent-open` backward compatibility: build a viewer for
+  # a sidecar pinning the previous quent commit (the PR's base commit, or the
+  # parent of the pushed commit), with the quent-open of this tree. A failure
+  # means this change breaks `quent open` for existing artifacts — add a
+  # compatibility path in the same PR instead of merging the breakage.
+  open-compat:
+    name: quent-open compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Picking the previous commit on push builds needs the parent of HEAD.
+          fetch-depth: 2
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          cache: true
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Pick the previous quent commit
+        id: previous
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: echo "commit=${BASE_SHA:-$(git rev-parse HEAD~1)}" >> "$GITHUB_OUTPUT"
+      - run: pixi run cargo test --package quent-open --locked -- --ignored opens_artifacts_built_by_a_previous_quent_commit
+        env:
+          QUENT_OPEN_COMPAT_COMMIT: ${{ steps.previous.outputs.commit }}
+          QUENT_OPEN_COMPAT_REMOTE: ${{ github.server_url }}/${{ github.repository }}
+
   deny:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -407,4 +407,64 @@ mod tests {
             wrapper::IO_PACKAGE
         ));
     }
+
+    /// Compatibility gate, run explicitly in CI (the `open-compat` job in
+    /// `rust.yml`): the quent-open being built must still open artifacts
+    /// exported by an older quent. A sidecar pins the quent revision it was
+    /// built from, so the generated wrapper must resolve and compile against
+    /// that revision — not against the current tree.
+    ///
+    /// The sidecar is synthesized as an older quent wrote it for the in-repo
+    /// simulator model, pinning `QUENT_OPEN_COMPAT_COMMIT` (in CI: the PR's
+    /// base commit, or the parent of the pushed commit). Everything after that
+    /// is the production path: sidecar → discovery → spec → wrapper generation
+    /// → `cargo build`, including the legacy `quent-exporter` retry.
+    ///
+    /// A failure means this tree breaks `quent open` for existing artifacts
+    /// (e.g. it renames a crate or feature the wrapper depends on, or changes
+    /// an API the generated `main.rs` calls). Ship a compatibility path in the
+    /// same PR — like the [`LEGACY_IO_PACKAGE`](wrapper::LEGACY_IO_PACKAGE)
+    /// retry in [`build_one`] — rather than merging the breakage.
+    #[tokio::test]
+    #[ignore = "fetches pinned git sources and compiles a full viewer; run explicitly (see rust.yml)"]
+    async fn opens_artifacts_built_by_a_previous_quent_commit() {
+        let commit = std::env::var("QUENT_OPEN_COMPAT_COMMIT").expect(
+            "set QUENT_OPEN_COMPAT_COMMIT to the quent commit whose artifacts must still open",
+        );
+        let remote = std::env::var("QUENT_OPEN_COMPAT_REMOTE")
+            .unwrap_or_else(|_| "https://github.com/rapidsai/quent".to_string());
+
+        // The sidecar an older quent wrote for the in-repo simulator model:
+        // quent and the model share the quent repository, pinned to `commit`.
+        let pin = quent_build_info::BuildInfo {
+            commit: Some(commit),
+            remote: Some(remote),
+            ..quent_build_info::BuildInfo::unknown()
+        };
+        let mut model = quent_build_info::ModelInfo::unknown();
+        model.name = "Simulator".into();
+        model.package = "quent-simulator-instrumentation".into();
+        model.type_path = "quent_simulator_instrumentation::SimulatorEvent".into();
+        model.source = pin.clone();
+        model.analyzer_package = Some("quent-simulator-analyzer".into());
+        let info = quent_build_info::ArtifactInfo { quent: pin, model };
+
+        // A context directory as the exporter lays it out (UUID-named).
+        let tmp = tempfile::tempdir().unwrap();
+        let context = tmp.path().join("01980000-0000-7000-8000-000000000000");
+        std::fs::create_dir_all(&context).unwrap();
+        info.write_sidecar(&context).unwrap();
+
+        let contexts = crate::spec::discover_contexts(&[tmp.path().to_path_buf()]).unwrap();
+        assert_eq!(contexts.len(), 1);
+        let spec = ViewerSpec::from_artifact(
+            &quent_build_info::ArtifactInfo::read_sidecar(&contexts[0]).unwrap(),
+        )
+        .unwrap();
+
+        let viewer = build_one(ViewerGroup { spec, contexts })
+            .await
+            .expect("a viewer for artifacts of the previous quent commit must still build");
+        assert!(viewer.bin.is_file());
+    }
 }


### PR DESCRIPTION
# Description

Follow-up to #343: artifacts pin the quent revision they were built from, so `quent-open` must keep opening sidecars written by older quent revisions. #341 broke that and nothing flagged it before merge — this adds a regression gate so the next such break fails in the PR that introduces it, and the compatibility path ships in that same PR instead of after the fact.

**The test** (`opens_artifacts_built_by_a_previous_quent_commit`, in `crates/open/src/viewer.rs`): synthesizes the sidecar an older quent wrote for the in-repo simulator model, pinned to `QUENT_OPEN_COMPAT_COMMIT`, then runs the production path — sidecar → discovery → spec → wrapper generation → `cargo build`, including the legacy `quent-exporter` retry — and asserts the viewer binary is produced. It is `#[ignore]`d in normal test runs since it fetches git sources and compiles a full viewer.

**The CI job** (`open-compat` in `rust.yml`): runs the test with the previous commit — the PR's base commit, or the parent of the pushed commit on `main` — against `${{ github.server_url }}/${{ github.repository }}`, so it also works on forks. This catches both manifest-level breakage (crate/feature renames, like #341) and generated-`main.rs` API breakage, since the wrapper actually compiles against the pinned revision.

When this job fails on a PR, that PR breaks `quent open` for existing artifacts: add a compatibility path (like the `quent-io` → `quent-exporter` retry in `build_one`) in the same PR, rather than merging the breakage.

Verified locally end-to-end: the test builds a viewer for a sidecar pinning `6a7ffce` (current `main~1`) from the real GitHub remote and passes; it is skipped in a plain `cargo test`.

Versioning-based detection (recording a bumped quent version in sidecars so quent-open can select the wrapper shape deterministically, see the note in #343) is intentionally left for a follow-up; this gate is independent of how the compatibility path is implemented.

## Related Issues

Follow-up to #343 / #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)