### PR TITLE
feat(timeline): pan time window with two-finger horizontal scroll

### DIFF
--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -370,6 +370,45 @@ export function Timeline({
       }
     });
 
+    // Two-finger horizontal trackpad scroll → pan the time window.
+    // Must be a capture-phase, non-passive listener so it fires before ECharts'
+    // child canvas sees the event, and so preventDefault() is permitted.
+    dom.addEventListener(
+      'wheel',
+      e => {
+        if (e.deltaX === 0 || Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+        if (instance.isDisposed?.()) return;
+
+        e.preventDefault();
+
+        const opt = instance.getOption() as {
+          dataZoom?: Array<{ start?: number; end?: number }>;
+        };
+        const dz = opt.dataZoom?.[0];
+        if (!dz) return;
+
+        const currentStart = dz.start ?? 0;
+        const currentEnd = dz.end ?? 100;
+        const spanPct = currentEnd - currentStart;
+
+        const rect = dom.getBoundingClientRect();
+        const usableWidth = Math.max(
+          1,
+          rect.width - TIMELINE_SPACING.left - TIMELINE_SPACING.right
+        );
+        const deltaPct = (e.deltaX / usableWidth) * spanPct;
+        const newStart = Math.max(0, Math.min(100 - spanPct, currentStart + deltaPct));
+
+        instance.dispatchAction({
+          type: 'dataZoom',
+          dataZoomIndex: 0,
+          start: newStart,
+          end: newStart + spanPct,
+        });
+      },
+      { capture: true, passive: false }
+    );
+
     // Pass non-shift wheel events through to the page for normal scrolling.
     // Without this, ECharts' inside dataZoom calls preventDefault on all wheel events.
     // When at the zoom limit, also block shift+wheel-in before ECharts sees it —

--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -371,14 +371,10 @@ export function Timeline({
     });
 
     // Two-finger horizontal trackpad scroll → pan the time window.
-    // Must be a capture-phase, non-passive listener so it fires before ECharts'
-    // child canvas sees the event, and so preventDefault() is permitted.
     dom.addEventListener(
       'wheel',
       e => {
-        // Shift+wheel is reserved for zooming — browsers remap deltaY to
-        // deltaX when shift is held, so without this guard the pan handler
-        // would swallow the zoom gesture.
+        // Shift+wheel is reserved for zoom; browsers remap deltaY to deltaX while shift is held.
         if (e.shiftKey) return;
         if (e.deltaX === 0 || Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
         if (instance.isDisposed?.()) return;

--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -376,6 +376,10 @@ export function Timeline({
     dom.addEventListener(
       'wheel',
       e => {
+        // Shift+wheel is reserved for zooming — browsers remap deltaY to
+        // deltaX when shift is held, so without this guard the pan handler
+        // would swallow the zoom gesture.
+        if (e.shiftKey) return;
         if (e.deltaX === 0 || Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
         if (instance.isDisposed?.()) return;
 


### PR DESCRIPTION
## Summary

Adds two-finger horizontal trackpad scrolling to pan the time window across the timeline view. When the pointer is over a timeline, a horizontal swipe slides the visible window left/right through time.

## How it works

A capture-phase, non-passive `wheel` listener on the Timeline chart:
- Detects a predominantly horizontal swipe (`|deltaX| > |deltaY|`), ignoring vertical scroll and shift+scroll zoom.
- Calls `preventDefault()` to suppress browser horizontal page scroll.
- Converts the pixel delta into a percentage of the current visible span and dispatches an ECharts `dataZoom` action, clamped to `[0, 100]`.

The action propagates through the existing ECharts connect group → `TimelineController` fires `onZoomChange` → `zoomRangeAtom` updates, so all stacked timelines, the controller bar, and the ruler stay in sync. Data re-fetches use the existing 150ms zoom debounce.

## Behavior preserved
- Vertical two-finger scroll → normal page scroll (unchanged).
- Shift + scroll → zoom (unchanged).

## Testing
Verified locally against the simulator backend with the Vite dev server: zoom in, then two-finger horizontal swipe pans the window; all charts and the ruler track together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)