### PR TITLE
refactor(schema): align the EventBuilder API with the builder conventions

### DIFF
--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -3,11 +3,18 @@
 
 use quent_constraints::{Constraint, validate};
 use quent_schema::{
-    Cardinality, DataType, Field, Schema,
+    Annotations, Cardinality, DataType, Field, Schema,
     builder::{AnnotationsBuilder, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder},
     test_utils::{self, entity, event, field, ident, schema},
     visitor::{Cursor, Visitor},
 };
+
+/// Annotations carrying the constraint `name` without data.
+fn constraint(name: &str) -> Annotations {
+    let mut builder = AnnotationsBuilder::new();
+    builder.try_insert_constraint(name, None).unwrap();
+    builder.build()
+}
 
 fn empty_schema() -> Schema {
     test_utils::schema("TestSchema", vec![], vec![])
@@ -88,12 +95,7 @@ fn passing_constraint_on_empty_schema() {
 #[test]
 fn constraint_without_validator_is_unregistered() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint("unknown", None)
-                .unwrap()
-                .build(),
-        )
+        .annotations(constraint("unknown"))
         .build();
     let report = validate::<(NoopA,)>(&schema);
     assert_eq!(report.unregistered_constraints.len(), 1);
@@ -109,12 +111,11 @@ fn constraint_without_validator_is_unregistered() {
 #[test]
 fn metadata_is_never_validated() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .metadata("not_validated", None)
-                .unwrap()
-                .build(),
-        )
+        .annotations({
+            let mut builder = AnnotationsBuilder::new();
+            builder.try_insert_metadata("not_validated", None).unwrap();
+            builder.build()
+        })
         .build();
     let report = validate::<(NoopA,)>(&schema);
     assert!(report.unregistered_constraints.is_empty());
@@ -122,12 +123,7 @@ fn metadata_is_never_validated() {
 
 #[test]
 fn unregistered_constraint_is_reported_once() {
-    let unknown = || {
-        AnnotationsBuilder::new()
-            .constraint("unknown", None)
-            .unwrap()
-            .build()
-    };
+    let unknown = || constraint("unknown");
     let field = Field::new(ident("ef"), DataType::U64, unknown());
     let event = EventBuilder::new(ident("Ev"), Cardinality::Once)
         .field(field)
@@ -174,12 +170,7 @@ fn constraint_failure_is_reported_per_constraint() {
 #[test]
 fn unregistered_and_failure_aggregate() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint("unknown", None)
-                .unwrap()
-                .build(),
-        )
+        .annotations(constraint("unknown"))
         .build();
     let report = validate::<(Failing,)>(&schema);
     assert!(

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -11,9 +11,10 @@ use quent_schema::{
 
 /// Annotations carrying the constraint `name` without data.
 fn constraint(name: &str) -> Annotations {
-    let mut builder = AnnotationsBuilder::new();
-    builder.try_insert_constraint(name, None).unwrap();
-    builder.build()
+    AnnotationsBuilder::new()
+        .try_with_constraint(name, None)
+        .unwrap()
+        .build()
 }
 
 fn empty_schema() -> Schema {
@@ -111,11 +112,12 @@ fn constraint_without_validator_is_unregistered() {
 #[test]
 fn metadata_is_never_validated() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations({
-            let mut builder = AnnotationsBuilder::new();
-            builder.try_insert_metadata("not_validated", None).unwrap();
-            builder.build()
-        })
+        .annotations(
+            AnnotationsBuilder::new()
+                .try_with_metadata("not_validated", None)
+                .unwrap()
+                .build(),
+        )
         .build();
     let report = validate::<(NoopA,)>(&schema);
     assert!(report.unregistered_constraints.is_empty());

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -128,9 +128,9 @@ fn unregistered_constraint_is_reported_once() {
     let unknown = || constraint("unknown");
     let field = Field::new(ident("ef"), DataType::U64, unknown());
     let event = EventBuilder::new(ident("Ev"), Cardinality::Once)
-        .field(field)
+        .try_with_field(field)
         .unwrap()
-        .annotations(unknown())
+        .with_annotations(unknown())
         .build();
     let entity = EntityBuilder::new(ident("E"))
         .event(event)

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -139,9 +139,9 @@ fn unregistered_constraint_is_reported_once() {
         .build();
     let record_field = Field::new(ident("rf"), DataType::U64, unknown());
     let record = RecordBuilder::new(ident("R"))
-        .field(record_field)
+        .try_with_field(record_field)
         .unwrap()
-        .annotations(unknown())
+        .with_annotations(unknown())
         .build();
     let schema = SchemaBuilder::new(ident("S"))
         .entity(entity)

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -4,7 +4,7 @@
 use quent_constraints::Constraint as _;
 use quent_fsm::{Fsm, FsmConstraint, FsmError};
 use quent_schema::{
-    Cardinality, Entity, Event, Schema,
+    Annotations, Cardinality, Entity, Event, Schema,
     builder::{AnnotationsBuilder, EntityBuilder},
     test_utils::{entity as bare_entity, event_with, ident, schema},
 };
@@ -28,16 +28,20 @@ fn fsm(initial: &str, transitions: &[(&str, &str)], exit: &[&str]) -> String {
     .to_string()
 }
 
+/// Annotations carrying the FSM constraint with `data`.
+fn fsm_annotations(data: Option<String>) -> Annotations {
+    let mut builder = AnnotationsBuilder::new();
+    builder
+        .try_insert_constraint(FsmConstraint::NAME, data)
+        .unwrap();
+    builder.build()
+}
+
 fn entity_with(name: &str, events: Vec<Event>, data: &str) -> Entity {
     EntityBuilder::new(ident(name))
         .events(events)
         .unwrap()
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint(FsmConstraint::NAME, Some(data.to_string()))
-                .unwrap()
-                .build(),
-        )
+        .annotations(fsm_annotations(Some(data.to_string())))
         .build()
 }
 
@@ -84,12 +88,7 @@ fn missing_data_is_rejected() {
     let entity = EntityBuilder::new(ident("E"))
         .event(event("a", Cardinality::Once))
         .unwrap()
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint(FsmConstraint::NAME, None)
-                .unwrap()
-                .build(),
-        )
+        .annotations(fsm_annotations(None))
         .build();
     let errors = validate(&schema_with(entity));
     assert!(
@@ -104,12 +103,7 @@ fn invalid_json_is_rejected() {
     let entity = EntityBuilder::new(ident("E"))
         .event(event("a", Cardinality::Once))
         .unwrap()
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint(FsmConstraint::NAME, Some("{ trash".to_string()))
-                .unwrap()
-                .build(),
-        )
+        .annotations(fsm_annotations(Some("{ trash".to_string())))
         .build();
     let errors = validate(&schema_with(entity));
     assert!(

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -30,11 +30,10 @@ fn fsm(initial: &str, transitions: &[(&str, &str)], exit: &[&str]) -> String {
 
 /// Annotations carrying the FSM constraint with `data`.
 fn fsm_annotations(data: Option<String>) -> Annotations {
-    let mut builder = AnnotationsBuilder::new();
-    builder
-        .try_insert_constraint(FsmConstraint::NAME, data)
-        .unwrap();
-    builder.build()
+    AnnotationsBuilder::new()
+        .try_with_constraint(FsmConstraint::NAME, data)
+        .unwrap()
+        .build()
 }
 
 fn entity_with(name: &str, events: Vec<Event>, data: &str) -> Entity {

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -41,20 +41,18 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
     let endpoint = RecordBuilder::new(ident("Endpoint"))
-        .annotations(docs("A network endpoint."))
-        .fields([
+        .with_annotations(docs("A network endpoint."))
+        .try_with_fields([
             field("host", DataType::String),
             field("port", DataType::U16),
-        ])
-        .unwrap()
+        ])?
         .build();
 
     let meta = RecordBuilder::new(ident("Meta"))
-        .fields([
+        .try_with_fields([
             field("tags", DataType::List(Box::new(DataType::String))),
             field("extra", DataType::DynamicRecord),
-        ])
-        .unwrap()
+        ])?
         .build();
 
     let connection = EntityBuilder::new(ident("Connection"))

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -59,21 +59,19 @@ fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
         .annotations(docs("A client connection."))
         .events([
             EventBuilder::new(ident("opened"), Cardinality::Once)
-                .fields([
+                .try_with_fields([
                     field("peer", DataType::Record(ident("Endpoint"))),
                     field("session", DataType::Uuid),
-                ])
-                .unwrap()
+                ])?
                 .build(),
             EventBuilder::new(ident("data"), Cardinality::Multi)
-                .fields([
+                .try_with_fields([
                     field("bytes", DataType::U64),
                     field(
                         "meta",
                         DataType::Option(Box::new(DataType::Record(ident("Meta")))),
                     ),
-                ])
-                .unwrap()
+                ])?
                 .build(),
             EventBuilder::new(ident("closed"), Cardinality::Once).build(),
         ])

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -6,7 +6,14 @@ use quent_schema::builder::{
     AnnotationsBuilder, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder,
 };
 use quent_schema::test_utils::{field, ident};
-use quent_schema::{Cardinality, DataType, Schema};
+use quent_schema::{Annotations, Cardinality, DataType, Schema};
+
+/// Annotations carrying only a documentation string.
+fn docs(text: &str) -> Annotations {
+    let mut builder = AnnotationsBuilder::new();
+    builder.set_docs(text);
+    builder.build()
+}
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=build.rs");
@@ -34,11 +41,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
     let endpoint = RecordBuilder::new(ident("Endpoint"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .docs("A network endpoint.")
-                .build(),
-        )
+        .annotations(docs("A network endpoint."))
         .fields([
             field("host", DataType::String),
             field("port", DataType::U16),
@@ -55,11 +58,7 @@ fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
         .build();
 
     let connection = EntityBuilder::new(ident("Connection"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .docs("A client connection.")
-                .build(),
-        )
+        .annotations(docs("A client connection."))
         .events([
             EventBuilder::new(ident("opened"), Cardinality::Once)
                 .fields([

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -135,7 +135,11 @@ mod tests {
 
     #[test]
     fn docs_annotations_become_doc_attributes() {
-        let docs = |text: &str| AnnotationsBuilder::new().docs(text).build();
+        let docs = |text: &str| {
+            let mut builder = AnnotationsBuilder::new();
+            builder.set_docs(text);
+            builder.build()
+        };
         let field_x = Field::new(ident("x"), DataType::U8, docs("field doc"));
         let ev = EventBuilder::new(ident("ev"), Cardinality::Once)
             .fields([field_x])

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -142,9 +142,9 @@ mod tests {
         };
         let field_x = Field::new(ident("x"), DataType::U8, docs("field doc"));
         let ev = EventBuilder::new(ident("ev"), Cardinality::Once)
-            .fields([field_x])
+            .try_with_field(field_x)
             .unwrap()
-            .annotations(docs("event doc"))
+            .with_annotations(docs("event doc"))
             .build();
         let en = EntityBuilder::new(ident("E"))
             .events([ev])

--- a/crates/instrumentation-build/src/runtime/mod.rs
+++ b/crates/instrumentation-build/src/runtime/mod.rs
@@ -99,7 +99,7 @@ mod tests {
     fn generate_assembles_event_impl_observer_handle_and_context() {
         let connection = EntityBuilder::new(ident("Connection"))
             .events([EventBuilder::new(ident("data"), Cardinality::Multi)
-                .fields([field("bytes", DataType::U64)])
+                .try_with_field(field("bytes", DataType::U64))
                 .unwrap()
                 .build()])
             .unwrap()

--- a/crates/ref-target/tests/ref-target-constraint.rs
+++ b/crates/ref-target/tests/ref-target-constraint.rs
@@ -12,10 +12,13 @@ use quent_schema::{
 fn entity_ref(target: Option<&str>) -> DataType {
     DataType::EntityRef {
         data: None,
-        annotations: AnnotationsBuilder::new()
-            .constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
-            .unwrap()
-            .build(),
+        annotations: {
+            let mut builder = AnnotationsBuilder::new();
+            builder
+                .try_insert_constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
+                .unwrap();
+            builder.build()
+        },
     }
 }
 

--- a/crates/ref-target/tests/ref-target-constraint.rs
+++ b/crates/ref-target/tests/ref-target-constraint.rs
@@ -12,13 +12,10 @@ use quent_schema::{
 fn entity_ref(target: Option<&str>) -> DataType {
     DataType::EntityRef {
         data: None,
-        annotations: {
-            let mut builder = AnnotationsBuilder::new();
-            builder
-                .try_insert_constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
-                .unwrap();
-            builder.build()
-        },
+        annotations: AnnotationsBuilder::new()
+            .try_with_constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
+            .unwrap()
+            .build(),
     }
 }
 

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -12,25 +12,27 @@ use quent_schema::{
 
 /// A type-erased tree-forming reference (no target).
 fn tree_ref() -> DataType {
+    let mut builder = AnnotationsBuilder::new();
+    builder
+        .try_insert_constraint(RefTreeConstraint::NAME, None)
+        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: AnnotationsBuilder::new()
-            .constraint(RefTreeConstraint::NAME, None)
-            .unwrap()
-            .build(),
+        annotations: builder.build(),
     }
 }
 
 /// A tree-forming reference restricted to a specific parent entity type.
 fn tree_ref_to(target: &str) -> DataType {
+    let mut builder = AnnotationsBuilder::new();
+    builder
+        .try_insert_constraint(RefTreeConstraint::NAME, None)
+        .unwrap()
+        .try_insert_constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
+        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: AnnotationsBuilder::new()
-            .constraint(RefTreeConstraint::NAME, None)
-            .unwrap()
-            .constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
-            .unwrap()
-            .build(),
+        annotations: builder.build(),
     }
 }
 

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -12,27 +12,25 @@ use quent_schema::{
 
 /// A type-erased tree-forming reference (no target).
 fn tree_ref() -> DataType {
-    let mut builder = AnnotationsBuilder::new();
-    builder
-        .try_insert_constraint(RefTreeConstraint::NAME, None)
-        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: builder.build(),
+        annotations: AnnotationsBuilder::new()
+            .try_with_constraint(RefTreeConstraint::NAME, None)
+            .unwrap()
+            .build(),
     }
 }
 
 /// A tree-forming reference restricted to a specific parent entity type.
 fn tree_ref_to(target: &str) -> DataType {
-    let mut builder = AnnotationsBuilder::new();
-    builder
-        .try_insert_constraint(RefTreeConstraint::NAME, None)
-        .unwrap()
-        .try_insert_constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
-        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: builder.build(),
+        annotations: AnnotationsBuilder::new()
+            .try_with_constraint(RefTreeConstraint::NAME, None)
+            .unwrap()
+            .try_with_constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
+            .unwrap()
+            .build(),
     }
 }
 

--- a/crates/schema/src/builder/annotations.rs
+++ b/crates/schema/src/builder/annotations.rs
@@ -91,6 +91,20 @@ impl AnnotationsBuilder {
         Ok(self)
     }
 
+    /// Add a constraint named `name`, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_with_constraint(
+        mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Result<Self, BuilderError> {
+        self.try_insert_constraint(name, data)?;
+        Ok(self)
+    }
+
     /// Set the constraint named `name`, returning the replaced entry, if any.
     pub fn set_constraint(
         &mut self,
@@ -120,6 +134,20 @@ impl AnnotationsBuilder {
         let name = name.into();
         self.metadata
             .try_insert(name.clone(), Metadata::from_parts(name, data))?;
+        Ok(self)
+    }
+
+    /// Add a metadata entry named `name`, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_with_metadata(
+        mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Result<Self, BuilderError> {
+        self.try_insert_metadata(name, data)?;
         Ok(self)
     }
 

--- a/crates/schema/src/builder/annotations.rs
+++ b/crates/schema/src/builder/annotations.rs
@@ -5,18 +5,25 @@ use crate::builder::{BuilderError, insert_unique};
 use crate::schema::Map;
 use crate::{Annotations, Constraint, Metadata};
 
-/// Builder for a map of named, optionally-valued string items.
-#[derive(Default)]
-struct OpaqueMapBuilder(Map<String, Option<String>>);
+/// Builder for a map of named items.
+struct OpaqueMapBuilder<T>(Map<String, T>);
 
-impl OpaqueMapBuilder {
-    fn add(mut self, name: impl Into<String>, data: Option<String>) -> Result<Self, BuilderError> {
-        let name = name.into();
+impl<T> Default for OpaqueMapBuilder<T> {
+    fn default() -> Self {
+        Self(Map::default())
+    }
+}
+
+impl<T> OpaqueMapBuilder<T> {
+    fn try_insert(&mut self, name: String, value: T) -> Result<(), BuilderError> {
         if name.is_empty() {
             return Err(BuilderError::EmptyName);
         }
-        insert_unique(&mut self.0, name.clone(), data)?;
-        Ok(self)
+        insert_unique(&mut self.0, name, value)
+    }
+
+    fn set(&mut self, name: String, value: T) -> Option<T> {
+        self.0.insert(name, value)
     }
 }
 
@@ -24,8 +31,8 @@ impl OpaqueMapBuilder {
 #[derive(Default)]
 pub struct AnnotationsBuilder {
     docs: Option<String>,
-    constraints: OpaqueMapBuilder,
-    metadata: OpaqueMapBuilder,
+    constraints: OpaqueMapBuilder<Constraint>,
+    metadata: OpaqueMapBuilder<Metadata>,
 }
 
 impl AnnotationsBuilder {
@@ -34,46 +41,101 @@ impl AnnotationsBuilder {
         Self::default()
     }
 
-    /// Set the documentation string.
-    pub fn docs(mut self, docs: impl Into<String>) -> Self {
-        self.docs = Some(docs.into());
-        self
+    /// Start from existing annotations.
+    pub fn from_annotations(annotations: &Annotations) -> Self {
+        Self {
+            docs: annotations.docs().map(str::to_owned),
+            constraints: OpaqueMapBuilder(
+                annotations
+                    .constraints()
+                    .map(|c| (c.name().to_owned(), c.clone()))
+                    .collect(),
+            ),
+            metadata: OpaqueMapBuilder(
+                annotations
+                    .metadata_entries()
+                    .map(|m| (m.name().to_owned(), m.clone()))
+                    .collect(),
+            ),
+        }
     }
 
-    /// Add a constraint named `name`. Errors if `name` is empty or already declared.
-    pub fn constraint(
-        mut self,
+    /// The documentation, if set.
+    pub fn docs(&self) -> Option<&str> {
+        self.docs.as_deref()
+    }
+
+    /// Set the documentation string, returning the replaced one, if any.
+    pub fn set_docs(&mut self, docs: impl Into<String>) -> Option<String> {
+        self.docs.replace(docs.into())
+    }
+
+    /// The constraint declared under `name`, if any.
+    pub fn constraint(&self, name: &str) -> Option<&Constraint> {
+        self.constraints.0.get(name)
+    }
+
+    /// Add a constraint named `name`.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_insert_constraint(
+        &mut self,
         name: impl Into<String>,
         data: Option<String>,
-    ) -> Result<Self, BuilderError> {
-        self.constraints = self.constraints.add(name, data)?;
+    ) -> Result<&mut Self, BuilderError> {
+        let name = name.into();
+        self.constraints
+            .try_insert(name.clone(), Constraint::from_parts(name, data))?;
         Ok(self)
     }
 
-    /// Add a metadata entry named `name`. Errors if `name` is empty or already declared.
-    pub fn metadata(
-        mut self,
+    /// Set the constraint named `name`, returning the replaced entry, if any.
+    pub fn set_constraint(
+        &mut self,
         name: impl Into<String>,
         data: Option<String>,
-    ) -> Result<Self, BuilderError> {
-        self.metadata = self.metadata.add(name, data)?;
+    ) -> Option<Constraint> {
+        let name = name.into();
+        self.constraints
+            .set(name.clone(), Constraint::from_parts(name, data))
+    }
+
+    /// The metadata entry declared under `name`, if any.
+    pub fn metadata(&self, name: &str) -> Option<&Metadata> {
+        self.metadata.0.get(name)
+    }
+
+    /// Add a metadata entry named `name`.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_insert_metadata(
+        &mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Result<&mut Self, BuilderError> {
+        let name = name.into();
+        self.metadata
+            .try_insert(name.clone(), Metadata::from_parts(name, data))?;
         Ok(self)
+    }
+
+    /// Set the metadata entry named `name`, returning the replaced entry, if any.
+    pub fn set_metadata(
+        &mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Option<Metadata> {
+        let name = name.into();
+        self.metadata
+            .set(name.clone(), Metadata::from_parts(name, data))
     }
 
     /// Finish building the annotations.
     pub fn build(self) -> Annotations {
-        Annotations::from_parts(
-            self.docs,
-            self.constraints
-                .0
-                .into_iter()
-                .map(|(k, v)| (k.clone(), Constraint::from_parts(k, v)))
-                .collect(),
-            self.metadata
-                .0
-                .into_iter()
-                .map(|(k, v)| (k.clone(), Metadata::from_parts(k, v)))
-                .collect(),
-        )
+        Annotations::from_parts(self.docs, self.constraints.0, self.metadata.0)
     }
 }

--- a/crates/schema/src/builder/event.rs
+++ b/crates/schema/src/builder/event.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::builder::{BuilderError, insert_unique};
+use crate::builder::{AnnotationsBuilder, BuilderError, insert_unique};
 use crate::schema::Map;
+use crate::schema::identifier::IdentifierError;
 use crate::{Annotations, Cardinality, Event, Field, Identifier};
 
 /// Builder for an [`Event`].
@@ -10,7 +11,7 @@ pub struct EventBuilder {
     name: Identifier,
     cardinality: Cardinality,
     payload: Map<Identifier, Field>,
-    annotations: Annotations,
+    annotations: AnnotationsBuilder,
 }
 
 impl EventBuilder {
@@ -20,32 +21,108 @@ impl EventBuilder {
             name,
             cardinality,
             payload: Map::default(),
-            annotations: Annotations::default(),
+            annotations: AnnotationsBuilder::new(),
         }
     }
 
-    /// Add a payload field. Errors if its name is already declared.
-    pub fn field(mut self, field: Field) -> Result<Self, BuilderError> {
+    /// Start an event named `name` with the given `cardinality`, validating
+    /// `name` as an [`Identifier`].
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is not a valid identifier.
+    pub fn try_new(
+        name: impl TryInto<Identifier, Error = IdentifierError>,
+        cardinality: Cardinality,
+    ) -> Result<Self, IdentifierError> {
+        Ok(Self::new(name.try_into()?, cardinality))
+    }
+
+    /// The name of the event.
+    pub fn name(&self) -> &Identifier {
+        &self.name
+    }
+
+    /// The cardinality of the event.
+    pub fn cardinality(&self) -> Cardinality {
+        self.cardinality
+    }
+
+    /// Set the cardinality of the event, returning the previous one.
+    pub fn set_cardinality(&mut self, cardinality: Cardinality) -> Cardinality {
+        std::mem::replace(&mut self.cardinality, cardinality)
+    }
+
+    /// The payload field declared under `name`, if any.
+    pub fn field(&self, name: &Identifier) -> Option<&Field> {
+        self.payload.get(name)
+    }
+
+    /// Set a payload field, returning the replaced one with the same name, if
+    /// any.
+    pub fn set_field(&mut self, field: Field) -> Option<Field> {
+        self.payload.insert(field.name().clone(), field)
+    }
+
+    /// Add a payload field.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_field(&mut self, field: Field) -> Result<&mut Self, BuilderError> {
         insert_unique(&mut self.payload, field.name().clone(), field)?;
         Ok(self)
     }
 
-    /// Add several payload fields. Errors on the first duplicate name.
-    pub fn fields(mut self, fields: impl IntoIterator<Item = Field>) -> Result<Self, BuilderError> {
+    /// Add a payload field, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_field(mut self, field: Field) -> Result<Self, BuilderError> {
+        self.try_insert_field(field)?;
+        Ok(self)
+    }
+
+    /// Add several payload fields, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_fields(
+        mut self,
+        fields: impl IntoIterator<Item = Field>,
+    ) -> Result<Self, BuilderError> {
         for field in fields {
-            self = self.field(field)?;
+            self.try_insert_field(field)?;
         }
         Ok(self)
     }
 
-    /// Set the event's annotations.
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = annotations;
+    /// The annotations of the event.
+    pub fn annotations(&self) -> &AnnotationsBuilder {
+        &self.annotations
+    }
+
+    /// The annotations of the event.
+    pub fn annotations_mut(&mut self) -> &mut AnnotationsBuilder {
+        &mut self.annotations
+    }
+
+    /// Set the event's annotations, replacing any added so far, and return the
+    /// builder for chaining.
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = AnnotationsBuilder::from_annotations(&annotations);
         self
     }
 
     /// Finish building the event.
     pub fn build(self) -> Event {
-        Event::from_parts(self.name, self.cardinality, self.payload, self.annotations)
+        Event::from_parts(
+            self.name,
+            self.cardinality,
+            self.payload,
+            self.annotations.build(),
+        )
     }
 }

--- a/crates/schema/src/builder/record.rs
+++ b/crates/schema/src/builder/record.rs
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::builder::{BuilderError, insert_unique};
+use crate::builder::{AnnotationsBuilder, BuilderError, insert_unique};
 use crate::schema::Map;
+use crate::schema::identifier::IdentifierError;
 use crate::{Annotations, Field, Identifier, Record};
 
 /// Builder for a [`Record`].
 pub struct RecordBuilder {
     name: Identifier,
     fields: Map<Identifier, Field>,
-    annotations: Annotations,
+    annotations: AnnotationsBuilder,
 }
 
 impl RecordBuilder {
@@ -18,32 +19,90 @@ impl RecordBuilder {
         Self {
             name,
             fields: Map::default(),
-            annotations: Annotations::default(),
+            annotations: AnnotationsBuilder::new(),
         }
     }
 
-    /// Add a field. Errors if its name is already declared.
-    pub fn field(mut self, field: Field) -> Result<Self, BuilderError> {
+    /// Start a record named `name`, validating `name` as an [`Identifier`].
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is not a valid identifier.
+    pub fn try_new(
+        name: impl TryInto<Identifier, Error = IdentifierError>,
+    ) -> Result<Self, IdentifierError> {
+        Ok(Self::new(name.try_into()?))
+    }
+
+    /// The name of the record.
+    pub fn name(&self) -> &Identifier {
+        &self.name
+    }
+
+    /// The field declared under `name`, if any.
+    pub fn field(&self, name: &Identifier) -> Option<&Field> {
+        self.fields.get(name)
+    }
+
+    /// Set a field, returning the replaced one with the same name, if any.
+    pub fn set_field(&mut self, field: Field) -> Option<Field> {
+        self.fields.insert(field.name().clone(), field)
+    }
+
+    /// Add a field.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_field(&mut self, field: Field) -> Result<&mut Self, BuilderError> {
         insert_unique(&mut self.fields, field.name().clone(), field)?;
         Ok(self)
     }
 
-    /// Add several fields. Errors on the first duplicate name.
-    pub fn fields(mut self, fields: impl IntoIterator<Item = Field>) -> Result<Self, BuilderError> {
+    /// Add a field, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_field(mut self, field: Field) -> Result<Self, BuilderError> {
+        self.try_insert_field(field)?;
+        Ok(self)
+    }
+
+    /// Add several fields, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_fields(
+        mut self,
+        fields: impl IntoIterator<Item = Field>,
+    ) -> Result<Self, BuilderError> {
         for field in fields {
-            self = self.field(field)?;
+            self.try_insert_field(field)?;
         }
         Ok(self)
     }
 
-    /// Set the record's annotations.
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = annotations;
+    /// The annotations of the record.
+    pub fn annotations(&self) -> &AnnotationsBuilder {
+        &self.annotations
+    }
+
+    /// The annotations of the record.
+    pub fn annotations_mut(&mut self) -> &mut AnnotationsBuilder {
+        &mut self.annotations
+    }
+
+    /// Set the record's annotations, replacing any added so far, and return
+    /// the builder for chaining.
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = AnnotationsBuilder::from_annotations(&annotations);
         self
     }
 
     /// Finish building the record.
     pub fn build(self) -> Record {
-        Record::from_parts(self.name, self.fields, self.annotations)
+        Record::from_parts(self.name, self.fields, self.annotations.build())
     }
 }

--- a/crates/schema/src/test_utils.rs
+++ b/crates/schema/src/test_utils.rs
@@ -39,7 +39,7 @@ pub fn entity(name: &str, events: impl IntoIterator<Item = Event>) -> Entity {
 }
 pub fn record(name: &str, fields: impl IntoIterator<Item = Field>) -> Record {
     RecordBuilder::new(ident(name))
-        .fields(fields)
+        .try_with_fields(fields)
         .unwrap()
         .build()
 }

--- a/crates/schema/src/test_utils.rs
+++ b/crates/schema/src/test_utils.rs
@@ -27,7 +27,7 @@ pub fn event_with(
     payload: impl IntoIterator<Item = Field>,
 ) -> Event {
     EventBuilder::new(ident(name), cardinality)
-        .fields(payload)
+        .try_with_fields(payload)
         .unwrap()
         .build()
 }

--- a/crates/schema/src/visitor.rs
+++ b/crates/schema/src/visitor.rs
@@ -334,13 +334,12 @@ mod test {
 
     #[test]
     fn recurses_data_types_and_entity_ref_annotations() {
-        let mut annotations = AnnotationsBuilder::new();
-        annotations
-            .try_insert_constraint("my.constraint.v1", None)
-            .unwrap();
         let entity_ref = DataType::EntityRef {
             data: None,
-            annotations: annotations.build(),
+            annotations: AnnotationsBuilder::new()
+                .try_with_constraint("my.constraint.v1", None)
+                .unwrap()
+                .build(),
         };
         let schema = schema(
             "S",

--- a/crates/schema/src/visitor.rs
+++ b/crates/schema/src/visitor.rs
@@ -334,12 +334,13 @@ mod test {
 
     #[test]
     fn recurses_data_types_and_entity_ref_annotations() {
+        let mut annotations = AnnotationsBuilder::new();
+        annotations
+            .try_insert_constraint("my.constraint.v1", None)
+            .unwrap();
         let entity_ref = DataType::EntityRef {
             data: None,
-            annotations: AnnotationsBuilder::new()
-                .constraint("my.constraint.v1", None)
-                .unwrap()
-                .build(),
+            annotations: annotations.build(),
         };
         let schema = schema(
             "S",


### PR DESCRIPTION
# Description

Applies the builder conventions to `EventBuilder`: `try_new` accepting plain strings, bare-noun getters, `set_field`/`set_cardinality` replacing and returning the previous value, `try_insert_field` for in-place adds, `try_with_field(s)` for chains, and an `AnnotationsBuilder` inside.

**Stacked on the RecordBuilder PR** — that one must merge first; this adds only the top commit.

## Related Issues

Part of #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)