### PR TITLE
perf(io): add event batch export via Exporter::drain_events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,7 @@ dependencies = [
  "async-trait",
  "quent-events",
  "thiserror 2.0.18",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/instrumentation/src/observer.rs
+++ b/crates/instrumentation/src/observer.rs
@@ -18,10 +18,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use uuid::Uuid;
 
-/// Max events drained per `recv_many` call, bounding batch memory and
-/// worst-case flush latency.
-const RECV_MANY_LIMIT: usize = 256;
-
 /// Wrapper around an optional channel sender.
 ///
 /// When the inner sender is `None` (i.e. the noop exporter is selected), `send`
@@ -155,32 +151,38 @@ where
     let (events_sender, mut events_receiver) = unbounded_channel();
 
     let forwarder_handle = runtime.handle().spawn(async move {
-        // One buffer for the task's lifetime. `recv_many` appends, so clear it
-        // after each `push_many` (whose post-state is unspecified) to refill
-        // from empty without reallocating.
+        // Reused across batches; `drain_events` leaves it empty and it is reserved
+        // to a full batch before each receive.
         let mut buffer = Vec::new();
         loop {
+            let limit = exporter.batch_size_hint().get();
+            buffer.reserve(limit);
             tokio::select! {
                 // Cancel-safe: if the cancellation branch wins, `buffer` is left
                 // untouched (no events are lost).
-                n = events_receiver.recv_many(&mut buffer, RECV_MANY_LIMIT) => {
+                n = events_receiver.recv_many(&mut buffer, limit) => {
                     // 0 means the channel is closed and drained.
                     if n == 0 {
                         break;
                     }
-                    if let Err(e) = exporter.push_many(&mut buffer).await {
+                    if let Err(e) = exporter.drain_events(&mut buffer).await {
                         warn!("unable to export events: {e}");
                     }
-                    buffer.clear();
+                    debug_assert!(buffer.is_empty(), "drain_events must leave the buffer empty");
                 },
                 () = cloned_token.cancelled() => {
                     events_receiver.close();
                     // drain events that are buffered
-                    while events_receiver.recv_many(&mut buffer, RECV_MANY_LIMIT).await != 0 {
-                        if let Err(e) = exporter.push_many(&mut buffer).await {
+                    loop {
+                        let limit = exporter.batch_size_hint().get();
+                        buffer.reserve(limit);
+                        if events_receiver.recv_many(&mut buffer, limit).await == 0 {
+                            break;
+                        }
+                        if let Err(e) = exporter.drain_events(&mut buffer).await {
                             warn!("unable to export events: {e}");
                         }
-                        buffer.clear();
+                        debug_assert!(buffer.is_empty(), "drain_events must leave the buffer empty");
                     }
                     break
                 },

--- a/crates/instrumentation/src/observer.rs
+++ b/crates/instrumentation/src/observer.rs
@@ -18,6 +18,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use uuid::Uuid;
 
+/// Max events drained per `recv_many` call, bounding batch memory and
+/// worst-case flush latency.
+const RECV_MANY_LIMIT: usize = 256;
+
 /// Wrapper around an optional channel sender.
 ///
 /// When the inner sender is `None` (i.e. the noop exporter is selected), `send`
@@ -151,25 +155,35 @@ where
     let (events_sender, mut events_receiver) = unbounded_channel();
 
     let forwarder_handle = runtime.handle().spawn(async move {
+        // One buffer for the task's lifetime. `recv_many` appends, so clear it
+        // after each `push_many` (whose post-state is unspecified) to refill
+        // from empty without reallocating.
+        let mut buffer = Vec::new();
         loop {
             tokio::select! {
-                Some(event) = events_receiver.recv() => {
-                    if let Err(e) = exporter.push(event).await {
-                        warn!("unable to export event: {e}");
+                // Cancel-safe: if the cancellation branch wins, `buffer` is left
+                // untouched (no events are lost).
+                n = events_receiver.recv_many(&mut buffer, RECV_MANY_LIMIT) => {
+                    // 0 means the channel is closed and drained.
+                    if n == 0 {
+                        break;
                     }
+                    if let Err(e) = exporter.push_many(&mut buffer).await {
+                        warn!("unable to export events: {e}");
+                    }
+                    buffer.clear();
                 },
                 () = cloned_token.cancelled() => {
                     events_receiver.close();
                     // drain events that are buffered
-                    while let Some(event) = events_receiver.recv().await {
-                        if let Err(e) = exporter.push(event).await {
-                            warn!("unable to export event: {e}");
+                    while events_receiver.recv_many(&mut buffer, RECV_MANY_LIMIT).await != 0 {
+                        if let Err(e) = exporter.push_many(&mut buffer).await {
+                            warn!("unable to export events: {e}");
                         }
+                        buffer.clear();
                     }
                     break
                 },
-                // the events channel has been closed: nothing left to forward.
-                else => break,
             }
         }
         // Tear down once, however the loop exited.

--- a/crates/io/msgpack/src/lib.rs
+++ b/crates/io/msgpack/src/lib.rs
@@ -14,7 +14,7 @@ use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncWriteExt, BufWriter},
 };
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 /// File extension for MessagePack event files.
@@ -87,7 +87,7 @@ where
                     batch.extend_from_slice(&(payload.len() as u32).to_be_bytes());
                     batch.extend_from_slice(&payload);
                 }
-                Err(e) => error!("unable to serialize event: {e}"),
+                Err(e) => warn!("unable to serialize event: {e}"),
             }
         }
         writer.write_all(batch).await?;

--- a/crates/io/msgpack/src/lib.rs
+++ b/crates/io/msgpack/src/lib.rs
@@ -35,6 +35,8 @@ pub struct MsgpackExporterOptions {
 pub struct MsgpackExporter {
     /// `None` once [`shutdown`](Exporter::shutdown) has flushed and released it.
     writer: Option<BufWriter<File>>,
+    /// Framing buffer reused across [`drain_events`](Exporter::drain_events).
+    batch: Vec<u8>,
 }
 
 impl MsgpackExporter {
@@ -50,6 +52,7 @@ impl MsgpackExporter {
             .await?;
         Ok(Self {
             writer: Some(BufWriter::new(file)),
+            batch: Vec::new(),
         })
     }
 }
@@ -69,14 +72,15 @@ where
     }
 
     async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
-        let Some(writer) = self.writer.as_mut() else {
+        let Self { writer, batch } = self;
+        let Some(writer) = writer.as_mut() else {
             events.clear();
             return Err(ExporterError::Shutdown);
         };
-        // Frame the whole batch into one buffer, then issue a single write. A
-        // record that fails to serialize is logged and skipped so one bad event
-        // does not drop the batch.
-        let mut batch = Vec::new();
+        // Frame the whole batch into the reused buffer, then issue a single
+        // write. A record that fails to serialize is logged and skipped so one
+        // bad event does not drop the batch.
+        batch.clear();
         for event in events.drain(..) {
             match rmp_serde::to_vec(&event) {
                 Ok(payload) => {
@@ -86,7 +90,7 @@ where
                 Err(e) => error!("unable to serialize event: {e}"),
             }
         }
-        writer.write_all(&batch).await?;
+        writer.write_all(batch).await?;
         Ok(())
     }
 

--- a/crates/io/msgpack/src/lib.rs
+++ b/crates/io/msgpack/src/lib.rs
@@ -68,6 +68,25 @@ where
         Ok(())
     }
 
+    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
+        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+        // Frame the whole batch into one buffer, then issue a single write. A
+        // record that fails to serialize is logged and skipped so one bad event
+        // does not drop the batch.
+        let mut batch = Vec::new();
+        for event in &*events {
+            match rmp_serde::to_vec(event) {
+                Ok(payload) => {
+                    batch.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+                    batch.extend_from_slice(&payload);
+                }
+                Err(e) => error!("unable to serialize event: {e}"),
+            }
+        }
+        writer.write_all(&batch).await?;
+        Ok(())
+    }
+
     async fn shutdown(mut self: Box<Self>) -> ExporterResult<()> {
         let Some(mut writer) = self.writer.take() else {
             return Ok(());

--- a/crates/io/msgpack/src/lib.rs
+++ b/crates/io/msgpack/src/lib.rs
@@ -68,14 +68,17 @@ where
         Ok(())
     }
 
-    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
-        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+    async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
+        let Some(writer) = self.writer.as_mut() else {
+            events.clear();
+            return Err(ExporterError::Shutdown);
+        };
         // Frame the whole batch into one buffer, then issue a single write. A
         // record that fails to serialize is logged and skipped so one bad event
         // does not drop the batch.
         let mut batch = Vec::new();
-        for event in &*events {
-            match rmp_serde::to_vec(event) {
+        for event in events.drain(..) {
+            match rmp_serde::to_vec(&event) {
                 Ok(payload) => {
                     batch.extend_from_slice(&(payload.len() as u32).to_be_bytes());
                     batch.extend_from_slice(&payload);

--- a/crates/io/ndjson/src/lib.rs
+++ b/crates/io/ndjson/src/lib.rs
@@ -37,6 +37,8 @@ pub struct NdjsonExporterOptions {
 pub struct NdjsonExporter {
     /// `None` once [`shutdown`](Exporter::shutdown) has flushed and released it.
     writer: Option<BufWriter<File>>,
+    /// Line buffer reused across [`drain_events`](Exporter::drain_events).
+    batch: String,
 }
 
 impl NdjsonExporter {
@@ -53,6 +55,7 @@ impl NdjsonExporter {
 
         Ok(Self {
             writer: Some(BufWriter::new(file)),
+            batch: String::new(),
         })
     }
 }
@@ -73,14 +76,15 @@ where
     }
 
     async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
-        let Some(writer) = self.writer.as_mut() else {
+        let Self { writer, batch } = self;
+        let Some(writer) = writer.as_mut() else {
             events.clear();
             return Err(ExporterError::Shutdown);
         };
-        // Concatenate the whole batch into one buffer, then issue a single
-        // write. A record that fails to serialize is logged and skipped so one
-        // bad event does not drop the batch.
-        let mut batch = String::new();
+        // Concatenate the whole batch into the reused buffer, then issue a
+        // single write. A record that fails to serialize is logged and skipped
+        // so one bad event does not drop the batch.
+        batch.clear();
         for event in events.drain(..) {
             match serde_json::to_string(&event) {
                 Ok(line) => {

--- a/crates/io/ndjson/src/lib.rs
+++ b/crates/io/ndjson/src/lib.rs
@@ -72,6 +72,25 @@ where
         Ok(())
     }
 
+    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
+        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+        // Concatenate the whole batch into one buffer, then issue a single
+        // write. A record that fails to serialize is logged and skipped so one
+        // bad event does not drop the batch.
+        let mut batch = String::new();
+        for event in &*events {
+            match serde_json::to_string(event) {
+                Ok(line) => {
+                    batch.push_str(&line);
+                    batch.push('\n');
+                }
+                Err(e) => error!("unable to serialize event: {e}"),
+            }
+        }
+        writer.write_all(batch.as_bytes()).await?;
+        Ok(())
+    }
+
     async fn shutdown(mut self: Box<Self>) -> ExporterResult<()> {
         let Some(mut writer) = self.writer.take() else {
             return Ok(());

--- a/crates/io/ndjson/src/lib.rs
+++ b/crates/io/ndjson/src/lib.rs
@@ -72,14 +72,17 @@ where
         Ok(())
     }
 
-    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
-        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+    async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
+        let Some(writer) = self.writer.as_mut() else {
+            events.clear();
+            return Err(ExporterError::Shutdown);
+        };
         // Concatenate the whole batch into one buffer, then issue a single
         // write. A record that fails to serialize is logged and skipped so one
         // bad event does not drop the batch.
         let mut batch = String::new();
-        for event in &*events {
-            match serde_json::to_string(event) {
+        for event in events.drain(..) {
+            match serde_json::to_string(&event) {
                 Ok(line) => {
                     batch.push_str(&line);
                     batch.push('\n');

--- a/crates/io/ndjson/src/lib.rs
+++ b/crates/io/ndjson/src/lib.rs
@@ -15,7 +15,7 @@ use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncWriteExt, BufWriter},
 };
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 /// File extension for ndjson event files.
@@ -91,7 +91,7 @@ where
                     batch.push_str(&line);
                     batch.push('\n');
                 }
-                Err(e) => error!("unable to serialize event: {e}"),
+                Err(e) => warn!("unable to serialize event: {e}"),
             }
         }
         writer.write_all(batch.as_bytes()).await?;

--- a/crates/io/postcard/src/lib.rs
+++ b/crates/io/postcard/src/lib.rs
@@ -68,14 +68,17 @@ where
         Ok(())
     }
 
-    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
-        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+    async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
+        let Some(writer) = self.writer.as_mut() else {
+            events.clear();
+            return Err(ExporterError::Shutdown);
+        };
         // Frame the whole batch into one buffer, then issue a single write. A
         // record that fails to serialize is logged and skipped so one bad event
         // does not drop the batch.
         let mut batch = Vec::new();
-        for event in &*events {
-            match postcard::to_allocvec(event) {
+        for event in events.drain(..) {
+            match postcard::to_allocvec(&event) {
                 Ok(payload) => {
                     batch.extend_from_slice(&(payload.len() as u32).to_be_bytes());
                     batch.extend_from_slice(&payload);

--- a/crates/io/postcard/src/lib.rs
+++ b/crates/io/postcard/src/lib.rs
@@ -35,6 +35,8 @@ pub struct PostcardExporterOptions {
 pub struct PostcardExporter {
     /// `None` once [`shutdown`](Exporter::shutdown) has flushed and released it.
     writer: Option<BufWriter<File>>,
+    /// Framing buffer reused across [`drain_events`](Exporter::drain_events).
+    batch: Vec<u8>,
 }
 
 impl PostcardExporter {
@@ -50,6 +52,7 @@ impl PostcardExporter {
             .await?;
         Ok(Self {
             writer: Some(BufWriter::new(file)),
+            batch: Vec::new(),
         })
     }
 }
@@ -69,14 +72,15 @@ where
     }
 
     async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
-        let Some(writer) = self.writer.as_mut() else {
+        let Self { writer, batch } = self;
+        let Some(writer) = writer.as_mut() else {
             events.clear();
             return Err(ExporterError::Shutdown);
         };
-        // Frame the whole batch into one buffer, then issue a single write. A
-        // record that fails to serialize is logged and skipped so one bad event
-        // does not drop the batch.
-        let mut batch = Vec::new();
+        // Frame the whole batch into the reused buffer, then issue a single
+        // write. A record that fails to serialize is logged and skipped so one
+        // bad event does not drop the batch.
+        batch.clear();
         for event in events.drain(..) {
             match postcard::to_allocvec(&event) {
                 Ok(payload) => {
@@ -86,7 +90,7 @@ where
                 Err(e) => error!("unable to serialize event: {e}"),
             }
         }
-        writer.write_all(&batch).await?;
+        writer.write_all(batch).await?;
         Ok(())
     }
 

--- a/crates/io/postcard/src/lib.rs
+++ b/crates/io/postcard/src/lib.rs
@@ -68,6 +68,25 @@ where
         Ok(())
     }
 
+    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()> {
+        let writer = self.writer.as_mut().ok_or(ExporterError::Shutdown)?;
+        // Frame the whole batch into one buffer, then issue a single write. A
+        // record that fails to serialize is logged and skipped so one bad event
+        // does not drop the batch.
+        let mut batch = Vec::new();
+        for event in &*events {
+            match postcard::to_allocvec(event) {
+                Ok(payload) => {
+                    batch.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+                    batch.extend_from_slice(&payload);
+                }
+                Err(e) => error!("unable to serialize event: {e}"),
+            }
+        }
+        writer.write_all(&batch).await?;
+        Ok(())
+    }
+
     async fn shutdown(mut self: Box<Self>) -> ExporterResult<()> {
         let Some(mut writer) = self.writer.take() else {
             return Ok(());

--- a/crates/io/postcard/src/lib.rs
+++ b/crates/io/postcard/src/lib.rs
@@ -14,7 +14,7 @@ use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncWriteExt, BufWriter},
 };
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 /// File extension for Postcard event files.
@@ -87,7 +87,7 @@ where
                     batch.extend_from_slice(&(payload.len() as u32).to_be_bytes());
                     batch.extend_from_slice(&payload);
                 }
-                Err(e) => error!("unable to serialize event: {e}"),
+                Err(e) => warn!("unable to serialize event: {e}"),
             }
         }
         writer.write_all(batch).await?;

--- a/crates/io/types/Cargo.toml
+++ b/crates/io/types/Cargo.toml
@@ -8,4 +8,5 @@ publish.workspace = true
 async-trait.workspace = true
 quent-events = { path = "../../events" }
 thiserror.workspace = true
+tracing.workspace = true
 uuid.workspace = true

--- a/crates/io/types/src/lib.rs
+++ b/crates/io/types/src/lib.rs
@@ -6,6 +6,7 @@
 use quent_events::Event;
 use std::num::NonZeroUsize;
 use thiserror::Error;
+use tracing::warn;
 use uuid::Uuid;
 
 /// A sink for one entity's event stream.
@@ -23,19 +24,22 @@ pub trait Exporter<T>: Send {
     ///
     /// Callers may pass fewer in [`drain_events`], or ignore it completely.
     fn batch_size_hint(&self) -> NonZeroUsize {
-        NonZeroUsize::new(256).unwrap()
+        const { NonZeroUsize::new(256).unwrap() }
     }
 
     /// Exports every event in `events`, in order, leaving it empty.
     ///
-    /// The default forwards each event to [`push`](Self::push). Override this
-    /// to amortize per-event overhead.
+    /// The default forwards each event to [`push`](Self::push), logging and
+    /// skipping any that fail so one failure does not drop the rest of the
+    /// batch. Override this to amortize per-event overhead.
     async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()>
     where
         T: Send + 'async_trait,
     {
         for event in events.drain(..) {
-            self.push(event).await?;
+            if let Err(e) = self.push(event).await {
+                warn!("unable to export event: {e}");
+            }
         }
         Ok(())
     }

--- a/crates/io/types/src/lib.rs
+++ b/crates/io/types/src/lib.rs
@@ -4,6 +4,7 @@
 //! Basic traits for exporter / importer implementations
 
 use quent_events::Event;
+use std::num::NonZeroUsize;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -18,14 +19,18 @@ pub trait Exporter<T>: Send {
     /// Export one event.
     async fn push(&mut self, event: Event<T>) -> ExporterResult<()>;
 
-    /// Export every event in `events`, in order.
+    /// Suggested max events per [`drain_events`](Self::drain_events) batch.
     ///
-    /// The contents of `events` on return are unspecified, a caller reusing the
-    /// buffer across batches must clear it.
+    /// Callers may pass fewer in [`drain_events`], or ignore it completely.
+    fn batch_size_hint(&self) -> NonZeroUsize {
+        NonZeroUsize::new(256).unwrap()
+    }
+
+    /// Exports every event in `events`, in order, leaving it empty.
     ///
     /// The default forwards each event to [`push`](Self::push). Override this
     /// to amortize per-event overhead.
-    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()>
+    async fn drain_events(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()>
     where
         T: Send + 'async_trait,
     {
@@ -35,7 +40,7 @@ pub trait Exporter<T>: Send {
         Ok(())
     }
 
-    /// Make a best-effort to flush any buffered events, then release any internal resources.
+    /// Make a best-effort to flush any buffered events.
     async fn shutdown(self: Box<Self>) -> ExporterResult<()>;
 }
 

--- a/crates/io/types/src/lib.rs
+++ b/crates/io/types/src/lib.rs
@@ -18,6 +18,23 @@ pub trait Exporter<T>: Send {
     /// Export one event.
     async fn push(&mut self, event: Event<T>) -> ExporterResult<()>;
 
+    /// Export every event in `events`, in order.
+    ///
+    /// The contents of `events` on return are unspecified, a caller reusing the
+    /// buffer across batches must clear it.
+    ///
+    /// The default forwards each event to [`push`](Self::push). Override this
+    /// to amortize per-event overhead.
+    async fn push_many(&mut self, events: &mut Vec<Event<T>>) -> ExporterResult<()>
+    where
+        T: Send + 'async_trait,
+    {
+        for event in events.drain(..) {
+            self.push(event).await?;
+        }
+        Ok(())
+    }
+
     /// Make a best-effort to flush any buffered events, then release any internal resources.
     async fn shutdown(self: Box<Self>) -> ExporterResult<()>;
 }


### PR DESCRIPTION
# Description

This PR adds `Exporter::drain_events` (default drains through single event pushes).

The observer forwarder task now drains the unbounded channel with `recv_many` and exports a batch per call instead of one call per event. It reuses one buffer which is reserved with `Exporter::batch_size_hint` before each `recv_many`.

For now only the msgpack/ndjson/postcard exporters override `drain_events` to export an event batch into one write buffer and then issue a single write. Callback and collector keep the default. I think the collector could leverage this too to shave off some overhead but that is a bit more work.