### PR TITLE
feat(yaml): scaffold quent-yaml with diagnostics and a spanned YAML tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,6 +2697,7 @@ name = "quent-yaml"
 version = "0.1.0"
 dependencies = [
  "saphyr-parser",
+ "strsim",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "saphyr-parser"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbeae0f40b92f2afe16422744aabb145187167184cc18bf4d01da5acdc665f09"
+checksum = "ebfd783fcf1b3f6bafd557be0e1427ec54f826f513c3cdd749f9844484df2a13"
 dependencies = [
  "arraydeque",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,7 +811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1438,7 +1444,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2687,6 +2693,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-yaml"
+version = "0.1.0"
+dependencies = [
+ "saphyr-parser",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,7 +2760,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3008,7 +3021,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3077,6 +3090,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saphyr-parser"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbeae0f40b92f2afe16422744aabb145187167184cc18bf4d01da5acdc665f09"
+dependencies = [
+ "arraydeque",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3406,7 +3429,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4153,7 +4176,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
     "crates/fsm",
     "crates/resource",
     "crates/instrumentation-build",
+    "crates/yaml",
 ]
 
 # The instrumentation-build example is deliberately its own workspace (see its

--- a/crates/yaml/Cargo.toml
+++ b/crates/yaml/Cargo.toml
@@ -9,5 +9,5 @@ publish.workspace = true
 # archived, and saphyr is its maintained successor lineage. Pinned exactly
 # because the tree builder relies on parser-level details (spanned events,
 # scalar styles, anchor ids) that may shift between pre-1.0 releases.
-saphyr-parser = "=0.0.9"
+saphyr-parser = "=0.0.11"
 strsim = "0.11"

--- a/crates/yaml/Cargo.toml
+++ b/crates/yaml/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-# Pinned exactly: the tree builder relies on parser-level details (spanned
-# events, scalar styles, anchor ids) of a pre-1.0 crate.
+# No Rust YAML parser has reached 1.0: serde_yaml stopped at 0.9 and is
+# archived, and saphyr is its maintained successor lineage. Pinned exactly
+# because the tree builder relies on parser-level details (spanned events,
+# scalar styles, anchor ids) that may shift between pre-1.0 releases.
 saphyr-parser = "=0.0.9"
+strsim = "0.11"

--- a/crates/yaml/Cargo.toml
+++ b/crates/yaml/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "quent-yaml"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+# Pinned exactly: the tree builder relies on parser-level details (spanned
+# events, scalar styles, anchor ids) of a pre-1.0 crate.
+saphyr-parser = "=0.0.9"

--- a/crates/yaml/src/diag.rs
+++ b/crates/yaml/src/diag.rs
@@ -8,7 +8,7 @@ use saphyr_parser::Span;
 /// A single located problem in a YAML model source.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
-    /// The source file name, or `"<input>"` for [`crate::load_str`].
+    /// The source file name, or `"<input>"` for text loaded without one.
     pub file: String,
     /// Source line, counted from 1 as editors display it.
     pub line: usize,
@@ -26,9 +26,12 @@ impl std::fmt::Display for Diagnostic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}:{}:{}: {} ({})",
-            self.file, self.line, self.column, self.message, self.path
+            "{}:{}:{}: {}",
+            self.file, self.line, self.column, self.message
         )?;
+        if !self.path.is_empty() {
+            write!(f, " ({})", self.path)?;
+        }
         if let Some(help) = &self.help {
             write!(f, "\n  help: {help}")?;
         }
@@ -36,7 +39,7 @@ impl std::fmt::Display for Diagnostic {
     }
 }
 
-/// A non-empty collection of [`Diagnostic`]s from one load.
+/// The problems collected from one load, in the order they were detected.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostics(pub(crate) Vec<Diagnostic>);
 
@@ -129,7 +132,7 @@ pub(crate) fn suggest<'c>(
     name: &str,
     candidates: impl IntoIterator<Item = &'c str>,
 ) -> Option<&'c str> {
-    let max_distance = (name.len() / 3).max(1);
+    let max_distance = (name.chars().count() / 3).max(1);
     candidates
         .into_iter()
         .map(|c| (strsim::levenshtein(name, c), c))

