### PR TITLE
fix(schema): mark unstable interface versions

### DIFF
--- a/crates/collector/proto/build.rs
+++ b/crates/collector/proto/build.rs
@@ -3,6 +3,6 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo::rerun-if-changed=../../../proto");
-    tonic_prost_build::compile_protos("../../../proto/quent/collector/v1/collector.proto")?;
+    tonic_prost_build::compile_protos("../../../proto/quent/collector/v1alpha/collector.proto")?;
     Ok(())
 }

--- a/crates/collector/proto/src/lib.rs
+++ b/crates/collector/proto/src/lib.rs
@@ -1,4 +1,4 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-tonic::include_proto!("quent.collector.v1");
+tonic::include_proto!("quent.collector.v1alpha");

--- a/crates/constraints/src/lib.rs
+++ b/crates/constraints/src/lib.rs
@@ -31,12 +31,12 @@ use quent_schema::{Schema, visitor::Visitor};
 pub trait Constraint: Visitor + Default {
     /// A unique name for this constraint.
     ///
-    /// While no restrictions are imposed on constraint names (other than that
-    /// they are valid UTF-8 strings) it is recommended to follow the
-    /// human-readable dot-separated pattern `project.constraint.version`. For
-    /// example: `quent.fsm.v1`. This reduces the probability of name clashes
-    /// between dependencies, and provides a means of easily detecting breaking
-    /// changes to the constraint's own schema.
+    /// While constraint names only need to be valid UTF-8, the recommended
+    /// pattern is `project.constraint.v<SEMVER>`, following [Semantic
+    /// Versioning]. Unstable constraints should use a major version of zero,
+    /// for example `quent.fsm.v0.1.0`.
+    ///
+    /// [Semantic Versioning]: https://semver.org/
     const NAME: &'static str;
 }
 
@@ -104,7 +104,7 @@ pub struct Report<R> {
 /// #     }
 /// # }
 /// # impl Constraint for DocConstraint {
-/// #     const NAME: &'static str = "quent.docs.constraint.v1";
+/// #     const NAME: &'static str = "quent.docs.constraint.v0.1.0";
 /// # }
 /// # type ConstraintA = DocConstraint;
 /// # type ConstraintB = DocConstraint;

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -181,7 +181,7 @@ impl Visitor for FsmConstraint {
 }
 
 impl Constraint for FsmConstraint {
-    const NAME: &'static str = "quent.fsm.v1";
+    const NAME: &'static str = "quent.fsm.v0.1.0";
 }
 
 pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError>) {

--- a/crates/ref-target/src/lib.rs
+++ b/crates/ref-target/src/lib.rs
@@ -86,7 +86,7 @@ impl Visitor for RefTargetConstraint {
 }
 
 impl Constraint for RefTargetConstraint {
-    const NAME: &'static str = "quent.ref-target.v1";
+    const NAME: &'static str = "quent.ref-target.v0.1.0";
 }
 
 #[derive(Debug, Error)]

--- a/crates/ref-tree/src/lib.rs
+++ b/crates/ref-tree/src/lib.rs
@@ -237,7 +237,7 @@ impl Visitor for RefTreeConstraint {
 }
 
 impl Constraint for RefTreeConstraint {
-    const NAME: &'static str = "quent.ref-tree.v1";
+    const NAME: &'static str = "quent.ref-tree.v0.1.0";
 }
 
 impl RefTreeConstraint {

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -57,7 +57,7 @@ pub enum CapacityKind {
 
 pub type Capacities = indexmap::IndexMap<Identifier, Capacity>;
 
-/// The data a `quent.resource.v1` constraint carries.
+/// The data a `quent.resource.v0.1.0` constraint carries.
 ///
 /// A resource is an entity with one or more capacities that other entities can claim.
 ///
@@ -84,7 +84,7 @@ pub enum Resource {
 
 impl Resource {
     /// The constraint name under which the data is carried.
-    pub const NAME: &'static str = "quent.resource.v1";
+    pub const NAME: &'static str = "quent.resource.v0.1.0";
 
     /// Deserialize [`Self`] from `annotations`, if it exists.
     pub fn from_annotations(annotations: &Annotations) -> Option<Self> {

--- a/crates/schema/src/visitor.rs
+++ b/crates/schema/src/visitor.rs
@@ -337,7 +337,7 @@ mod test {
         let entity_ref = DataType::EntityRef {
             data: None,
             annotations: AnnotationsBuilder::new()
-                .try_with_constraint("my.constraint.v1", None)
+                .try_with_constraint("quent.visitor-test.v0.1.0", None)
                 .unwrap()
                 .build(),
         };

--- a/proto/quent/collector/v1alpha/collector.proto
+++ b/proto/quent/collector/v1alpha/collector.proto
@@ -3,7 +3,8 @@
 
 syntax = "proto3";
 
-package quent.collector.v1;
+// See https://google.aip.dev/185 for the `v1alpha` versioning convention.
+package quent.collector.v1alpha;
 
 service Collector {
   // Opens an event stream for a single entity of a single source. Each stream

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -3,4 +3,4 @@
 
 //! Generated code from Protobuf definitions
 
-tonic::include_proto!("quent.collector.v1");
+tonic::include_proto!("quent.collector.v1alpha");


### PR DESCRIPTION
# Description

Suggests SemVer identifiers for constraints and renames the collector protobuf package from `v1` to `v1alpha`.

🤖 Generated with Codex