### PR TITLE
refactor(collector)!: migrate collector wire format from CBOR to bitcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -251,6 +251,30 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitcode"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6ed1b54d8dc333e7be604d00fa9262f4635485ffea923647b6521a5fff045d"
+dependencies = [
+ "arrayvec",
+ "bitcode_derive",
+ "bytemuck",
+ "glam",
+ "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238b90427dfad9da4a9abd60f3ec1cdee6b80454bde49ed37f1781dd8e9dc7f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -710,7 +734,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -781,7 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1028,6 +1052,12 @@ checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
 dependencies = [
  "bstr",
 ]
+
+[[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
 name = "glob"
@@ -1408,7 +1438,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1650,7 +1680,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2126,7 +2156,7 @@ dependencies = [
 name = "quent-collector-client"
 version = "0.1.0"
 dependencies = [
- "ciborium",
+ "bitcode",
  "http",
  "quent-collector-proto",
  "quent-events",
@@ -2184,7 +2214,6 @@ dependencies = [
 name = "quent-instrumentation"
 version = "0.1.0"
 dependencies = [
- "ciborium",
  "criterion",
  "http",
  "pprof",
@@ -2329,7 +2358,6 @@ dependencies = [
 name = "quent-model"
 version = "0.1.0"
 dependencies = [
- "ciborium",
  "quent-attributes",
  "quent-build-info",
  "quent-collector-client",
@@ -2999,7 +3027,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3397,7 +3425,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4144,7 +4172,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ repository = "https://github.com/rapidsai/quent"
 
 [workspace.dependencies]
 async-trait = "0.1.89"
+bitcode = { version = "0.6.9", features = ["serde"] }
 http = "1"
 indexmap = "2"
 log = {version = "0.4.28", features = ["kv"]}

--- a/crates/collector/client/Cargo.toml
+++ b/crates/collector/client/Cargo.toml
@@ -3,8 +3,9 @@ name = "quent-collector-client"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
+
 [dependencies]
-ciborium = "0.2.2"
+bitcode.workspace = true
 http.workspace = true
 quent-collector-proto = { path = "../proto" }
 quent-events = { path = "../../events" }

--- a/crates/collector/client/src/lib.rs
+++ b/crates/collector/client/src/lib.rs
@@ -29,6 +29,15 @@ pub trait CollectorSink {
     fn ingest(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>>;
 }
 
+/// Decode `bytes` into an [`Event`], inverting the wire encoding this client
+/// produces on send.
+pub fn deserialize_event<T>(bytes: &[u8]) -> Result<Event<T>, bitcode::Error>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    bitcode::deserialize(bytes)
+}
+
 #[derive(Debug, Error)]
 pub enum CollectorError {
     #[error("Unable to connect: {0}")]
@@ -114,8 +123,6 @@ where
             // Max bytes in the buffer.
             // gRPC max default is 4 MiB, reserve 256 KiB for overhead.
             const MAX_BUFFER_BYTES: usize = (4 * 1024 * 1024) - (256 * 1024);
-            // Reusable serialization buffer so we can re-use the allocation.
-            let mut serialized_event = Vec::with_capacity(4096);
 
             /// function to flush the buffer
             async fn flush_buffer(
@@ -136,13 +143,15 @@ where
             loop {
                 select! {
                     Some(event) = event_receiver.recv() => {
-                        serialized_event.clear();
-                        if let Err(e) = ciborium::into_writer(&event, &mut serialized_event) {
-                            error!("unable to serialize event: {e}");
-                            continue;
-                        }
+                        let serialized_event = match bitcode::serialize(&event) {
+                            Ok(bytes) => bytes,
+                            Err(e) => {
+                                error!("unable to serialize event: {e}");
+                                continue;
+                            }
+                        };
                         num_buffer_bytes += serialized_event.len();
-                        buffer.push(serialized_event.clone());
+                        buffer.push(serialized_event);
 
                         if num_buffer_bytes >= MAX_BUFFER_BYTES {
                             if flush_buffer(&mut buffer, &mut num_buffer_bytes, &grpc_sender).await.is_err() {
@@ -162,12 +171,10 @@ where
                         event_receiver.close();
                         // drain events that are buffered
                         while let Some(event) = event_receiver.recv().await {
-                            serialized_event.clear();
-                            if let Err(e) = ciborium::into_writer(&event, &mut serialized_event) {
-                                error!("unable to serialize event: {e}");
-                                continue;
+                            match bitcode::serialize(&event) {
+                                Ok(bytes) => buffer.push(bytes),
+                                Err(e) => error!("unable to serialize event: {e}"),
                             }
-                            buffer.push(serialized_event.clone());
                         }
 
                         if flush_buffer(&mut buffer, &mut num_buffer_bytes, &grpc_sender).await.is_err() {

--- a/crates/collector/server/src/lib.rs
+++ b/crates/collector/server/src/lib.rs
@@ -8,6 +8,6 @@
 pub mod server;
 
 /// Re-exported so callers constructing a [`server::CollectorService`] over a
-/// generic context type can bound it without depending on
-/// `quent-collector-client` directly.
-pub use quent_collector_client::CollectorSink;
+/// generic context type can bound it, and decode ingested events, without
+/// depending on `quent-collector-client` directly.
+pub use quent_collector_client::{CollectorSink, deserialize_event};

--- a/crates/instrumentation/Cargo.toml
+++ b/crates/instrumentation/Cargo.toml
@@ -14,7 +14,6 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-ciborium = "0.2.2"
 criterion = { version = "0.5", features = ["html_reports"] }
 http.workspace = true
 pprof = { version = "0.14", features = ["criterion", "flamegraph"] }

--- a/crates/instrumentation/benches/event_emit.rs
+++ b/crates/instrumentation/benches/event_emit.rs
@@ -21,9 +21,9 @@ use std::path::Path;
 
 use criterion::{BenchmarkGroup, Criterion, Throughput, black_box, measurement::WallTime};
 use pprof::criterion::{Output, PProfProfiler};
-use quent_collector::{CollectorSink, server::CollectorService};
+use quent_collector::{CollectorSink, deserialize_event, server::CollectorService};
 use quent_collector_proto::collector_server::CollectorServer;
-use quent_events::{EntityEvent, Event};
+use quent_events::EntityEvent;
 use quent_instrumentation::{Context, Observer};
 use quent_io::filesystem::{self, Format};
 use quent_io::{CollectorExporterOptions, ExporterOptions};
@@ -72,8 +72,7 @@ impl BenchSink {
 impl CollectorSink for BenchSink {
     fn ingest(&self, entity: &str, event: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
         if entity == BenchEvent::NAME {
-            self.observer
-                .send(ciborium::from_reader::<Event<BenchEvent>, _>(event)?);
+            self.observer.send(deserialize_event::<BenchEvent>(event)?);
             Ok(())
         } else {
             Err(format!("unknown entity stream `{entity}`").into())

--- a/crates/instrumentation/tests/collector_roundtrip.rs
+++ b/crates/instrumentation/tests/collector_roundtrip.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use common::TestEvent;
-use quent_collector::{CollectorSink, server::CollectorService};
+use quent_collector::{CollectorSink, deserialize_event, server::CollectorService};
 use quent_collector_proto::collector_server::CollectorServer;
 use quent_events::{EntityEvent, Event};
 use quent_instrumentation::Context;
@@ -34,7 +34,7 @@ impl CollectorSink for CountingSink {
         if entity != TestEvent::NAME {
             return Err(format!("unexpected entity `{entity}`").into());
         }
-        let _: Event<TestEvent> = ciborium::from_reader(event)?;
+        let _: Event<TestEvent> = deserialize_event(event)?;
         self.received.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -222,8 +222,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         .map(|(comp_event, field)| {
             quote! {
                 if entity == <#comp_event as quent_model::EntityEvent>::NAME {
-                    let e: quent_model::Event<#comp_event> =
-                        quent_model::ciborium::from_reader(event)?;
+                    let e = quent_model::deserialize_event::<#comp_event>(event)?;
                     self.#field.send(e);
                     return Ok(());
                 }

--- a/crates/model/Cargo.toml
+++ b/crates/model/Cargo.toml
@@ -19,7 +19,6 @@ collector = ["dep:quent-collector-client"]
 quent-collector-client = { path = "../collector/client", optional = true }
 uuid = { workspace = true, features = ["v7"] }
 serde = { workspace = true, optional = true }
-ciborium = "0.2.2"
 quent-attributes = { path = "../attributes" }
 quent-build-info = { path = "../build-info" }
 quent-model-macros = { path = "../model-macros" }

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -83,11 +83,10 @@ pub trait ResourceGroup {
 }
 
 // Re-exports referenced by generated instrumentation code and by model consumers.
-pub use ciborium;
 pub use quent_attributes as attributes;
 pub use quent_build_info as build_info;
 #[cfg(feature = "collector")]
-pub use quent_collector_client::CollectorSink;
+pub use quent_collector_client::{CollectorSink, deserialize_event};
 pub use quent_events::{EntityEvent, Event};
 pub use quent_instrumentation::{Context, Observer, write_sidecar};
 pub use quent_io as io;


### PR DESCRIPTION
# Description

Migrate the collector wire format from ciborium (CBOR) to bitcode, which according to some benchmarks (https://github.com/djkoloski/rust_serialization_benchmark) is roughly 10–40× faster than ciborium on both serialize and deserialize.

The codec is now encapsulated in quent-collector-client: bitcode::serialize on send, a new deserialize_event helper on receive. The model! macro and all decode sites call deserialize_event rather than naming the codec, so bitcode lives in one crate and drops out of quent-model entirely.

Breaking: a bitcode client cannot talk to a ciborium server; upgrade both together.

🤖 Written by Claude Code (Opus 4.8).

## Related Issues

Solves #322