### PR TITLE
refactor(schema): align the SchemaBuilder API with the builder conventions

### DIFF
--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -3,11 +3,18 @@
 
 use quent_constraints::{Constraint, validate};
 use quent_schema::{
-    Cardinality, DataType, Field, Schema,
+    Annotations, Cardinality, DataType, Field, Schema,
     builder::{AnnotationsBuilder, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder},
     test_utils::{self, entity, event, field, ident, schema},
     visitor::{Cursor, Visitor},
 };
+
+/// Annotations carrying the constraint `name` without data.
+fn constraint(name: &str) -> Annotations {
+    let mut builder = AnnotationsBuilder::new();
+    builder.try_insert_constraint(name, None).unwrap();
+    builder.build()
+}
 
 fn empty_schema() -> Schema {
     test_utils::schema("TestSchema", vec![], vec![])
@@ -88,12 +95,7 @@ fn passing_constraint_on_empty_schema() {
 #[test]
 fn constraint_without_validator_is_unregistered() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint("unknown", None)
-                .unwrap()
-                .build(),
-        )
+        .annotations(constraint("unknown"))
         .build();
     let report = validate::<(NoopA,)>(&schema);
     assert_eq!(report.unregistered_constraints.len(), 1);
@@ -109,12 +111,11 @@ fn constraint_without_validator_is_unregistered() {
 #[test]
 fn metadata_is_never_validated() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .metadata("not_validated", None)
-                .unwrap()
-                .build(),
-        )
+        .annotations({
+            let mut builder = AnnotationsBuilder::new();
+            builder.try_insert_metadata("not_validated", None).unwrap();
+            builder.build()
+        })
         .build();
     let report = validate::<(NoopA,)>(&schema);
     assert!(report.unregistered_constraints.is_empty());
@@ -122,12 +123,7 @@ fn metadata_is_never_validated() {
 
 #[test]
 fn unregistered_constraint_is_reported_once() {
-    let unknown = || {
-        AnnotationsBuilder::new()
-            .constraint("unknown", None)
-            .unwrap()
-            .build()
-    };
+    let unknown = || constraint("unknown");
     let field = Field::new(ident("ef"), DataType::U64, unknown());
     let event = EventBuilder::new(ident("Ev"), Cardinality::Once)
         .field(field)
@@ -174,12 +170,7 @@ fn constraint_failure_is_reported_per_constraint() {
 #[test]
 fn unregistered_and_failure_aggregate() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint("unknown", None)
-                .unwrap()
-                .build(),
-        )
+        .annotations(constraint("unknown"))
         .build();
     let report = validate::<(Failing,)>(&schema);
     assert!(

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -11,9 +11,10 @@ use quent_schema::{
 
 /// Annotations carrying the constraint `name` without data.
 fn constraint(name: &str) -> Annotations {
-    let mut builder = AnnotationsBuilder::new();
-    builder.try_insert_constraint(name, None).unwrap();
-    builder.build()
+    AnnotationsBuilder::new()
+        .try_with_constraint(name, None)
+        .unwrap()
+        .build()
 }
 
 fn empty_schema() -> Schema {
@@ -111,11 +112,12 @@ fn constraint_without_validator_is_unregistered() {
 #[test]
 fn metadata_is_never_validated() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations({
-            let mut builder = AnnotationsBuilder::new();
-            builder.try_insert_metadata("not_validated", None).unwrap();
-            builder.build()
-        })
+        .annotations(
+            AnnotationsBuilder::new()
+                .try_with_metadata("not_validated", None)
+                .unwrap()
+                .build(),
+        )
         .build();
     let report = validate::<(NoopA,)>(&schema);
     assert!(report.unregistered_constraints.is_empty());

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -128,9 +128,9 @@ fn unregistered_constraint_is_reported_once() {
     let unknown = || constraint("unknown");
     let field = Field::new(ident("ef"), DataType::U64, unknown());
     let event = EventBuilder::new(ident("Ev"), Cardinality::Once)
-        .field(field)
+        .try_with_field(field)
         .unwrap()
-        .annotations(unknown())
+        .with_annotations(unknown())
         .build();
     let entity = EntityBuilder::new(ident("E"))
         .event(event)

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -96,7 +96,7 @@ fn passing_constraint_on_empty_schema() {
 #[test]
 fn constraint_without_validator_is_unregistered() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(constraint("unknown"))
+        .with_annotations(constraint("unknown"))
         .build();
     let report = validate::<(NoopA,)>(&schema);
     assert_eq!(report.unregistered_constraints.len(), 1);
@@ -112,7 +112,7 @@ fn constraint_without_validator_is_unregistered() {
 #[test]
 fn metadata_is_never_validated() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(
+        .with_annotations(
             AnnotationsBuilder::new()
                 .try_with_metadata("not_validated", None)
                 .unwrap()
@@ -144,11 +144,11 @@ fn unregistered_constraint_is_reported_once() {
         .with_annotations(unknown())
         .build();
     let schema = SchemaBuilder::new(ident("S"))
-        .entity(entity)
+        .try_with_entity(entity)
         .unwrap()
-        .record(record)
+        .try_with_record(record)
         .unwrap()
-        .annotations(unknown())
+        .with_annotations(unknown())
         .build();
     let report = validate::<(NoopA,)>(&schema);
     // The same name used at six sites is deduplicated to a single entry.
@@ -172,7 +172,7 @@ fn constraint_failure_is_reported_per_constraint() {
 #[test]
 fn unregistered_and_failure_aggregate() {
     let schema = SchemaBuilder::new(ident("TestSchema"))
-        .annotations(constraint("unknown"))
+        .with_annotations(constraint("unknown"))
         .build();
     let report = validate::<(Failing,)>(&schema);
     assert!(

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -133,9 +133,9 @@ fn unregistered_constraint_is_reported_once() {
         .with_annotations(unknown())
         .build();
     let entity = EntityBuilder::new(ident("E"))
-        .event(event)
+        .try_with_event(event)
         .unwrap()
-        .annotations(unknown())
+        .with_annotations(unknown())
         .build();
     let record_field = Field::new(ident("rf"), DataType::U64, unknown());
     let record = RecordBuilder::new(ident("R"))

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -139,9 +139,9 @@ fn unregistered_constraint_is_reported_once() {
         .build();
     let record_field = Field::new(ident("rf"), DataType::U64, unknown());
     let record = RecordBuilder::new(ident("R"))
-        .field(record_field)
+        .try_with_field(record_field)
         .unwrap()
-        .annotations(unknown())
+        .with_annotations(unknown())
         .build();
     let schema = SchemaBuilder::new(ident("S"))
         .entity(entity)

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -38,9 +38,9 @@ fn fsm_annotations(data: Option<String>) -> Annotations {
 
 fn entity_with(name: &str, events: Vec<Event>, data: &str) -> Entity {
     EntityBuilder::new(ident(name))
-        .events(events)
+        .try_with_events(events)
         .unwrap()
-        .annotations(fsm_annotations(Some(data.to_string())))
+        .with_annotations(fsm_annotations(Some(data.to_string())))
         .build()
 }
 
@@ -85,9 +85,9 @@ fn single_state_fsm_passes() {
 #[test]
 fn missing_data_is_rejected() {
     let entity = EntityBuilder::new(ident("E"))
-        .event(event("a", Cardinality::Once))
+        .try_with_event(event("a", Cardinality::Once))
         .unwrap()
-        .annotations(fsm_annotations(None))
+        .with_annotations(fsm_annotations(None))
         .build();
     let errors = validate(&schema_with(entity));
     assert!(
@@ -100,9 +100,9 @@ fn missing_data_is_rejected() {
 #[test]
 fn invalid_json_is_rejected() {
     let entity = EntityBuilder::new(ident("E"))
-        .event(event("a", Cardinality::Once))
+        .try_with_event(event("a", Cardinality::Once))
         .unwrap()
-        .annotations(fsm_annotations(Some("{ trash".to_string())))
+        .with_annotations(fsm_annotations(Some("{ trash".to_string())))
         .build();
     let errors = validate(&schema_with(entity));
     assert!(

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -4,7 +4,7 @@
 use quent_constraints::Constraint as _;
 use quent_fsm::{Fsm, FsmConstraint, FsmError};
 use quent_schema::{
-    Cardinality, Entity, Event, Schema,
+    Annotations, Cardinality, Entity, Event, Schema,
     builder::{AnnotationsBuilder, EntityBuilder},
     test_utils::{entity as bare_entity, event_with, ident, schema},
 };
@@ -28,16 +28,20 @@ fn fsm(initial: &str, transitions: &[(&str, &str)], exit: &[&str]) -> String {
     .to_string()
 }
 
+/// Annotations carrying the FSM constraint with `data`.
+fn fsm_annotations(data: Option<String>) -> Annotations {
+    let mut builder = AnnotationsBuilder::new();
+    builder
+        .try_insert_constraint(FsmConstraint::NAME, data)
+        .unwrap();
+    builder.build()
+}
+
 fn entity_with(name: &str, events: Vec<Event>, data: &str) -> Entity {
     EntityBuilder::new(ident(name))
         .events(events)
         .unwrap()
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint(FsmConstraint::NAME, Some(data.to_string()))
-                .unwrap()
-                .build(),
-        )
+        .annotations(fsm_annotations(Some(data.to_string())))
         .build()
 }
 
@@ -84,12 +88,7 @@ fn missing_data_is_rejected() {
     let entity = EntityBuilder::new(ident("E"))
         .event(event("a", Cardinality::Once))
         .unwrap()
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint(FsmConstraint::NAME, None)
-                .unwrap()
-                .build(),
-        )
+        .annotations(fsm_annotations(None))
         .build();
     let errors = validate(&schema_with(entity));
     assert!(
@@ -104,12 +103,7 @@ fn invalid_json_is_rejected() {
     let entity = EntityBuilder::new(ident("E"))
         .event(event("a", Cardinality::Once))
         .unwrap()
-        .annotations(
-            AnnotationsBuilder::new()
-                .constraint(FsmConstraint::NAME, Some("{ trash".to_string()))
-                .unwrap()
-                .build(),
-        )
+        .annotations(fsm_annotations(Some("{ trash".to_string())))
         .build();
     let errors = validate(&schema_with(entity));
     assert!(

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -30,11 +30,10 @@ fn fsm(initial: &str, transitions: &[(&str, &str)], exit: &[&str]) -> String {
 
 /// Annotations carrying the FSM constraint with `data`.
 fn fsm_annotations(data: Option<String>) -> Annotations {
-    let mut builder = AnnotationsBuilder::new();
-    builder
-        .try_insert_constraint(FsmConstraint::NAME, data)
-        .unwrap();
-    builder.build()
+    AnnotationsBuilder::new()
+        .try_with_constraint(FsmConstraint::NAME, data)
+        .unwrap()
+        .build()
 }
 
 fn entity_with(name: &str, events: Vec<Event>, data: &str) -> Entity {

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -41,20 +41,18 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
     let endpoint = RecordBuilder::new(ident("Endpoint"))
-        .annotations(docs("A network endpoint."))
-        .fields([
+        .with_annotations(docs("A network endpoint."))
+        .try_with_fields([
             field("host", DataType::String),
             field("port", DataType::U16),
-        ])
-        .unwrap()
+        ])?
         .build();
 
     let meta = RecordBuilder::new(ident("Meta"))
-        .fields([
+        .try_with_fields([
             field("tags", DataType::List(Box::new(DataType::String))),
             field("extra", DataType::DynamicRecord),
-        ])
-        .unwrap()
+        ])?
         .build();
 
     let connection = EntityBuilder::new(ident("Connection"))

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -56,8 +56,8 @@ fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
         .build();
 
     let connection = EntityBuilder::new(ident("Connection"))
-        .annotations(docs("A client connection."))
-        .events([
+        .with_annotations(docs("A client connection."))
+        .try_with_events([
             EventBuilder::new(ident("opened"), Cardinality::Once)
                 .try_with_fields([
                     field("peer", DataType::Record(ident("Endpoint"))),
@@ -74,8 +74,7 @@ fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
                 ])?
                 .build(),
             EventBuilder::new(ident("closed"), Cardinality::Once).build(),
-        ])
-        .unwrap()
+        ])?
         .build();
 
     let schema = SchemaBuilder::new(ident("Demo"))

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -78,10 +78,8 @@ fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
         .build();
 
     let schema = SchemaBuilder::new(ident("Demo"))
-        .records([endpoint, meta])
-        .unwrap()
-        .entities([connection])
-        .unwrap()
+        .try_with_records([endpoint, meta])?
+        .try_with_entity(connection)?
         .build();
 
     Ok(schema)

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -59,21 +59,19 @@ fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
         .annotations(docs("A client connection."))
         .events([
             EventBuilder::new(ident("opened"), Cardinality::Once)
-                .fields([
+                .try_with_fields([
                     field("peer", DataType::Record(ident("Endpoint"))),
                     field("session", DataType::Uuid),
-                ])
-                .unwrap()
+                ])?
                 .build(),
             EventBuilder::new(ident("data"), Cardinality::Multi)
-                .fields([
+                .try_with_fields([
                     field("bytes", DataType::U64),
                     field(
                         "meta",
                         DataType::Option(Box::new(DataType::Record(ident("Meta")))),
                     ),
-                ])
-                .unwrap()
+                ])?
                 .build(),
             EventBuilder::new(ident("closed"), Cardinality::Once).build(),
         ])

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -6,7 +6,14 @@ use quent_schema::builder::{
     AnnotationsBuilder, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder,
 };
 use quent_schema::test_utils::{field, ident};
-use quent_schema::{Cardinality, DataType, Schema};
+use quent_schema::{Annotations, Cardinality, DataType, Schema};
+
+/// Annotations carrying only a documentation string.
+fn docs(text: &str) -> Annotations {
+    let mut builder = AnnotationsBuilder::new();
+    builder.set_docs(text);
+    builder.build()
+}
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=build.rs");
@@ -34,11 +41,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
     let endpoint = RecordBuilder::new(ident("Endpoint"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .docs("A network endpoint.")
-                .build(),
-        )
+        .annotations(docs("A network endpoint."))
         .fields([
             field("host", DataType::String),
             field("port", DataType::U16),
@@ -55,11 +58,7 @@ fn demo_schema() -> std::result::Result<Schema, Box<dyn std::error::Error>> {
         .build();
 
     let connection = EntityBuilder::new(ident("Connection"))
-        .annotations(
-            AnnotationsBuilder::new()
-                .docs("A client connection.")
-                .build(),
-        )
+        .annotations(docs("A client connection."))
         .events([
             EventBuilder::new(ident("opened"), Cardinality::Once)
                 .fields([

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -152,7 +152,7 @@ mod tests {
             .with_annotations(docs("entity doc"))
             .build();
         let s = SchemaBuilder::new(ident("M"))
-            .entities([en])
+            .try_with_entity(en)
             .unwrap()
             .build();
 

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -147,9 +147,9 @@ mod tests {
             .with_annotations(docs("event doc"))
             .build();
         let en = EntityBuilder::new(ident("E"))
-            .events([ev])
+            .try_with_event(ev)
             .unwrap()
-            .annotations(docs("entity doc"))
+            .with_annotations(docs("entity doc"))
             .build();
         let s = SchemaBuilder::new(ident("M"))
             .entities([en])

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -135,7 +135,11 @@ mod tests {
 
     #[test]
     fn docs_annotations_become_doc_attributes() {
-        let docs = |text: &str| AnnotationsBuilder::new().docs(text).build();
+        let docs = |text: &str| {
+            let mut builder = AnnotationsBuilder::new();
+            builder.set_docs(text);
+            builder.build()
+        };
         let field_x = Field::new(ident("x"), DataType::U8, docs("field doc"));
         let ev = EventBuilder::new(ident("ev"), Cardinality::Once)
             .fields([field_x])

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -142,9 +142,9 @@ mod tests {
         };
         let field_x = Field::new(ident("x"), DataType::U8, docs("field doc"));
         let ev = EventBuilder::new(ident("ev"), Cardinality::Once)
-            .fields([field_x])
+            .try_with_field(field_x)
             .unwrap()
-            .annotations(docs("event doc"))
+            .with_annotations(docs("event doc"))
             .build();
         let en = EntityBuilder::new(ident("E"))
             .events([ev])

--- a/crates/instrumentation-build/src/runtime/mod.rs
+++ b/crates/instrumentation-build/src/runtime/mod.rs
@@ -99,7 +99,7 @@ mod tests {
     fn generate_assembles_event_impl_observer_handle_and_context() {
         let connection = EntityBuilder::new(ident("Connection"))
             .events([EventBuilder::new(ident("data"), Cardinality::Multi)
-                .fields([field("bytes", DataType::U64)])
+                .try_with_field(field("bytes", DataType::U64))
                 .unwrap()
                 .build()])
             .unwrap()

--- a/crates/instrumentation-build/src/runtime/mod.rs
+++ b/crates/instrumentation-build/src/runtime/mod.rs
@@ -107,7 +107,7 @@ mod tests {
             .unwrap()
             .build();
         let s = SchemaBuilder::new(ident("Demo"))
-            .entity(connection)
+            .try_with_entity(connection)
             .unwrap()
             .build();
         let src = pretty(generate_runtime_types(&s).unwrap());

--- a/crates/instrumentation-build/src/runtime/mod.rs
+++ b/crates/instrumentation-build/src/runtime/mod.rs
@@ -98,10 +98,12 @@ mod tests {
     #[test]
     fn generate_assembles_event_impl_observer_handle_and_context() {
         let connection = EntityBuilder::new(ident("Connection"))
-            .events([EventBuilder::new(ident("data"), Cardinality::Multi)
-                .try_with_field(field("bytes", DataType::U64))
-                .unwrap()
-                .build()])
+            .try_with_event(
+                EventBuilder::new(ident("data"), Cardinality::Multi)
+                    .try_with_field(field("bytes", DataType::U64))
+                    .unwrap()
+                    .build(),
+            )
             .unwrap()
             .build();
         let s = SchemaBuilder::new(ident("Demo"))

--- a/crates/ref-target/tests/ref-target-constraint.rs
+++ b/crates/ref-target/tests/ref-target-constraint.rs
@@ -12,10 +12,13 @@ use quent_schema::{
 fn entity_ref(target: Option<&str>) -> DataType {
     DataType::EntityRef {
         data: None,
-        annotations: AnnotationsBuilder::new()
-            .constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
-            .unwrap()
-            .build(),
+        annotations: {
+            let mut builder = AnnotationsBuilder::new();
+            builder
+                .try_insert_constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
+                .unwrap();
+            builder.build()
+        },
     }
 }
 

--- a/crates/ref-target/tests/ref-target-constraint.rs
+++ b/crates/ref-target/tests/ref-target-constraint.rs
@@ -12,13 +12,10 @@ use quent_schema::{
 fn entity_ref(target: Option<&str>) -> DataType {
     DataType::EntityRef {
         data: None,
-        annotations: {
-            let mut builder = AnnotationsBuilder::new();
-            builder
-                .try_insert_constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
-                .unwrap();
-            builder.build()
-        },
+        annotations: AnnotationsBuilder::new()
+            .try_with_constraint(RefTargetConstraint::NAME, target.map(ToString::to_string))
+            .unwrap()
+            .build(),
     }
 }
 

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -12,25 +12,27 @@ use quent_schema::{
 
 /// A type-erased tree-forming reference (no target).
 fn tree_ref() -> DataType {
+    let mut builder = AnnotationsBuilder::new();
+    builder
+        .try_insert_constraint(RefTreeConstraint::NAME, None)
+        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: AnnotationsBuilder::new()
-            .constraint(RefTreeConstraint::NAME, None)
-            .unwrap()
-            .build(),
+        annotations: builder.build(),
     }
 }
 
 /// A tree-forming reference restricted to a specific parent entity type.
 fn tree_ref_to(target: &str) -> DataType {
+    let mut builder = AnnotationsBuilder::new();
+    builder
+        .try_insert_constraint(RefTreeConstraint::NAME, None)
+        .unwrap()
+        .try_insert_constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
+        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: AnnotationsBuilder::new()
-            .constraint(RefTreeConstraint::NAME, None)
-            .unwrap()
-            .constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
-            .unwrap()
-            .build(),
+        annotations: builder.build(),
     }
 }
 

--- a/crates/ref-tree/tests/ref-tree-constraint.rs
+++ b/crates/ref-tree/tests/ref-tree-constraint.rs
@@ -12,27 +12,25 @@ use quent_schema::{
 
 /// A type-erased tree-forming reference (no target).
 fn tree_ref() -> DataType {
-    let mut builder = AnnotationsBuilder::new();
-    builder
-        .try_insert_constraint(RefTreeConstraint::NAME, None)
-        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: builder.build(),
+        annotations: AnnotationsBuilder::new()
+            .try_with_constraint(RefTreeConstraint::NAME, None)
+            .unwrap()
+            .build(),
     }
 }
 
 /// A tree-forming reference restricted to a specific parent entity type.
 fn tree_ref_to(target: &str) -> DataType {
-    let mut builder = AnnotationsBuilder::new();
-    builder
-        .try_insert_constraint(RefTreeConstraint::NAME, None)
-        .unwrap()
-        .try_insert_constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
-        .unwrap();
     DataType::EntityRef {
         data: None,
-        annotations: builder.build(),
+        annotations: AnnotationsBuilder::new()
+            .try_with_constraint(RefTreeConstraint::NAME, None)
+            .unwrap()
+            .try_with_constraint(RefTargetConstraint::NAME, Some(ident(target).to_string()))
+            .unwrap()
+            .build(),
     }
 }
 

--- a/crates/schema/src/builder/annotations.rs
+++ b/crates/schema/src/builder/annotations.rs
@@ -91,6 +91,20 @@ impl AnnotationsBuilder {
         Ok(self)
     }
 
+    /// Add a constraint named `name`, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_with_constraint(
+        mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Result<Self, BuilderError> {
+        self.try_insert_constraint(name, data)?;
+        Ok(self)
+    }
+
     /// Set the constraint named `name`, returning the replaced entry, if any.
     pub fn set_constraint(
         &mut self,
@@ -120,6 +134,20 @@ impl AnnotationsBuilder {
         let name = name.into();
         self.metadata
             .try_insert(name.clone(), Metadata::from_parts(name, data))?;
+        Ok(self)
+    }
+
+    /// Add a metadata entry named `name`, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_with_metadata(
+        mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Result<Self, BuilderError> {
+        self.try_insert_metadata(name, data)?;
         Ok(self)
     }
 

--- a/crates/schema/src/builder/annotations.rs
+++ b/crates/schema/src/builder/annotations.rs
@@ -5,18 +5,25 @@ use crate::builder::{BuilderError, insert_unique};
 use crate::schema::Map;
 use crate::{Annotations, Constraint, Metadata};
 
-/// Builder for a map of named, optionally-valued string items.
-#[derive(Default)]
-struct OpaqueMapBuilder(Map<String, Option<String>>);
+/// Builder for a map of named items.
+struct OpaqueMapBuilder<T>(Map<String, T>);
 
-impl OpaqueMapBuilder {
-    fn add(mut self, name: impl Into<String>, data: Option<String>) -> Result<Self, BuilderError> {
-        let name = name.into();
+impl<T> Default for OpaqueMapBuilder<T> {
+    fn default() -> Self {
+        Self(Map::default())
+    }
+}
+
+impl<T> OpaqueMapBuilder<T> {
+    fn try_insert(&mut self, name: String, value: T) -> Result<(), BuilderError> {
         if name.is_empty() {
             return Err(BuilderError::EmptyName);
         }
-        insert_unique(&mut self.0, name.clone(), data)?;
-        Ok(self)
+        insert_unique(&mut self.0, name, value)
+    }
+
+    fn set(&mut self, name: String, value: T) -> Option<T> {
+        self.0.insert(name, value)
     }
 }
 
@@ -24,8 +31,8 @@ impl OpaqueMapBuilder {
 #[derive(Default)]
 pub struct AnnotationsBuilder {
     docs: Option<String>,
-    constraints: OpaqueMapBuilder,
-    metadata: OpaqueMapBuilder,
+    constraints: OpaqueMapBuilder<Constraint>,
+    metadata: OpaqueMapBuilder<Metadata>,
 }
 
 impl AnnotationsBuilder {
@@ -34,46 +41,101 @@ impl AnnotationsBuilder {
         Self::default()
     }
 
-    /// Set the documentation string.
-    pub fn docs(mut self, docs: impl Into<String>) -> Self {
-        self.docs = Some(docs.into());
-        self
+    /// Start from existing annotations.
+    pub fn from_annotations(annotations: &Annotations) -> Self {
+        Self {
+            docs: annotations.docs().map(str::to_owned),
+            constraints: OpaqueMapBuilder(
+                annotations
+                    .constraints()
+                    .map(|c| (c.name().to_owned(), c.clone()))
+                    .collect(),
+            ),
+            metadata: OpaqueMapBuilder(
+                annotations
+                    .metadata_entries()
+                    .map(|m| (m.name().to_owned(), m.clone()))
+                    .collect(),
+            ),
+        }
     }
 
-    /// Add a constraint named `name`. Errors if `name` is empty or already declared.
-    pub fn constraint(
-        mut self,
+    /// The documentation, if set.
+    pub fn docs(&self) -> Option<&str> {
+        self.docs.as_deref()
+    }
+
+    /// Set the documentation string, returning the replaced one, if any.
+    pub fn set_docs(&mut self, docs: impl Into<String>) -> Option<String> {
+        self.docs.replace(docs.into())
+    }
+
+    /// The constraint declared under `name`, if any.
+    pub fn constraint(&self, name: &str) -> Option<&Constraint> {
+        self.constraints.0.get(name)
+    }
+
+    /// Add a constraint named `name`.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_insert_constraint(
+        &mut self,
         name: impl Into<String>,
         data: Option<String>,
-    ) -> Result<Self, BuilderError> {
-        self.constraints = self.constraints.add(name, data)?;
+    ) -> Result<&mut Self, BuilderError> {
+        let name = name.into();
+        self.constraints
+            .try_insert(name.clone(), Constraint::from_parts(name, data))?;
         Ok(self)
     }
 
-    /// Add a metadata entry named `name`. Errors if `name` is empty or already declared.
-    pub fn metadata(
-        mut self,
+    /// Set the constraint named `name`, returning the replaced entry, if any.
+    pub fn set_constraint(
+        &mut self,
         name: impl Into<String>,
         data: Option<String>,
-    ) -> Result<Self, BuilderError> {
-        self.metadata = self.metadata.add(name, data)?;
+    ) -> Option<Constraint> {
+        let name = name.into();
+        self.constraints
+            .set(name.clone(), Constraint::from_parts(name, data))
+    }
+
+    /// The metadata entry declared under `name`, if any.
+    pub fn metadata(&self, name: &str) -> Option<&Metadata> {
+        self.metadata.0.get(name)
+    }
+
+    /// Add a metadata entry named `name`.
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is empty or already declared.
+    pub fn try_insert_metadata(
+        &mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Result<&mut Self, BuilderError> {
+        let name = name.into();
+        self.metadata
+            .try_insert(name.clone(), Metadata::from_parts(name, data))?;
         Ok(self)
+    }
+
+    /// Set the metadata entry named `name`, returning the replaced entry, if any.
+    pub fn set_metadata(
+        &mut self,
+        name: impl Into<String>,
+        data: Option<String>,
+    ) -> Option<Metadata> {
+        let name = name.into();
+        self.metadata
+            .set(name.clone(), Metadata::from_parts(name, data))
     }
 
     /// Finish building the annotations.
     pub fn build(self) -> Annotations {
-        Annotations::from_parts(
-            self.docs,
-            self.constraints
-                .0
-                .into_iter()
-                .map(|(k, v)| (k.clone(), Constraint::from_parts(k, v)))
-                .collect(),
-            self.metadata
-                .0
-                .into_iter()
-                .map(|(k, v)| (k.clone(), Metadata::from_parts(k, v)))
-                .collect(),
-        )
+        Annotations::from_parts(self.docs, self.constraints.0, self.metadata.0)
     }
 }

--- a/crates/schema/src/builder/entity.rs
+++ b/crates/schema/src/builder/entity.rs
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::builder::{BuilderError, insert_unique};
+use crate::builder::{AnnotationsBuilder, BuilderError, insert_unique};
 use crate::schema::Map;
+use crate::schema::identifier::IdentifierError;
 use crate::{Annotations, Entity, Event, Identifier};
 
 /// Builder for an [`Entity`].
 pub struct EntityBuilder {
     name: Identifier,
     events: Map<Identifier, Event>,
-    annotations: Annotations,
+    annotations: AnnotationsBuilder,
 }
 
 impl EntityBuilder {
@@ -18,32 +19,90 @@ impl EntityBuilder {
         Self {
             name,
             events: Map::default(),
-            annotations: Annotations::default(),
+            annotations: AnnotationsBuilder::new(),
         }
     }
 
-    /// Add an event. Errors if its name is already declared.
-    pub fn event(mut self, event: Event) -> Result<Self, BuilderError> {
+    /// Start an entity named `name`, validating `name` as an [`Identifier`].
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is not a valid identifier.
+    pub fn try_new(
+        name: impl TryInto<Identifier, Error = IdentifierError>,
+    ) -> Result<Self, IdentifierError> {
+        Ok(Self::new(name.try_into()?))
+    }
+
+    /// The name of the entity.
+    pub fn name(&self) -> &Identifier {
+        &self.name
+    }
+
+    /// The event declared under `name`, if any.
+    pub fn event(&self, name: &Identifier) -> Option<&Event> {
+        self.events.get(name)
+    }
+
+    /// Set an event, returning the replaced one with the same name, if any.
+    pub fn set_event(&mut self, event: Event) -> Option<Event> {
+        self.events.insert(event.name().clone(), event)
+    }
+
+    /// Add an event.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_event(&mut self, event: Event) -> Result<&mut Self, BuilderError> {
         insert_unique(&mut self.events, event.name().clone(), event)?;
         Ok(self)
     }
 
-    /// Add several events. Errors on the first duplicate name.
-    pub fn events(mut self, events: impl IntoIterator<Item = Event>) -> Result<Self, BuilderError> {
+    /// Add an event, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_event(mut self, event: Event) -> Result<Self, BuilderError> {
+        self.try_insert_event(event)?;
+        Ok(self)
+    }
+
+    /// Add several events, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_events(
+        mut self,
+        events: impl IntoIterator<Item = Event>,
+    ) -> Result<Self, BuilderError> {
         for event in events {
-            self = self.event(event)?;
+            self.try_insert_event(event)?;
         }
         Ok(self)
     }
 
-    /// Set the entity's annotations.
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = annotations;
+    /// The annotations of the entity.
+    pub fn annotations(&self) -> &AnnotationsBuilder {
+        &self.annotations
+    }
+
+    /// The annotations of the entity.
+    pub fn annotations_mut(&mut self) -> &mut AnnotationsBuilder {
+        &mut self.annotations
+    }
+
+    /// Set the entity's annotations, replacing any added so far, and return
+    /// the builder for chaining.
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = AnnotationsBuilder::from_annotations(&annotations);
         self
     }
 
     /// Finish building the entity.
     pub fn build(self) -> Entity {
-        Entity::from_parts(self.name, self.events, self.annotations)
+        Entity::from_parts(self.name, self.events, self.annotations.build())
     }
 }

--- a/crates/schema/src/builder/event.rs
+++ b/crates/schema/src/builder/event.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::builder::{BuilderError, insert_unique};
+use crate::builder::{AnnotationsBuilder, BuilderError, insert_unique};
 use crate::schema::Map;
+use crate::schema::identifier::IdentifierError;
 use crate::{Annotations, Cardinality, Event, Field, Identifier};
 
 /// Builder for an [`Event`].
@@ -10,7 +11,7 @@ pub struct EventBuilder {
     name: Identifier,
     cardinality: Cardinality,
     payload: Map<Identifier, Field>,
-    annotations: Annotations,
+    annotations: AnnotationsBuilder,
 }
 
 impl EventBuilder {
@@ -20,32 +21,108 @@ impl EventBuilder {
             name,
             cardinality,
             payload: Map::default(),
-            annotations: Annotations::default(),
+            annotations: AnnotationsBuilder::new(),
         }
     }
 
-    /// Add a payload field. Errors if its name is already declared.
-    pub fn field(mut self, field: Field) -> Result<Self, BuilderError> {
+    /// Start an event named `name` with the given `cardinality`, validating
+    /// `name` as an [`Identifier`].
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is not a valid identifier.
+    pub fn try_new(
+        name: impl TryInto<Identifier, Error = IdentifierError>,
+        cardinality: Cardinality,
+    ) -> Result<Self, IdentifierError> {
+        Ok(Self::new(name.try_into()?, cardinality))
+    }
+
+    /// The name of the event.
+    pub fn name(&self) -> &Identifier {
+        &self.name
+    }
+
+    /// The cardinality of the event.
+    pub fn cardinality(&self) -> Cardinality {
+        self.cardinality
+    }
+
+    /// Set the cardinality of the event, returning the previous one.
+    pub fn set_cardinality(&mut self, cardinality: Cardinality) -> Cardinality {
+        std::mem::replace(&mut self.cardinality, cardinality)
+    }
+
+    /// The payload field declared under `name`, if any.
+    pub fn field(&self, name: &Identifier) -> Option<&Field> {
+        self.payload.get(name)
+    }
+
+    /// Set a payload field, returning the replaced one with the same name, if
+    /// any.
+    pub fn set_field(&mut self, field: Field) -> Option<Field> {
+        self.payload.insert(field.name().clone(), field)
+    }
+
+    /// Add a payload field.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_field(&mut self, field: Field) -> Result<&mut Self, BuilderError> {
         insert_unique(&mut self.payload, field.name().clone(), field)?;
         Ok(self)
     }
 
-    /// Add several payload fields. Errors on the first duplicate name.
-    pub fn fields(mut self, fields: impl IntoIterator<Item = Field>) -> Result<Self, BuilderError> {
+    /// Add a payload field, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_field(mut self, field: Field) -> Result<Self, BuilderError> {
+        self.try_insert_field(field)?;
+        Ok(self)
+    }
+
+    /// Add several payload fields, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_fields(
+        mut self,
+        fields: impl IntoIterator<Item = Field>,
+    ) -> Result<Self, BuilderError> {
         for field in fields {
-            self = self.field(field)?;
+            self.try_insert_field(field)?;
         }
         Ok(self)
     }
 
-    /// Set the event's annotations.
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = annotations;
+    /// The annotations of the event.
+    pub fn annotations(&self) -> &AnnotationsBuilder {
+        &self.annotations
+    }
+
+    /// The annotations of the event.
+    pub fn annotations_mut(&mut self) -> &mut AnnotationsBuilder {
+        &mut self.annotations
+    }
+
+    /// Set the event's annotations, replacing any added so far, and return the
+    /// builder for chaining.
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = AnnotationsBuilder::from_annotations(&annotations);
         self
     }
 
     /// Finish building the event.
     pub fn build(self) -> Event {
-        Event::from_parts(self.name, self.cardinality, self.payload, self.annotations)
+        Event::from_parts(
+            self.name,
+            self.cardinality,
+            self.payload,
+            self.annotations.build(),
+        )
     }
 }

--- a/crates/schema/src/builder/mod.rs
+++ b/crates/schema/src/builder/mod.rs
@@ -9,6 +9,7 @@ use std::hash::Hash;
 use thiserror::Error;
 
 use crate::schema::Map;
+use crate::schema::identifier::IdentifierError;
 use crate::{Annotations, Entity, Identifier, Record, Schema};
 
 pub mod annotations;
@@ -52,7 +53,7 @@ pub struct SchemaBuilder {
     name: Identifier,
     entities: Map<Identifier, Entity>,
     records: Map<Identifier, Record>,
-    annotations: Annotations,
+    annotations: AnnotationsBuilder,
 }
 
 impl SchemaBuilder {
@@ -62,52 +63,140 @@ impl SchemaBuilder {
             name,
             entities: Map::default(),
             records: Map::default(),
-            annotations: Annotations::default(),
+            annotations: AnnotationsBuilder::new(),
         }
     }
 
-    /// Add an entity. Errors if its name is already declared.
-    pub fn entity(mut self, entity: Entity) -> Result<Self, BuilderError> {
+    /// Start a schema named `name`, validating `name` as an [`Identifier`].
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is not a valid identifier.
+    pub fn try_new(
+        name: impl TryInto<Identifier, Error = IdentifierError>,
+    ) -> Result<Self, IdentifierError> {
+        Ok(Self::new(name.try_into()?))
+    }
+
+    /// The name of the schema.
+    pub fn name(&self) -> &Identifier {
+        &self.name
+    }
+
+    /// The entity declared under `name`, if any.
+    pub fn entity(&self, name: &Identifier) -> Option<&Entity> {
+        self.entities.get(name)
+    }
+
+    /// Set an entity, returning the replaced one with the same name, if any.
+    pub fn set_entity(&mut self, entity: Entity) -> Option<Entity> {
+        self.entities.insert(entity.name().clone(), entity)
+    }
+
+    /// Add an entity.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_entity(&mut self, entity: Entity) -> Result<&mut Self, BuilderError> {
         insert_unique(&mut self.entities, entity.name().clone(), entity)?;
         Ok(self)
     }
 
-    /// Add several entities. Errors on the first duplicate name.
-    pub fn entities(
+    /// Add an entity, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_entity(mut self, entity: Entity) -> Result<Self, BuilderError> {
+        self.try_insert_entity(entity)?;
+        Ok(self)
+    }
+
+    /// Add several entities, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_entities(
         mut self,
         entities: impl IntoIterator<Item = Entity>,
     ) -> Result<Self, BuilderError> {
         for entity in entities {
-            self = self.entity(entity)?;
+            self.try_insert_entity(entity)?;
         }
         Ok(self)
     }
 
-    /// Add a record. Errors if its name is already declared.
-    pub fn record(mut self, record: Record) -> Result<Self, BuilderError> {
+    /// The record declared under `name`, if any.
+    pub fn record(&self, name: &Identifier) -> Option<&Record> {
+        self.records.get(name)
+    }
+
+    /// Set a record, returning the replaced one with the same name, if any.
+    pub fn set_record(&mut self, record: Record) -> Option<Record> {
+        self.records.insert(record.name().clone(), record)
+    }
+
+    /// Add a record.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_record(&mut self, record: Record) -> Result<&mut Self, BuilderError> {
         insert_unique(&mut self.records, record.name().clone(), record)?;
         Ok(self)
     }
 
-    /// Add several records. Errors on the first duplicate name.
-    pub fn records(
+    /// Add a record, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_record(mut self, record: Record) -> Result<Self, BuilderError> {
+        self.try_insert_record(record)?;
+        Ok(self)
+    }
+
+    /// Add several records, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_records(
         mut self,
         records: impl IntoIterator<Item = Record>,
     ) -> Result<Self, BuilderError> {
         for record in records {
-            self = self.record(record)?;
+            self.try_insert_record(record)?;
         }
         Ok(self)
     }
 
-    /// Set the schema's annotations.
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = annotations;
+    /// The annotations of the schema.
+    pub fn annotations(&self) -> &AnnotationsBuilder {
+        &self.annotations
+    }
+
+    /// The annotations of the schema.
+    pub fn annotations_mut(&mut self) -> &mut AnnotationsBuilder {
+        &mut self.annotations
+    }
+
+    /// Set the schema's annotations, replacing any added so far, and return
+    /// the builder for chaining.
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = AnnotationsBuilder::from_annotations(&annotations);
         self
     }
 
     /// Finish building the schema.
     pub fn build(self) -> Schema {
-        Schema::from_parts(self.name, self.entities, self.records, self.annotations)
+        Schema::from_parts(
+            self.name,
+            self.entities,
+            self.records,
+            self.annotations.build(),
+        )
     }
 }

--- a/crates/schema/src/builder/record.rs
+++ b/crates/schema/src/builder/record.rs
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::builder::{BuilderError, insert_unique};
+use crate::builder::{AnnotationsBuilder, BuilderError, insert_unique};
 use crate::schema::Map;
+use crate::schema::identifier::IdentifierError;
 use crate::{Annotations, Field, Identifier, Record};
 
 /// Builder for a [`Record`].
 pub struct RecordBuilder {
     name: Identifier,
     fields: Map<Identifier, Field>,
-    annotations: Annotations,
+    annotations: AnnotationsBuilder,
 }
 
 impl RecordBuilder {
@@ -18,32 +19,90 @@ impl RecordBuilder {
         Self {
             name,
             fields: Map::default(),
-            annotations: Annotations::default(),
+            annotations: AnnotationsBuilder::new(),
         }
     }
 
-    /// Add a field. Errors if its name is already declared.
-    pub fn field(mut self, field: Field) -> Result<Self, BuilderError> {
+    /// Start a record named `name`, validating `name` as an [`Identifier`].
+    ///
+    /// # Errors
+    ///
+    /// Errors if `name` is not a valid identifier.
+    pub fn try_new(
+        name: impl TryInto<Identifier, Error = IdentifierError>,
+    ) -> Result<Self, IdentifierError> {
+        Ok(Self::new(name.try_into()?))
+    }
+
+    /// The name of the record.
+    pub fn name(&self) -> &Identifier {
+        &self.name
+    }
+
+    /// The field declared under `name`, if any.
+    pub fn field(&self, name: &Identifier) -> Option<&Field> {
+        self.fields.get(name)
+    }
+
+    /// Set a field, returning the replaced one with the same name, if any.
+    pub fn set_field(&mut self, field: Field) -> Option<Field> {
+        self.fields.insert(field.name().clone(), field)
+    }
+
+    /// Add a field.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_field(&mut self, field: Field) -> Result<&mut Self, BuilderError> {
         insert_unique(&mut self.fields, field.name().clone(), field)?;
         Ok(self)
     }
 
-    /// Add several fields. Errors on the first duplicate name.
-    pub fn fields(mut self, fields: impl IntoIterator<Item = Field>) -> Result<Self, BuilderError> {
+    /// Add a field, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_field(mut self, field: Field) -> Result<Self, BuilderError> {
+        self.try_insert_field(field)?;
+        Ok(self)
+    }
+
+    /// Add several fields, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_fields(
+        mut self,
+        fields: impl IntoIterator<Item = Field>,
+    ) -> Result<Self, BuilderError> {
         for field in fields {
-            self = self.field(field)?;
+            self.try_insert_field(field)?;
         }
         Ok(self)
     }
 
-    /// Set the record's annotations.
-    pub fn annotations(mut self, annotations: Annotations) -> Self {
-        self.annotations = annotations;
+    /// The annotations of the record.
+    pub fn annotations(&self) -> &AnnotationsBuilder {
+        &self.annotations
+    }
+
+    /// The annotations of the record.
+    pub fn annotations_mut(&mut self) -> &mut AnnotationsBuilder {
+        &mut self.annotations
+    }
+
+    /// Set the record's annotations, replacing any added so far, and return
+    /// the builder for chaining.
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = AnnotationsBuilder::from_annotations(&annotations);
         self
     }
 
     /// Finish building the record.
     pub fn build(self) -> Record {
-        Record::from_parts(self.name, self.fields, self.annotations)
+        Record::from_parts(self.name, self.fields, self.annotations.build())
     }
 }

--- a/crates/schema/src/test_utils.rs
+++ b/crates/schema/src/test_utils.rs
@@ -39,7 +39,7 @@ pub fn entity(name: &str, events: impl IntoIterator<Item = Event>) -> Entity {
 }
 pub fn record(name: &str, fields: impl IntoIterator<Item = Field>) -> Record {
     RecordBuilder::new(ident(name))
-        .fields(fields)
+        .try_with_fields(fields)
         .unwrap()
         .build()
 }

--- a/crates/schema/src/test_utils.rs
+++ b/crates/schema/src/test_utils.rs
@@ -33,7 +33,7 @@ pub fn event_with(
 }
 pub fn entity(name: &str, events: impl IntoIterator<Item = Event>) -> Entity {
     EntityBuilder::new(ident(name))
-        .events(events)
+        .try_with_events(events)
         .unwrap()
         .build()
 }

--- a/crates/schema/src/test_utils.rs
+++ b/crates/schema/src/test_utils.rs
@@ -27,7 +27,7 @@ pub fn event_with(
     payload: impl IntoIterator<Item = Field>,
 ) -> Event {
     EventBuilder::new(ident(name), cardinality)
-        .fields(payload)
+        .try_with_fields(payload)
         .unwrap()
         .build()
 }

--- a/crates/schema/src/test_utils.rs
+++ b/crates/schema/src/test_utils.rs
@@ -49,9 +49,9 @@ pub fn schema(
     records: impl IntoIterator<Item = Record>,
 ) -> Schema {
     SchemaBuilder::new(ident(name))
-        .entities(entities)
+        .try_with_entities(entities)
         .unwrap()
-        .records(records)
+        .try_with_records(records)
         .unwrap()
         .build()
 }

--- a/crates/schema/src/visitor.rs
+++ b/crates/schema/src/visitor.rs
@@ -334,13 +334,12 @@ mod test {
 
     #[test]
     fn recurses_data_types_and_entity_ref_annotations() {
-        let mut annotations = AnnotationsBuilder::new();
-        annotations
-            .try_insert_constraint("my.constraint.v1", None)
-            .unwrap();
         let entity_ref = DataType::EntityRef {
             data: None,
-            annotations: annotations.build(),
+            annotations: AnnotationsBuilder::new()
+                .try_with_constraint("my.constraint.v1", None)
+                .unwrap()
+                .build(),
         };
         let schema = schema(
             "S",

--- a/crates/schema/src/visitor.rs
+++ b/crates/schema/src/visitor.rs
@@ -334,12 +334,13 @@ mod test {
 
     #[test]
     fn recurses_data_types_and_entity_ref_annotations() {
+        let mut annotations = AnnotationsBuilder::new();
+        annotations
+            .try_insert_constraint("my.constraint.v1", None)
+            .unwrap();
         let entity_ref = DataType::EntityRef {
             data: None,
-            annotations: AnnotationsBuilder::new()
-                .constraint("my.constraint.v1", None)
-                .unwrap()
-                .build(),
+            annotations: annotations.build(),
         };
         let schema = schema(
             "S",


### PR DESCRIPTION
# Description

Aligns all five schema builders (`AnnotationsBuilder`, `RecordBuilder`, `EventBuilder`, `EntityBuilder`, `SchemaBuilder`) with one API convention: bare-noun getters returning references, `set_*` replacing and returning the previous entry, `try_insert_*` erroring on duplicate or empty names, `try_with_*` for construction chains, `try_new` accepting plain strings, and each builder holding an `AnnotationsBuilder` (`annotations_mut` to amend, `with_annotations` to replace). Call sites updated mechanically.

## Related Issues

Part of #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)