--- a/crates/yaml/src/diag.rs
+++ b/crates/yaml/src/diag.rs
@@ -10,9 +10,9 @@ use saphyr_parser::Span;
 pub struct Diagnostic {
     /// The source file name, or `"<input>"` for [`crate::load_str`].
     pub file: String,
-    /// 1-based source line.
+    /// Source line, counted from 1 as editors display it.
     pub line: usize,
-    /// 1-based source column.
+    /// Source column, counted from 1 as editors display it.
     pub column: usize,
     /// Dotted semantic path, e.g. `entities.Engine.events.started.once.load`.
     pub path: String,
@@ -106,7 +106,7 @@ impl Sink {
         Diagnostic {
             file: self.file.clone(),
             line: span.start.line(),
-            // saphyr markers are 0-based in the column.
+            // saphyr marker columns count from 0; displayed columns from 1.
             column: span.start.col() + 1,
             path: path.to_string(),
             message,
@@ -132,39 +132,15 @@ pub(crate) fn suggest<'c>(
     let max_distance = (name.len() / 3).max(1);
     candidates
         .into_iter()
-        .map(|c| (levenshtein(name, c), c))
+        .map(|c| (strsim::levenshtein(name, c), c))
         .filter(|&(d, _)| d <= max_distance)
         .min_by_key(|&(d, _)| d)
         .map(|(_, c)| c)
 }
 
-fn levenshtein(a: &str, b: &str) -> usize {
-    let b: Vec<char> = b.chars().collect();
-    let mut row: Vec<usize> = (0..=b.len()).collect();
-    for (i, ca) in a.chars().enumerate() {
-        let mut prev = row[0];
-        row[0] = i + 1;
-        for (j, &cb) in b.iter().enumerate() {
-            let cost = if ca == cb { prev } else { prev + 1 };
-            prev = row[j + 1];
-            row[j + 1] = cost.min(prev + 1).min(row[j] + 1);
-        }
-    }
-    row[b.len()]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn levenshtein_basics() {
-        assert_eq!(levenshtein("", ""), 0);
-        assert_eq!(levenshtein("abc", "abc"), 0);
-        assert_eq!(levenshtein("abc", "abd"), 1);
-        assert_eq!(levenshtein("strin", "string"), 1);
-        assert_eq!(levenshtein("kitten", "sitting"), 3);
-    }
 
     #[test]
     fn suggest_picks_closest_within_bound() {

--- a/crates/yaml/src/diag.rs
+++ b/crates/yaml/src/diag.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Located diagnostics for YAML model sources.
+
+use saphyr_parser::Span;
+
+/// A single located problem in a YAML model source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    /// The source file name, or `"<input>"` for [`crate::load_str`].
+    pub file: String,
+    /// 1-based source line.
+    pub line: usize,
+    /// 1-based source column.
+    pub column: usize,
+    /// Dotted semantic path, e.g. `entities.Engine.events.started.once.load`.
+    pub path: String,
+    /// What is wrong.
+    pub message: String,
+    /// Optional hint on how to fix it.
+    pub help: Option<String>,
+}
+
+impl std::fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}: {} ({})",
+            self.file, self.line, self.column, self.message, self.path
+        )?;
+        if let Some(help) = &self.help {
+            write!(f, "\n  help: {help}")?;
+        }
+        Ok(())
+    }
+}
+
+/// A non-empty collection of [`Diagnostic`]s from one load.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostics(pub(crate) Vec<Diagnostic>);
+
+impl Diagnostics {
+    /// The diagnostics, in source order of detection.
+    pub fn iter(&self) -> impl Iterator<Item = &Diagnostic> + '_ {
+        self.0.iter()
+    }
+}
+
+impl std::fmt::Display for Diagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, d) in self.0.iter().enumerate() {
+            if i > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "{d}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for Diagnostics {}
+
+impl IntoIterator for Diagnostics {
+    type Item = Diagnostic;
+    type IntoIter = std::vec::IntoIter<Diagnostic>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Collector that stamps every diagnostic with the source file name.
+///
+/// Lowering pushes into one shared sink so a single run reports every problem
+/// instead of aborting at the first.
+pub(crate) struct Sink {
+    file: String,
+    out: Vec<Diagnostic>,
+}
+
+impl Sink {
+    pub(crate) fn new(file: impl Into<String>) -> Self {
+        Self {
+            file: file.into(),
+            out: Vec::new(),
+        }
+    }
+
+    pub(crate) fn error(
+        &mut self,
+        span: Span,
+        path: &str,
+        message: impl Into<String>,
+        help: Option<String>,
+    ) {
+        self.out.push(self.make(span, path, message.into(), help));
+    }
+
+    pub(crate) fn make(
+        &self,
+        span: Span,
+        path: &str,
+        message: String,
+        help: Option<String>,
+    ) -> Diagnostic {
+        Diagnostic {
+            file: self.file.clone(),
+            line: span.start.line(),
+            // saphyr markers are 0-based in the column.
+            column: span.start.col() + 1,
+            path: path.to_string(),
+            message,
+            help,
+        }
+    }
+
+    pub(crate) fn has_errors(&self) -> bool {
+        !self.out.is_empty()
+    }
+
+    pub(crate) fn into_diagnostics(self) -> Diagnostics {
+        Diagnostics(self.out)
+    }
+}
+
+/// Return the closest of `candidates` to `name`, if any is close enough to be
+/// a plausible typo.
+pub(crate) fn suggest<'c>(
+    name: &str,
+    candidates: impl IntoIterator<Item = &'c str>,
+) -> Option<&'c str> {
+    let max_distance = (name.len() / 3).max(1);
+    candidates
+        .into_iter()
+        .map(|c| (levenshtein(name, c), c))
+        .filter(|&(d, _)| d <= max_distance)
+        .min_by_key(|&(d, _)| d)
+        .map(|(_, c)| c)
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut row: Vec<usize> = (0..=b.len()).collect();
+    for (i, ca) in a.chars().enumerate() {
+        let mut prev = row[0];
+        row[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = if ca == cb { prev } else { prev + 1 };
+            prev = row[j + 1];
+            row[j + 1] = cost.min(prev + 1).min(row[j] + 1);
+        }
+    }
+    row[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("abc", "abd"), 1);
+        assert_eq!(levenshtein("strin", "string"), 1);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+    }
+
+    #[test]
+    fn suggest_picks_closest_within_bound() {
+        assert_eq!(suggest("strin", ["string", "bool", "u16"]), Some("string"));
+        assert_eq!(suggest("zzz", ["string", "bool"]), None);
+    }
+}

--- a/crates/yaml/src/lib.rs
+++ b/crates/yaml/src/lib.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! YAML source format for `quent-schema` application event models.
+//!
+//! This is the foundation slice: located [`Diagnostics`] and the owned,
+//! spanned YAML tree the format is parsed into. The format itself (mapping
+//! walking, the type mini-language, lowering to a schema, and the load API)
+//! follows in the next changes.
+
+// The tree is only consumed by the upcoming lowering; removed with it.
+#![allow(dead_code)]
+
+mod diag;
+mod tree;
+
+pub use diag::{Diagnostic, Diagnostics};

--- a/crates/yaml/src/lib.rs
+++ b/crates/yaml/src/lib.rs
@@ -3,10 +3,10 @@
 
 //! YAML source format for `quent-schema` application event models.
 //!
-//! This is the foundation slice: located [`Diagnostics`] and the owned,
-//! spanned YAML tree the format is parsed into. The format itself (mapping
-//! walking, the type mini-language, lowering to a schema, and the load API)
-//! follows in the next changes.
+//! This is the foundation slice: located [`Diagnostics`] and the owned YAML
+//! tree the format is parsed into, which carries source positions on every
+//! node. The format itself (mapping access, the type mini-language, lowering
+//! to a schema, and the load API) follows in the next changes.
 
 // The tree is only consumed by the upcoming lowering; removed with it.
 #![allow(dead_code)]

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -48,7 +48,7 @@ impl Node {
     }
 }
 
-/// What a plain scalar resolves to under the YAML 1.2 Core schema.
+/// What an unquoted scalar's text means under the YAML 1.2 Core schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Resolved {
     Null,
@@ -58,7 +58,13 @@ pub(crate) enum Resolved {
     Str,
 }
 
