### PR TITLE
feat(ui): zoom timeline with mouse wheel and trackpad pinch

### DIFF
--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -282,6 +282,17 @@ export function OperatorGanttChart({
           filterMode: 'none',
           xAxisIndex: [0],
         },
+        {
+          // Trackpad pinch arrives as ctrl+wheel; plain wheel stays reserved
+          // for scrolling the operator rows (see the wrapper wheel handler).
+          type: 'inside',
+          zoomOnMouseWheel: 'ctrl',
+          moveOnMouseMove: false,
+          moveOnMouseWheel: false,
+          throttle: 30,
+          filterMode: 'none',
+          xAxisIndex: [0],
+        },
       ],
     }),
     [gridOptions, startTimeMs, xAxisMax, yAxisCategories, customSeriesData, renderItem]
@@ -351,7 +362,9 @@ export function OperatorGanttChart({
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
     const handleWheel = (e: WheelEvent) => {
-      if (e.shiftKey) return;
+      // shift+wheel and ctrl+wheel (trackpad pinch) are zoom gestures — let
+      // them through to ECharts.
+      if (e.shiftKey || e.ctrlKey) return;
       e.stopPropagation();
     };
     wrapper.addEventListener('wheel', handleWheel, { capture: true, passive: true });

--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -272,7 +272,10 @@ export function Timeline({
         },
         {
           type: 'inside',
-          zoomOnMouseWheel: 'shift',
+          // `true` (no modifier required) covers mouse wheel, trackpad
+          // two-finger scroll, and trackpad pinch (delivered as ctrl+wheel).
+          // ECharts centers the zoom on the pointer's axis position.
+          zoomOnMouseWheel: true,
           moveOnMouseMove: false,
           moveOnMouseWheel: false,
           throttle: 30,
@@ -370,29 +373,20 @@ export function Timeline({
       }
     });
 
-    // Pass non-shift wheel events through to the page for normal scrolling.
-    // Without this, ECharts' inside dataZoom calls preventDefault on all wheel events.
-    // When at the zoom limit, also block shift+wheel-in before ECharts sees it —
-    // ECharts converts a blocked zoom into a pan, so we must stop it at the source.
+    // All wheel/pinch input over the chart zooms via the inside dataZoom, and
+    // ECharts preventDefaults the events it consumes. The one event it must
+    // never see is wheel-in at the minimum zoom window — ECharts converts a
+    // blocked zoom into a pan — so stop it before it reaches the chart and
+    // suppress the browser fallback (page scroll / pinch page-zoom) ourselves.
     dom.addEventListener(
       'wheel',
       e => {
-        if (!e.shiftKey) {
+        if (e.deltaY < 0 && atZoomLimitRef.current) {
           e.stopPropagation();
-        } else if (e.deltaY < 0 && atZoomLimitRef.current) {
-          e.stopPropagation();
+          e.preventDefault();
         }
       },
-      { capture: true, passive: true }
-    );
-
-    // Prevent the browser from handling shift+wheel-in when ECharts can't zoom further
-    dom.addEventListener(
-      'wheel',
-      e => {
-        if (e.shiftKey && e.deltaY < 0) e.preventDefault();
-      },
-      { passive: false }
+      { capture: true, passive: false }
     );
   }, []);
 


### PR DESCRIPTION
## Summary

The timeline view now zooms with plain mouse wheel, trackpad two-finger scroll, and trackpad pinch (delivered by browsers as ctrl+wheel), centered on the pointer's position on the time axis. Previously zooming required shift+wheel, and plain wheel was passed through to the page for scrolling.

- **Resource timeline rows** (`Timeline.tsx`): the inside dataZoom uses `zoomOnMouseWheel: true`, so all wheel/pinch input zooms; ECharts anchors the zoom at the pointer. The minimum-zoom-window guard now applies to all wheel input and suppresses the browser fallback (page scroll / pinch page-zoom) at the limit — ECharts would otherwise convert a blocked zoom into a pan.
- **Operator gantt** (`OperatorGanttChart.tsx`): plain wheel stays reserved for scrolling the operator rows (its only scroll mechanism); trackpad pinch (ctrl+wheel) zooms alongside the existing shift+wheel.

The zoom controller bar already zoomed on plain wheel; all charts stay in sync via the existing connect group and zoom atom.

Note the trade-off: with wheel bound to zoom, scrolling the page requires the pointer to be outside a timeline chart (e.g. over the tree columns).

## Test plan

- [x] `pnpm exec vitest run packages/@quent/components/src/lib/timeline.utils.test.ts` (48 passed)
- [x] eslint clean on both changed files
- [x] Manually verified against the simulator server (`quent-simulator-server` + `quent-simulator` + `pnpm dev`): wheel and pinch zoom center on the pointer, ruler/controller/rows stay in sync, zoom-in stops at the minimum window, gantt rows still scroll with plain wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)