### PR TITLE
chore: add missing instrumentation build example `Cargo.lock`

### DIFF
--- a/crates/instrumentation-build/example/Cargo.lock
+++ b/crates/instrumentation-build/example/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "async-trait",
  "quent-events",
  "thiserror",
+ "tracing",
  "uuid",
 ]
 


### PR DESCRIPTION
Fixes the failing Rust workflow step:
```
pixi run cargo clippy --manifest-path crates/instrumentation-build/example/Cargo.toml --all-targets --locked -- -D warnings
```