-/// Resolve a plain scalar's text under the YAML 1.2 Core schema.
+/// Decide what an unquoted scalar's text means.
+///
+/// The parser hands scalars over as raw text; YAML's typing of unquoted
+/// ("plain") scalars is the 1.2 Core schema implemented here: `true` is a
+/// boolean, `42` an integer, `~` null, and so on, while anything quoted is
+/// always a string. This backs null handling, the quote-your-name rule, and
+/// annotation payload conversion.
 pub(crate) fn resolve_plain(text: &str) -> Resolved {
     match text {
         "" | "~" | "null" | "Null" | "NULL" => Resolved::Null,

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -65,6 +65,11 @@ pub(crate) enum Resolved {
 /// boolean, `42` an integer, `~` null, and so on, while anything quoted is
 /// always a string. This backs null handling, the quote-your-name rule, and
 /// annotation payload conversion.
+///
+/// Classification is by pattern, deliberately not via `saphyr`'s own scalar
+/// parsing: that parses values and silently falls back to string when a
+/// number does not fit (an overflowing integer would quietly load as text),
+/// which would make such cases undiagnosable.
 pub(crate) fn resolve_plain(text: &str) -> Resolved {
     match text {
         "" | "~" | "null" | "Null" | "NULL" => Resolved::Null,

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -1,14 +1,27 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Owned, spanned YAML tree built from the saphyr parser event stream.
+//! Owned YAML tree built from the saphyr parser event stream, with a source
+//! span (position range) on every node.
 //!
-//! Built at the event level rather than through a serde deserializer (such as
-//! the archived serde_yaml) because the serde data model cannot deliver what
-//! a source language needs: it carries no source spans, silently keeps the
-//! last value for duplicate mapping keys, and stops at the first error. The
-//! event stream keeps every node's span, lets duplicate keys survive until
-//! they can be diagnosed, and leaves scalar styles observable.
+//! YAML terms used throughout this crate: a *scalar* is a single value (as
+//! opposed to a *mapping*, keys to values, and a *sequence*, a list), and a
+//! scalar's *style* is how it is written: unquoted (called *plain* in YAML),
+//! quoted, or as an indented block. `&name` puts an *anchor* on a node and
+//! `*name` (an *alias*) reuses the anchored node elsewhere.
+//!
+//! The tree is built at the event level rather than through the two obvious
+//! shortcuts, because both discard what a source language must report:
+//!
+//! - A serde deserializer (such as the archived serde_yaml) carries no
+//!   source positions, silently keeps the last value for duplicate mapping
+//!   keys, and stops at the first error.
+//! - saphyr's own trees (`Yaml`, the span-annotated `MarkedYaml`) also keep
+//!   the last duplicate key silently, and store scalars as parsed values,
+//!   losing the original text and style.
+//!
+//! The event stream keeps every node's span, lets duplicate keys survive
+//! until they can be diagnosed, and leaves styles observable.
 
 use std::collections::HashMap;
 
@@ -31,7 +44,7 @@ pub(crate) enum Kind {
 }
 
 impl Node {
-    /// The scalar text and style, if this node is a scalar.
+    /// The text and quoting style, if this node is a scalar (single value).
     pub(crate) fn scalar(&self) -> Option<(&str, ScalarStyle)> {
         match &self.kind {
             Kind::Scalar { text, style } => Some((text, *style)),
@@ -39,7 +52,7 @@ impl Node {
         }
     }
 
-    /// True if this node is a plain scalar that resolves to null.
+    /// True if this node is an unquoted scalar meaning null.
     pub(crate) fn is_null(&self) -> bool {
         matches!(
             self.scalar(),
@@ -81,11 +94,11 @@ pub(crate) fn resolve_plain(text: &str) -> Resolved {
     }
 }
 
-/// What a plain scalar in a name position would wrongly resolve to, phrased
-/// for a diagnostic. `None` when the scalar is a string (or not plain).
+/// What an unquoted scalar in a name position would wrongly mean, phrased
+/// for a diagnostic. `None` when it reads as a string (or is quoted).
 ///
-/// This is the single quoting rule for name positions, shared by mapping keys
-/// and name-valued scalars.
+/// This is the single quoting rule for name positions, shared by mapping
+/// keys and name-valued scalars.
 pub(crate) fn non_string_kind(text: &str, style: ScalarStyle) -> Option<&'static str> {
     if style != ScalarStyle::Plain {
         return None;
@@ -159,9 +172,10 @@ enum Frame {
 
 /// Parse `src` into a single-document tree.
 ///
-/// Structural problems (scan errors, tags, merge keys, aliases to unknown
-/// anchors, multiple documents) abort with one located diagnostic; everything
-/// past this point reports multiple diagnostics per run.
+/// Structural problems abort with one located diagnostic: syntax errors,
+/// tags (`!!type` markers), merge keys (`<<`, YAML 1.1 mapping inheritance),
+/// aliases to unknown anchors, and multiple `---`-separated documents in one
+/// file. Everything past this point reports multiple diagnostics per run.
 pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
     if let Some(line) = leading_directive(src) {
         sink.error(
@@ -313,7 +327,7 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
     root
 }
 
-/// A zero-width span at a line and column counted from 1, as editors
+/// An empty position range at a line and column counted from 1, as editors
 /// display them, for errors that have no parsed node.
 fn span_at(line: usize, column: usize) -> Span {
     // Sink adds 1 to marker columns, which count from 0.

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -3,9 +3,12 @@
 
 //! Owned, spanned YAML tree built from the saphyr parser event stream.
 //!
-//! Built at the event level rather than through serde or a stock YAML tree so
-//! that every node keeps its source span, duplicate mapping keys survive until
-//! they can be diagnosed, and scalar styles remain observable.
+//! Built at the event level rather than through a serde deserializer (such as
+//! the archived serde_yaml) because the serde data model cannot deliver what
+//! a source language needs: it carries no source spans, silently keeps the
+//! last value for duplicate mapping keys, and stops at the first error. The
+//! event stream keeps every node's span, lets duplicate keys survive until
+//! they can be diagnosed, and leaves scalar styles observable.
 
 use std::collections::HashMap;
 
@@ -163,8 +166,9 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
     let mut anchors: HashMap<usize, Node> = HashMap::new();
     let mut root: Option<Node> = None;
     let mut document_seen = false;
-    // Total nodes materialized through aliases, capping pathological
-    // expansion (billion laughs) of otherwise tiny inputs.
+    // Total nodes materialized through aliases, capping the "Billion
+    // Laughs" attack: aliases of nested anchors can expand a tiny input
+    // exponentially.
     let mut alias_nodes: usize = 0;
     const MAX_ALIAS_NODES: usize = 65_536;
 
@@ -194,7 +198,7 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
                     sink.error(
                         span,
                         "",
-                        "multiple YAML documents are not supported",
+                        "multiple YAML documents are not supported yet",
                         Some("keep the model in a single document".to_string()),
                     );
                     return None;
@@ -298,10 +302,10 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
     root
 }
 
-/// A zero-width span at a 1-based line and column, for errors that have no
-/// parsed node.
+/// A zero-width span at a line and column counted from 1, as editors
+/// display them, for errors that have no parsed node.
 fn span_at(line: usize, column: usize) -> Span {
-    // Sink renders 0-based marker columns as 1-based.
+    // Sink adds 1 to marker columns, which count from 0.
     let marker = saphyr_parser::Marker::new(0, line, column.saturating_sub(1));
     Span {
         start: marker,
@@ -341,7 +345,8 @@ fn attach(
     true
 }
 
-/// The 1-based line of a leading `%` directive, if the document has one.
+/// The line of a leading `%` directive, counted from 1, if the document has
+/// one.
 ///
 /// Directives are only legal before the content starts, so scanning stops at
 /// the first line that is not blank, a comment, or a directive.

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -70,8 +70,8 @@ pub(crate) fn resolve_plain(text: &str) -> Resolved {
         "" | "~" | "null" | "Null" | "NULL" => Resolved::Null,
         "true" | "True" | "TRUE" => Resolved::Bool(true),
         "false" | "False" | "FALSE" => Resolved::Bool(false),
-        _ if is_core_int(text) => Resolved::Int,
-        _ if is_core_float(text) => Resolved::Float,
+        _ if reads_as_int(text) => Resolved::Int,
+        _ if reads_as_float(text) => Resolved::Float,
         _ => Resolved::Str,
     }
 }
@@ -94,7 +94,7 @@ pub(crate) fn non_string_kind(text: &str, style: ScalarStyle) -> Option<&'static
     }
 }
 
-fn is_core_int(s: &str) -> bool {
+fn reads_as_int(s: &str) -> bool {
     if let Some(hex) = s.strip_prefix("0x") {
         return !hex.is_empty() && hex.bytes().all(|b| b.is_ascii_hexdigit());
     }
@@ -105,7 +105,7 @@ fn is_core_int(s: &str) -> bool {
     !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
 }
 
-fn is_core_float(s: &str) -> bool {
+fn reads_as_float(s: &str) -> bool {
     if matches!(s, ".nan" | ".NaN" | ".NAN") {
         return true;
     }

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -4,11 +4,9 @@
 //! Owned YAML tree built from the saphyr parser event stream, with a source
 //! span (position range) on every node.
 //!
-//! YAML terms used throughout this crate: a *scalar* is a single value (as
-//! opposed to a *mapping*, keys to values, and a *sequence*, a list), and a
-//! scalar's *style* is how it is written: unquoted (called *plain* in YAML),
-//! quoted, or as an indented block. `&name` puts an *anchor* on a node and
-//! `*name` (an *alias*) reuses the anchored node elsewhere.
+//! A scalar's *style* is how it is written: unquoted (called *plain* in
+//! YAML), quoted, or as an indented block. `&name` puts an *anchor* on a
+//! node and `*name` (an *alias*) reuses the anchored node elsewhere.
 //!
 //! The tree is built at the event level rather than through the two obvious
 //! shortcuts, because both discard what a source language must report:
@@ -44,7 +42,7 @@ pub(crate) enum Kind {
 }
 
 impl Node {
-    /// The text and quoting style, if this node is a scalar (single value).
+    /// The text and quoting style, if this node is a scalar.
     pub(crate) fn scalar(&self) -> Option<(&str, ScalarStyle)> {
         match &self.kind {
             Kind::Scalar { text, style } => Some((text, *style)),

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -1,21 +1,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Owned YAML tree built from the saphyr parser event stream, with a source
-//! span (position range) on every node.
+//! Owned YAML tree with a source position on every node.
 //!
-//! The tree is built at the event level rather than through the two obvious
-//! shortcuts, because both discard what a source language must report:
+//! A YAML parser can hand back a document in three ways, and this builds the
+//! tree from the lowest of them: the stream of parse events (start mapping,
+//! scalar, end mapping, ...). The two higher-level options both throw away
+//! what a source language must report on:
 //!
-//! - A serde deserializer (such as the archived serde_yaml) carries no
-//!   source positions, silently keeps the last value for duplicate mapping
-//!   keys, and stops at the first error.
-//! - saphyr's own trees (`Yaml`, the span-annotated `MarkedYaml`) also keep
-//!   the last duplicate key silently, and store scalars as parsed values,
-//!   losing the original text and style.
+//! - Deserializing straight into typed structs (as serde_yaml does) drops
+//!   source positions, keeps only the last of any duplicated key, and stops
+//!   at the first error.
+//! - A ready-made document tree (saphyr's own `Yaml` / `MarkedYaml`) also
+//!   silently keeps the last duplicate key, and stores each scalar as an
+//!   already-parsed value, losing its original text and quoting.
 //!
-//! The event stream keeps every node's span, lets duplicate keys survive
-//! until they can be diagnosed, and leaves styles observable.
+//! Building from the event stream keeps every node's position, lets duplicate
+//! keys survive until they can be reported, and leaves each scalar's original
+//! text intact.
 
 use std::collections::HashMap;
 

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -168,13 +168,28 @@ enum Frame {
     },
 }
 
+/// Nesting depth past which a document is rejected. saphyr limits flow
+/// collection depth but not block collections, and the tree's recursive
+/// `Drop`/`Clone` would overflow the stack on a deep enough tree.
+const MAX_DEPTH: usize = 128;
+
+/// Byte budget for content reused through anchors and aliases, bounding the
+/// "Billion Laughs" memory amplification (a tiny input whose aliases clone
+/// large or nested anchored content many times over).
+const MAX_REUSE_BYTES: usize = 64 << 20;
+
 /// Parse `src` into a single-document tree.
 ///
 /// Structural problems abort with one located diagnostic: syntax errors,
 /// tags (`!!type` markers), merge keys (`<<`, YAML 1.1 mapping inheritance),
-/// aliases to unknown anchors, and multiple `---`-separated documents in one
-/// file. Everything past this point reports multiple diagnostics per run.
+/// directives (`%...`), aliases to unknown anchors, multiple `---`-separated
+/// documents in one file, and inputs exceeding the depth or reuse limits.
+/// Everything past this point reports multiple diagnostics per run.
 pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
+    // Editors often save a leading byte-order mark; saphyr would otherwise
+    // fold it into the first scalar's text.
+    let src = src.strip_prefix('\u{feff}').unwrap_or(src);
+
     if let Some(line) = leading_directive(src) {
         sink.error(
             span_at(line, 1),
@@ -189,11 +204,8 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
     let mut anchors: HashMap<usize, Node> = HashMap::new();
     let mut root: Option<Node> = None;
     let mut document_seen = false;
-    // Total nodes materialized through aliases, capping the "Billion
-    // Laughs" attack: aliases of nested anchors can expand a tiny input
-    // exponentially.
-    let mut alias_nodes: usize = 0;
-    const MAX_ALIAS_NODES: usize = 65_536;
+    // Bytes cloned for anchor registration and alias expansion so far.
+    let mut reused: usize = 0;
 
     for item in Parser::new_from_str(src) {
         let (event, span) = match item {
@@ -236,26 +248,35 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
                         style,
                     },
                 };
-                if !attach(&mut stack, &mut root, &mut anchors, aid, node, sink) {
+                if !attach(
+                    &mut stack,
+                    &mut root,
+                    &mut anchors,
+                    aid,
+                    node,
+                    &mut reused,
+                    sink,
+                ) {
                     return None;
                 }
             }
             Event::Alias(aid) => match anchors.get(&aid) {
                 Some(node) => {
-                    alias_nodes += node_count(node);
-                    if alias_nodes > MAX_ALIAS_NODES {
-                        sink.error(
-                            span,
-                            "",
-                            format!("alias expansion exceeds {MAX_ALIAS_NODES} nodes"),
-                            None,
-                        );
+                    if !charge(&mut reused, node_bytes(node), span, sink) {
                         return None;
                     }
                     // Keep the anchor's spans: diagnostics inside aliased
                     // content should point at where the content is written.
                     let node = node.clone();
-                    if !attach(&mut stack, &mut root, &mut anchors, 0, node, sink) {
+                    if !attach(
+                        &mut stack,
+                        &mut root,
+                        &mut anchors,
+                        0,
+                        node,
+                        &mut reused,
+                        sink,
+                    ) {
                         return None;
                     }
                 }
@@ -270,6 +291,15 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
                 }
             },
             Event::SequenceStart(aid, _) => {
+                if stack.len() >= MAX_DEPTH {
+                    sink.error(
+                        span,
+                        "",
+                        format!("nesting exceeds the maximum depth of {MAX_DEPTH}"),
+                        None,
+                    );
+                    return None;
+                }
                 stack.push(Frame::Seq {
                     span,
                     aid,
@@ -277,18 +307,40 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
                 });
             }
             Event::SequenceEnd => {
-                let Some(Frame::Seq { span, aid, items }) = stack.pop() else {
+                let Some(Frame::Seq {
+                    span: start,
+                    aid,
+                    items,
+                }) = stack.pop()
+                else {
                     unreachable!("parser balances sequence events");
                 };
                 let node = Node {
-                    span,
+                    span: enclosing(start, span),
                     kind: Kind::Seq(items),
                 };
-                if !attach(&mut stack, &mut root, &mut anchors, aid, node, sink) {
+                if !attach(
+                    &mut stack,
+                    &mut root,
+                    &mut anchors,
+                    aid,
+                    node,
+                    &mut reused,
+                    sink,
+                ) {
                     return None;
                 }
             }
             Event::MappingStart(aid, _) => {
+                if stack.len() >= MAX_DEPTH {
+                    sink.error(
+                        span,
+                        "",
+                        format!("nesting exceeds the maximum depth of {MAX_DEPTH}"),
+                        None,
+                    );
+                    return None;
+                }
                 stack.push(Frame::Map {
                     span,
                     aid,
@@ -298,31 +350,73 @@ pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
             }
             Event::MappingEnd => {
                 let Some(Frame::Map {
-                    span, aid, pairs, ..
+                    span: start,
+                    aid,
+                    pairs,
+                    ..
                 }) = stack.pop()
                 else {
                     unreachable!("parser balances mapping events");
                 };
                 let node = Node {
-                    span,
+                    span: enclosing(start, span),
                     kind: Kind::Map(pairs),
                 };
-                if !attach(&mut stack, &mut root, &mut anchors, aid, node, sink) {
+                if !attach(
+                    &mut stack,
+                    &mut root,
+                    &mut anchors,
+                    aid,
+                    node,
+                    &mut reused,
+                    sink,
+                ) {
                     return None;
                 }
             }
         }
     }
 
-    if root.is_none() {
+    // An empty document (`""`) or an explicit-empty one (`---`, `~`) leaves no
+    // mapping to build a model from.
+    match root {
+        Some(node) if !node.is_null() => Some(node),
+        node => {
+            let span = node.map_or_else(|| span_at(1, 1), |n| n.span);
+            sink.error(
+                span,
+                "",
+                "empty document; expected a mapping at the root",
+                None,
+            );
+            None
+        }
+    }
+}
+
+/// The span from `start`'s beginning to `end`'s end, for a collection whose
+/// bounds arrive on separate events.
+fn enclosing(start: Span, end: Span) -> Span {
+    Span {
+        start: start.start,
+        end: end.end,
+    }
+}
+
+/// Charge `bytes` against the anchor/alias reuse budget, reporting at `span`
+/// and returning false when it would be exceeded.
+fn charge(reused: &mut usize, bytes: usize, span: Span, sink: &mut Sink) -> bool {
+    *reused += bytes;
+    if *reused > MAX_REUSE_BYTES {
         sink.error(
-            span_at(1, 1),
+            span,
             "",
-            "empty document; expected a mapping at the root",
+            format!("anchor and alias reuse exceeds {MAX_REUSE_BYTES} bytes"),
             None,
         );
+        return false;
     }
-    root
+    true
 }
 
 /// An empty position range at a line and column counted from 1, as editors
@@ -346,9 +440,13 @@ fn attach(
     anchors: &mut HashMap<usize, Node>,
     aid: usize,
     node: Node,
+    reused: &mut usize,
     sink: &mut Sink,
 ) -> bool {
     if aid != 0 {
+        if !charge(reused, node_bytes(&node), node.span, sink) {
+            return false;
+        }
         anchors.insert(aid, node.clone());
     }
     match stack.last_mut() {
@@ -372,9 +470,11 @@ fn attach(
 /// one.
 ///
 /// Directives are only legal before the content starts, so scanning stops at
-/// the first line that is not blank, a comment, or a directive.
+/// the first line that is not blank, a comment, or a directive. Splits on a
+/// lone `\r` as well, which saphyr treats as a line break but `str::lines`
+/// does not.
 fn leading_directive(src: &str) -> Option<usize> {
-    for (index, line) in src.lines().enumerate() {
+    for (index, line) in src.split(['\n', '\r']).enumerate() {
         let trimmed = line.trim_start();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
@@ -387,14 +487,17 @@ fn leading_directive(src: &str) -> Option<usize> {
     None
 }
 
-/// The number of nodes in a subtree, matching the cost of cloning it.
-fn node_count(node: &Node) -> usize {
+/// The byte weight of a subtree, approximating the memory to clone it: one
+/// byte per node plus the length of every scalar's text.
+///
+/// Recursion is bounded by [`MAX_DEPTH`], enforced before any subtree grows.
+fn node_bytes(node: &Node) -> usize {
     1 + match &node.kind {
-        Kind::Scalar { .. } => 0,
-        Kind::Seq(items) => items.iter().map(node_count).sum(),
+        Kind::Scalar { text, .. } => text.len(),
+        Kind::Seq(items) => items.iter().map(node_bytes).sum(),
         Kind::Map(pairs) => pairs
             .iter()
-            .map(|(k, v)| node_count(k) + node_count(v))
+            .map(|(k, v)| node_bytes(k) + node_bytes(v))
             .sum(),
     }
 }
@@ -467,7 +570,39 @@ mod tests {
         // Undefined aliases are a scan error in saphyr itself; the in-tree
         // alias branch remains as a backstop.
         assert!(parse_err("a: *nope\n").contains("unknown anchor"));
-        assert!(parse_err("").contains("empty document"));
         assert!(parse_err("a: [1\n").contains("YAML syntax error"));
+        assert!(parse_err("%YAML 1.1\n---\na: 1\n").contains("directives are not supported"));
+        // A lone carriage return is a line break to saphyr but not to
+        // `str::lines`, so the directive must still be caught.
+        assert!(parse_err("\r%YAML 1.1\n---\na: 1\n").contains("directives are not supported"));
+    }
+
+    #[test]
+    fn rejects_empty_documents() {
+        assert!(parse_err("").contains("empty document"));
+        // An explicit-empty document yields a null scalar, not no root.
+        assert!(parse_err("---\n").contains("empty document"));
+        assert!(parse_err("~\n").contains("empty document"));
+    }
+
+    #[test]
+    fn strips_leading_byte_order_mark() {
+        let root = parse_ok("\u{feff}a: 1\n");
+        let Kind::Map(pairs) = &root.kind else {
+            panic!("expected map");
+        };
+        assert_eq!(pairs[0].0.scalar().unwrap().0, "a");
+    }
+
+    #[test]
+    fn rejects_excessive_depth() {
+        let deep = "- ".repeat(MAX_DEPTH + 10);
+        assert!(parse_err(&deep).contains("maximum depth"));
+    }
+
+    #[test]
+    fn collection_span_reaches_its_end() {
+        let root = parse_ok("a: 1\nb: 2\n");
+        assert!(root.span.end.line() >= 2, "map span should reach its end");
     }
 }

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -1,0 +1,445 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Owned, spanned YAML tree built from the saphyr parser event stream.
+//!
+//! Built at the event level rather than through serde or a stock YAML tree so
+//! that every node keeps its source span, duplicate mapping keys survive until
+//! they can be diagnosed, and scalar styles remain observable.
+
+use std::collections::HashMap;
+
+use saphyr_parser::{Event, Parser, ScalarStyle, Span};
+
+use crate::diag::Sink;
+
+/// A YAML node with its source span.
+#[derive(Debug, Clone)]
+pub(crate) struct Node {
+    pub(crate) span: Span,
+    pub(crate) kind: Kind,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum Kind {
+    Scalar { text: String, style: ScalarStyle },
+    Seq(Vec<Node>),
+    Map(Vec<(Node, Node)>),
+}
+
+impl Node {
+    /// The scalar text and style, if this node is a scalar.
+    pub(crate) fn scalar(&self) -> Option<(&str, ScalarStyle)> {
+        match &self.kind {
+            Kind::Scalar { text, style } => Some((text, *style)),
+            _ => None,
+        }
+    }
+
+    /// True if this node is a plain scalar that resolves to null.
+    pub(crate) fn is_null(&self) -> bool {
+        matches!(
+            self.scalar(),
+            Some((text, ScalarStyle::Plain)) if matches!(resolve_plain(text), Resolved::Null)
+        )
+    }
+}
+
+/// What a plain scalar resolves to under the YAML 1.2 Core schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Resolved {
+    Null,
+    Bool(bool),
+    Int,
+    Float,
+    Str,
+}
+
+/// Resolve a plain scalar's text under the YAML 1.2 Core schema.
+pub(crate) fn resolve_plain(text: &str) -> Resolved {
+    match text {
+        "" | "~" | "null" | "Null" | "NULL" => Resolved::Null,
+        "true" | "True" | "TRUE" => Resolved::Bool(true),
+        "false" | "False" | "FALSE" => Resolved::Bool(false),
+        _ if is_core_int(text) => Resolved::Int,
+        _ if is_core_float(text) => Resolved::Float,
+        _ => Resolved::Str,
+    }
+}
+
+/// What a plain scalar in a name position would wrongly resolve to, phrased
+/// for a diagnostic. `None` when the scalar is a string (or not plain).
+///
+/// This is the single quoting rule for name positions, shared by mapping keys
+/// and name-valued scalars.
+pub(crate) fn non_string_kind(text: &str, style: ScalarStyle) -> Option<&'static str> {
+    if style != ScalarStyle::Plain {
+        return None;
+    }
+    match resolve_plain(text) {
+        Resolved::Str => None,
+        Resolved::Null => Some("null"),
+        Resolved::Bool(_) => Some("a boolean"),
+        Resolved::Int => Some("an integer"),
+        Resolved::Float => Some("a float"),
+    }
+}
+
+fn is_core_int(s: &str) -> bool {
+    if let Some(hex) = s.strip_prefix("0x") {
+        return !hex.is_empty() && hex.bytes().all(|b| b.is_ascii_hexdigit());
+    }
+    if let Some(oct) = s.strip_prefix("0o") {
+        return !oct.is_empty() && oct.bytes().all(|b| (b'0'..=b'7').contains(&b));
+    }
+    let digits = s.strip_prefix(['-', '+']).unwrap_or(s);
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn is_core_float(s: &str) -> bool {
+    if matches!(s, ".nan" | ".NaN" | ".NAN") {
+        return true;
+    }
+    let unsigned = s.strip_prefix(['-', '+']).unwrap_or(s);
+    if matches!(unsigned, ".inf" | ".Inf" | ".INF") {
+        return true;
+    }
+    // [0-9]+ (\. [0-9]*)? | \. [0-9]+ — followed by an optional exponent.
+    let mantissa = match unsigned.split_once(['e', 'E']) {
+        Some((m, exp)) => {
+            let exp_digits = exp.strip_prefix(['-', '+']).unwrap_or(exp);
+            if exp_digits.is_empty() || !exp_digits.bytes().all(|b| b.is_ascii_digit()) {
+                return false;
+            }
+            m
+        }
+        None => unsigned,
+    };
+    let (int_part, frac_part) = match mantissa.split_once('.') {
+        Some((i, f)) => (i, Some(f)),
+        None => (mantissa, None),
+    };
+    if !int_part.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    match frac_part {
+        // "." alone, or a fraction with non-digits, is not a float.
+        Some(f) => (!int_part.is_empty() || !f.is_empty()) && f.bytes().all(|b| b.is_ascii_digit()),
+        None => !int_part.is_empty(),
+    }
+}
+
+enum Frame {
+    Map {
+        span: Span,
+        aid: usize,
+        pairs: Vec<(Node, Node)>,
+        key: Option<Node>,
+    },
+    Seq {
+        span: Span,
+        aid: usize,
+        items: Vec<Node>,
+    },
+}
+
+/// Parse `src` into a single-document tree.
+///
+/// Structural problems (scan errors, tags, merge keys, aliases to unknown
+/// anchors, multiple documents) abort with one located diagnostic; everything
+/// past this point reports multiple diagnostics per run.
+pub(crate) fn parse(src: &str, sink: &mut Sink) -> Option<Node> {
+    if let Some(line) = leading_directive(src) {
+        sink.error(
+            span_at(line, 1),
+            "",
+            "YAML directives are not supported; model files are read as YAML 1.2",
+            None,
+        );
+        return None;
+    }
+
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut anchors: HashMap<usize, Node> = HashMap::new();
+    let mut root: Option<Node> = None;
+    let mut document_seen = false;
+    // Total nodes materialized through aliases, capping pathological
+    // expansion (billion laughs) of otherwise tiny inputs.
+    let mut alias_nodes: usize = 0;
+    const MAX_ALIAS_NODES: usize = 65_536;
+
+    for item in Parser::new_from_str(src) {
+        let (event, span) = match item {
+            Ok(ok) => ok,
+            Err(e) => {
+                let at = Span {
+                    start: *e.marker(),
+                    end: *e.marker(),
+                };
+                sink.error(at, "", format!("YAML syntax error: {}", e.info()), None);
+                return None;
+            }
+        };
+        if let Event::Scalar(_, _, _, Some(_))
+        | Event::SequenceStart(_, Some(_))
+        | Event::MappingStart(_, Some(_)) = &event
+        {
+            sink.error(span, "", "YAML tags are not supported in model files", None);
+            return None;
+        }
+        match event {
+            Event::StreamStart | Event::StreamEnd | Event::DocumentEnd | Event::Nothing => {}
+            Event::DocumentStart(_) => {
+                if document_seen {
+                    sink.error(
+                        span,
+                        "",
+                        "multiple YAML documents are not supported",
+                        Some("keep the model in a single document".to_string()),
+                    );
+                    return None;
+                }
+                document_seen = true;
+            }
+            Event::Scalar(text, style, aid, _) => {
+                let node = Node {
+                    span,
+                    kind: Kind::Scalar {
+                        text: text.into_owned(),
+                        style,
+                    },
+                };
+                if !attach(&mut stack, &mut root, &mut anchors, aid, node, sink) {
+                    return None;
+                }
+            }
+            Event::Alias(aid) => match anchors.get(&aid) {
+                Some(node) => {
+                    alias_nodes += node_count(node);
+                    if alias_nodes > MAX_ALIAS_NODES {
+                        sink.error(
+                            span,
+                            "",
+                            format!("alias expansion exceeds {MAX_ALIAS_NODES} nodes"),
+                            None,
+                        );
+                        return None;
+                    }
+                    // Keep the anchor's spans: diagnostics inside aliased
+                    // content should point at where the content is written.
+                    let node = node.clone();
+                    if !attach(&mut stack, &mut root, &mut anchors, 0, node, sink) {
+                        return None;
+                    }
+                }
+                None => {
+                    sink.error(
+                        span,
+                        "",
+                        "alias refers to an unknown or still-open anchor",
+                        None,
+                    );
+                    return None;
+                }
+            },
+            Event::SequenceStart(aid, _) => {
+                stack.push(Frame::Seq {
+                    span,
+                    aid,
+                    items: Vec::new(),
+                });
+            }
+            Event::SequenceEnd => {
+                let Some(Frame::Seq { span, aid, items }) = stack.pop() else {
+                    unreachable!("parser balances sequence events");
+                };
+                let node = Node {
+                    span,
+                    kind: Kind::Seq(items),
+                };
+                if !attach(&mut stack, &mut root, &mut anchors, aid, node, sink) {
+                    return None;
+                }
+            }
+            Event::MappingStart(aid, _) => {
+                stack.push(Frame::Map {
+                    span,
+                    aid,
+                    pairs: Vec::new(),
+                    key: None,
+                });
+            }
+            Event::MappingEnd => {
+                let Some(Frame::Map {
+                    span, aid, pairs, ..
+                }) = stack.pop()
+                else {
+                    unreachable!("parser balances mapping events");
+                };
+                let node = Node {
+                    span,
+                    kind: Kind::Map(pairs),
+                };
+                if !attach(&mut stack, &mut root, &mut anchors, aid, node, sink) {
+                    return None;
+                }
+            }
+        }
+    }
+
+    if root.is_none() {
+        sink.error(
+            span_at(1, 1),
+            "",
+            "empty document; expected a mapping at the root",
+            None,
+        );
+    }
+    root
+}
+
+/// A zero-width span at a 1-based line and column, for errors that have no
+/// parsed node.
+fn span_at(line: usize, column: usize) -> Span {
+    // Sink renders 0-based marker columns as 1-based.
+    let marker = saphyr_parser::Marker::new(0, line, column.saturating_sub(1));
+    Span {
+        start: marker,
+        end: marker,
+    }
+}
+
+/// Attach a completed node as the next key, value, or item.
+///
+/// This is the one point where a node becomes a mapping key, so merge keys
+/// (`<<`) are rejected here. Returns false after reporting one.
+fn attach(
+    stack: &mut [Frame],
+    root: &mut Option<Node>,
+    anchors: &mut HashMap<usize, Node>,
+    aid: usize,
+    node: Node,
+    sink: &mut Sink,
+) -> bool {
+    if aid != 0 {
+        anchors.insert(aid, node.clone());
+    }
+    match stack.last_mut() {
+        None => *root = Some(node),
+        Some(Frame::Map { pairs, key, .. }) => match key.take() {
+            None => {
+                if matches!(node.scalar(), Some(("<<", ScalarStyle::Plain))) {
+                    sink.error(node.span, "", "merge keys (`<<`) are not supported", None);
+                    return false;
+                }
+                *key = Some(node);
+            }
+            Some(k) => pairs.push((k, node)),
+        },
+        Some(Frame::Seq { items, .. }) => items.push(node),
+    }
+    true
+}
+
+/// The 1-based line of a leading `%` directive, if the document has one.
+///
+/// Directives are only legal before the content starts, so scanning stops at
+/// the first line that is not blank, a comment, or a directive.
+fn leading_directive(src: &str) -> Option<usize> {
+    for (index, line) in src.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if line.starts_with('%') {
+            return Some(index + 1);
+        }
+        return None;
+    }
+    None
+}
+
+/// The number of nodes in a subtree, matching the cost of cloning it.
+fn node_count(node: &Node) -> usize {
+    1 + match &node.kind {
+        Kind::Scalar { .. } => 0,
+        Kind::Seq(items) => items.iter().map(node_count).sum(),
+        Kind::Map(pairs) => pairs
+            .iter()
+            .map(|(k, v)| node_count(k) + node_count(v))
+            .sum(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_core_scalars() {
+        for s in ["", "~", "null", "NULL"] {
+            assert_eq!(resolve_plain(s), Resolved::Null, "{s:?}");
+        }
+        assert_eq!(resolve_plain("true"), Resolved::Bool(true));
+        assert_eq!(resolve_plain("False"), Resolved::Bool(false));
+        for s in ["0", "42", "-7", "+7", "0x1F", "0o755"] {
+            assert_eq!(resolve_plain(s), Resolved::Int, "{s:?}");
+        }
+        for s in [
+            "1.5", "-0.1", ".5", "2.", "1e5", "1.2e-3", ".inf", "-.Inf", ".nan",
+        ] {
+            assert_eq!(resolve_plain(s), Resolved::Float, "{s:?}");
+        }
+        // YAML 1.1-isms and near-misses stay strings under 1.2 Core.
+        for s in [
+            "on", "off", "yes", "no", "y", "n", "08x", "0o8", "1.2.3", ".", "e5", "1e", "opened",
+        ] {
+            assert_eq!(resolve_plain(s), Resolved::Str, "{s:?}");
+        }
+    }
+
+    fn parse_ok(src: &str) -> Node {
+        let mut sink = Sink::new("<test>");
+        let node = parse(src, &mut sink);
+        assert!(!sink.has_errors(), "{}", sink.into_diagnostics());
+        node.expect("root")
+    }
+
+    fn parse_err(src: &str) -> String {
+        let mut sink = Sink::new("<test>");
+        let node = parse(src, &mut sink);
+        assert!(node.is_none() || sink.has_errors());
+        sink.into_diagnostics().to_string()
+    }
+
+    #[test]
+    fn keeps_duplicate_keys_and_order() {
+        let root = parse_ok("a: 1\nb: 2\na: 3\n");
+        let Kind::Map(pairs) = &root.kind else {
+            panic!("expected map");
+        };
+        let keys: Vec<_> = pairs.iter().map(|(k, _)| k.scalar().unwrap().0).collect();
+        assert_eq!(keys, ["a", "b", "a"]);
+    }
+
+    #[test]
+    fn resolves_aliases_by_clone() {
+        let root = parse_ok("x: &a {v: 1}\ny: *a\n");
+        let Kind::Map(pairs) = &root.kind else {
+            panic!("expected map");
+        };
+        assert!(matches!(pairs[1].1.kind, Kind::Map(_)));
+    }
+
+    #[test]
+    fn rejects_structural_problems() {
+        assert!(parse_err("a: !!str x\n").contains("tags are not supported"));
+        assert!(parse_err("---\na: 1\n---\nb: 2\n").contains("multiple YAML documents"));
+        assert!(parse_err("base: &b {x: 1}\nd:\n  <<: *b\n").contains("merge keys"));
+        // Undefined aliases are a scan error in saphyr itself; the in-tree
+        // alias branch remains as a backstop.
+        assert!(parse_err("a: *nope\n").contains("unknown anchor"));
+        assert!(parse_err("").contains("empty document"));
+        assert!(parse_err("a: [1\n").contains("YAML syntax error"));
+    }
+}

--- a/crates/yaml/src/tree.rs
+++ b/crates/yaml/src/tree.rs
@@ -4,10 +4,6 @@
 //! Owned YAML tree built from the saphyr parser event stream, with a source
 //! span (position range) on every node.
 //!
-//! A scalar's *style* is how it is written: unquoted (called *plain* in
-//! YAML), quoted, or as an indented block. `&name` puts an *anchor* on a
-//! node and `*name` (an *alias*) reuses the anchored node elsewhere.
-//!
 //! The tree is built at the event level rather than through the two obvious
 //! shortcuts, because both discard what a source language must report:
 //!


### PR DESCRIPTION
# Description

First slice of a YAML source format for application event models. Adds the `quent-yaml` crate with its two foundations, and nothing yet built on top of them:

- **Located diagnostics** (`diag.rs`): a `Diagnostic` (file, line, column, semantic path, message, optional help) and a `Sink` that accumulates them so one load reports every problem instead of stopping at the first. Suggestions use `strsim`.
- **An owned YAML tree** (`tree.rs`) built from the saphyr parser's event stream rather than a deserializer or a ready-made document tree — those drop source positions, silently keep only the last of a duplicated key, and lose a scalar's original text. The event stream keeps every node's position, lets duplicate keys survive until they can be reported, and preserves scalar text. Structural problems abort with one located diagnostic: syntax errors, tags, merge keys, directives, unknown-anchor aliases, and multiple documents. Guards against resource exhaustion: a nesting-depth cap (a deeply nested block document would otherwise overflow the tree's recursive drop) and a byte budget on anchor/alias reuse (Billion Laughs). Strips a leading byte-order mark.

The format itself — mapping access, the type mini-language, lowering to a `quent_schema::Schema`, and the load API — follows in later PRs in this stack. `#![allow(dead_code)]` is intentional for this slice; the consumers land next.

## Related Issues

Part 1/6 of #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)