### PR TITLE
feat(yaml): FSM entities via an fsms: block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,6 +2784,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "quent-constraints",
+ "quent-fsm",
  "quent-ref-target",
  "quent-ref-tree",
  "quent-schema",

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -1,63 +1,175 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use quent_schema::{Entity, Identifier};
+use quent_constraints::Constraint;
+use quent_schema::builder::{AnnotationsBuilder, BuilderError, EntityBuilder, EventBuilder};
+use quent_schema::{Cardinality, Entity, Field, Identifier};
+use thiserror::Error;
 
-use crate::{ExitStates, Fsm, FsmError, Transition, check_entity};
+use crate::{ExitStates, Fsm, FsmConstraint, Transition};
 
-/// Builds an [`Fsm`] for a specific [`Entity`], validating it on
-/// [`FsmBuilder::build`].
-pub struct FsmBuilder<'a> {
-    entity: &'a Entity,
-    initial_state: Identifier,
-    transitions: Vec<Transition>,
-    exit_from_states: ExitStates,
+/// One state of an FSM entity: its name, the event payload it carries, and its
+/// outgoing transitions and role flags.
+pub struct StateDecl {
+    /// State name, used verbatim as the state event's name.
+    pub name: Identifier,
+    /// Fields of the state event.
+    pub attributes: Vec<Field>,
+    /// States this state transitions to.
+    pub to: Vec<Identifier>,
+    /// Whether the FSM begins in this state.
+    pub initial: bool,
+    /// Whether the FSM may exit from this state.
+    pub exit: bool,
 }
 
-impl<'a> FsmBuilder<'a> {
-    pub(crate) fn new(
-        entity: &'a Entity,
-        initial_state: Identifier,
-        exit_state: Identifier,
-    ) -> Self {
+/// Builds an FSM [`Entity`] from its states, so any frontend gets the same
+/// state-to-event lowering.
+///
+/// Each state becomes one event whose cardinality is derived from the topology
+/// (a state on a cycle is [`Cardinality::Multi`], otherwise [`Cardinality::Once`]).
+/// The FSM topology is attached as the FSM constraint. Whether the topology is
+/// valid (reachability, exits, event coverage) is checked separately by
+/// [`crate::FsmConstraint`] during schema validation.
+pub struct FsmEntityBuilder {
+    id: Identifier,
+    annotations: AnnotationsBuilder,
+    states: Vec<StateDecl>,
+}
+
+/// A structural problem that prevents building an FSM entity at all, before any
+/// topology validation.
+#[derive(Debug, Error)]
+pub enum FsmShapeError {
+    /// No state was marked initial.
+    #[error("no state is marked as the initial state")]
+    NoInitialState,
+    /// More than one state was marked initial.
+    #[error("more than one state is marked as the initial state")]
+    MultipleInitialStates(Vec<Identifier>),
+    /// No state was marked as an exit.
+    #[error("no state is marked as an exit state")]
+    NoExitState,
+    /// A duplicate attribute name within a state reached the schema builder.
+    #[error(transparent)]
+    Build(#[from] BuilderError),
+    /// The FSM topology failed to serialize to its constraint payload.
+    #[error(transparent)]
+    Serialize(#[from] serde_json::Error),
+}
+
+impl FsmEntityBuilder {
+    /// Begin an FSM entity named `id`, carrying `annotations` (to which the FSM
+    /// constraint is added on [`Self::build`]).
+    pub fn new(id: Identifier, annotations: AnnotationsBuilder) -> Self {
         Self {
-            entity,
-            initial_state,
-            transitions: Vec::new(),
-            exit_from_states: ExitStates {
-                state: exit_state,
-                others: Vec::new(),
-            },
+            id,
+            annotations,
+            states: Vec::new(),
         }
     }
 
-    /// Add a transition from `source` to `target`.
-    pub fn transition(mut self, source: Identifier, target: Identifier) -> Self {
-        self.transitions.push(Transition { source, target });
-        self
+    /// Add a state.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_state(&mut self, state: StateDecl) -> Result<&mut Self, BuilderError> {
+        if self.states.iter().any(|s| s.name == state.name) {
+            return Err(BuilderError::DuplicateName(state.name.to_string()));
+        }
+        self.states.push(state);
+        Ok(self)
     }
 
-    /// Add another state the FSM may exit from (i.e. the FSM entity goes out of
-    /// existence).
-    pub fn exit_from(mut self, state: Identifier) -> Self {
-        self.exit_from_states.others.push(state);
-        self
+    /// Add a state, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_state(mut self, state: StateDecl) -> Result<Self, BuilderError> {
+        self.try_insert_state(state)?;
+        Ok(self)
     }
 
-    /// Validate the FSM topology against the entity and return the FSM
-    /// constraint, or return any violations found.
-    pub fn build(self) -> Result<Fsm, FsmError> {
-        let fsm = Fsm {
-            initial_state: self.initial_state,
-            transitions: self.transitions,
-            exit_from_states: self.exit_from_states,
+    /// Add several states, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_states(
+        mut self,
+        states: impl IntoIterator<Item = StateDecl>,
+    ) -> Result<Self, BuilderError> {
+        for state in states {
+            self.try_insert_state(state)?;
+        }
+        Ok(self)
+    }
+
+    /// Assemble the entity: derive each state event's cardinality from the
+    /// topology, attach the events and the FSM constraint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FsmShapeError`] if there is not exactly one initial state, no
+    /// exit state, a state has a duplicate attribute name, or the topology fails
+    /// to serialize.
+    pub fn build(self) -> Result<Entity, FsmShapeError> {
+        let Self {
+            id,
+            mut annotations,
+            states,
+        } = self;
+
+        let initials: Vec<Identifier> = states
+            .iter()
+            .filter(|s| s.initial)
+            .map(|s| s.name.clone())
+            .collect();
+        let initial = match initials.as_slice() {
+            [one] => one.clone(),
+            [] => return Err(FsmShapeError::NoInitialState),
+            _ => return Err(FsmShapeError::MultipleInitialStates(initials)),
         };
-        let mut errors = Vec::new();
-        check_entity(self.entity, &fsm, &mut errors);
-        match errors.len() {
-            0 => Ok(fsm),
-            1 => Err(errors.pop().unwrap()),
-            _ => Err(FsmError::Multiple(errors)),
+
+        let exits: Vec<Identifier> = states
+            .iter()
+            .filter(|s| s.exit)
+            .map(|s| s.name.clone())
+            .collect();
+        let Some((first_exit, other_exits)) = exits.split_first() else {
+            return Err(FsmShapeError::NoExitState);
+        };
+
+        let transitions: Vec<Transition> = states
+            .iter()
+            .flat_map(|state| {
+                let source = state.name.clone();
+                state
+                    .to
+                    .iter()
+                    .map(move |target| Transition::new(source.clone(), target.clone()))
+            })
+            .collect();
+        let fsm = Fsm::new(
+            initial,
+            transitions,
+            ExitStates::new(first_exit.clone(), other_exits.to_vec()),
+        );
+
+        let mut entity = EntityBuilder::new(id);
+        for state in states {
+            // An isolated state has no place on the topology; the FSM constraint
+            // reports it, so `Once` here is only a stand-in.
+            let cardinality = fsm.cardinality(&state.name).unwrap_or(Cardinality::Once);
+            let event = EventBuilder::new(state.name, cardinality)
+                .try_with_fields(state.attributes)?
+                .build();
+            entity = entity.try_with_event(event)?;
         }
+
+        annotations.set_constraint(FsmConstraint::NAME, Some(fsm.constraint_data()?));
+        Ok(entity.with_annotations(annotations.build()).build())
     }
 }

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 
 mod builder;
 
-pub use builder::FsmBuilder;
+pub use builder::{FsmEntityBuilder, FsmShapeError, StateDecl};
 
 /// A directed transition between two named states in an [`Fsm`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -32,6 +32,10 @@ pub struct Transition {
 }
 
 impl Transition {
+    pub(crate) fn new(source: Identifier, target: Identifier) -> Self {
+        Self { source, target }
+    }
+
     /// The name of the source state.
     pub fn source(&self) -> &Identifier {
         &self.source
@@ -51,6 +55,12 @@ struct ExitStates {
     others: Vec<Identifier>,
 }
 
+impl ExitStates {
+    pub(crate) fn new(state: Identifier, others: Vec<Identifier>) -> Self {
+        Self { state, others }
+    }
+}
+
 /// The state-transition topology of a finite state machine.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fsm {
@@ -65,15 +75,16 @@ pub struct Fsm {
 }
 
 impl Fsm {
-    /// Return a builder for an [`Fsm`] constraint over `entity`, beginning in
-    /// `initial_state` and able to exit from `exit_state`. Further exit states
-    /// can be added on the builder.
-    pub fn builder(
-        entity: &Entity,
+    pub(crate) fn new(
         initial_state: Identifier,
-        exit_state: Identifier,
-    ) -> FsmBuilder<'_> {
-        FsmBuilder::new(entity, initial_state, exit_state)
+        transitions: Vec<Transition>,
+        exit_from_states: ExitStates,
+    ) -> Self {
+        Self {
+            initial_state,
+            transitions,
+            exit_from_states,
+        }
     }
 
     /// The name of the initial state this FSM transitions into when it comes
@@ -93,6 +104,52 @@ impl Fsm {
     /// The states from which this FSM can exit to go out of existence.
     pub fn exit_from_states(&self) -> impl Iterator<Item = &Identifier> {
         std::iter::once(&self.exit_from_states.state).chain(self.exit_from_states.others.iter())
+    }
+
+    /// This FSM encoded as its [`FsmConstraint`] payload (JSON).
+    ///
+    /// # Errors
+    ///
+    /// Errors if the topology fails to serialize.
+    pub(crate) fn constraint_data(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// The cardinality a state's event must have: [`Cardinality::Multi`] if the
+    /// state lies on a cycle, [`Cardinality::Once`] otherwise, or `None` if the
+    /// name is not a state of this FSM.
+    pub fn cardinality(&self, state: &Identifier) -> Option<Cardinality> {
+        if !self.states().any(|s| s == state) {
+            return None;
+        }
+        Some(if find_cyclic(&self.graph(), self).contains(state) {
+            Cardinality::Multi
+        } else {
+            Cardinality::Once
+        })
+    }
+
+    /// Every state named by this FSM: the initial state, every transition
+    /// endpoint, and every exit state. May yield duplicates.
+    fn states(&self) -> impl Iterator<Item = &Identifier> {
+        std::iter::once(&self.initial_state)
+            .chain(self.transitions.iter().flat_map(|t| [&t.source, &t.target]))
+            .chain(self.exit_from_states())
+    }
+
+    /// The transition graph with synthetic `Init` and `Exit` nodes.
+    fn graph(&self) -> DiGraphMap<GraphNode<'_>, ()> {
+        std::iter::once((GraphNode::Init, GraphNode::Named(&self.initial_state), ()))
+            .chain(
+                self.transitions
+                    .iter()
+                    .map(|t| (GraphNode::Named(&t.source), GraphNode::Named(&t.target), ())),
+            )
+            .chain(
+                self.exit_from_states()
+                    .map(|x| (GraphNode::Named(x), GraphNode::Exit, ())),
+            )
+            .collect()
     }
 }
 
@@ -202,10 +259,7 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
         .collect();
 
     // Gather every state named
-    let states: HashSet<&Identifier> = std::iter::once(&fsm.initial_state)
-        .chain(fsm.transitions.iter().flat_map(|t| [&t.source, &t.target]))
-        .chain(fsm.exit_from_states())
-        .collect();
+    let states: HashSet<&Identifier> = fsm.states().collect();
 
     // Requirement 2: every state name corresponds to an entity event name.
     for &state in states.difference(&event_names) {
@@ -224,18 +278,7 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
     }
 
     // Graph of states + transitions
-    let graph: DiGraphMap<GraphNode, ()> =
-        std::iter::once((GraphNode::Init, GraphNode::Named(&fsm.initial_state), ()))
-            .chain(
-                fsm.transitions
-                    .iter()
-                    .map(|t| (GraphNode::Named(&t.source), GraphNode::Named(&t.target), ())),
-            )
-            .chain(
-                fsm.exit_from_states()
-                    .map(|x| (GraphNode::Named(x), GraphNode::Exit, ())),
-            )
-            .collect();
+    let graph = fsm.graph();
 
     // Requirement 4: every state is reachable from the initial state.
     let reachable_from_init: HashSet<GraphNode> =

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use quent_constraints::Constraint as _;
-use quent_fsm::{Fsm, FsmConstraint, FsmError};
+use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmError, StateDecl};
 use quent_schema::{
     Annotations, Cardinality, Entity, Event, Schema,
     builder::{AnnotationsBuilder, EntityBuilder},
@@ -11,6 +11,16 @@ use quent_schema::{
 
 fn event(name: &str, cardinality: Cardinality) -> Event {
     event_with(name, cardinality, vec![])
+}
+
+fn state(name: &str, to: &[&str], initial: bool, exit: bool) -> StateDecl {
+    StateDecl {
+        name: ident(name),
+        attributes: vec![],
+        to: to.iter().map(|s| ident(s)).collect(),
+        initial,
+        exit,
+    }
 }
 
 // Build the constraint's JSON directly so we can build it in an invalid way.
@@ -283,43 +293,36 @@ fn entity_without_fsm_constraint_is_ignored() {
 }
 
 #[test]
-fn builder_produces_valid_fsm_and_exposes_data() {
-    let entity = bare_entity(
-        "E",
-        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
-    );
-    let fsm = Fsm::builder(&entity, ident("a"), ident("b"))
-        .transition(ident("a"), ident("b"))
+fn builder_produces_entity_with_state_events() {
+    let entity = FsmEntityBuilder::new(ident("E"), AnnotationsBuilder::new())
+        .try_with_states([
+            state("a", &["b"], true, false),
+            state("b", &[], false, true),
+        ])
+        .unwrap()
         .build()
         .unwrap();
 
-    assert_eq!(fsm.initial_state(), &ident("a"));
-    assert_eq!(fsm.transitions().len(), 1);
-    assert_eq!(fsm.transitions()[0].source(), &ident("a"));
-    assert_eq!(fsm.transitions()[0].target(), &ident("b"));
-    assert_eq!(
-        fsm.exit_from_states().collect::<Vec<_>>(),
-        vec![&ident("b")],
-    );
+    let names: Vec<_> = entity.events().map(|e| e.name().to_string()).collect();
+    assert_eq!(names, vec!["a", "b"]);
+    assert!(entity.annotations().has_constraint(FsmConstraint::NAME));
 }
 
 #[test]
-fn builder_rejects_unknown_event() {
-    // b is not an event
-    let entity = bare_entity("E", vec![event("a", Cardinality::Once)]);
-    let err = Fsm::builder(&entity, ident("b"), ident("b"))
+fn cardinality_is_derived_from_cycles() {
+    // a -> b, b -> b: a sits off any cycle (Once), b self-loops (Multi).
+    let entity = FsmEntityBuilder::new(ident("E"), AnnotationsBuilder::new())
+        .try_with_states([
+            state("a", &["b"], true, false),
+            state("b", &["b"], false, true),
+        ])
+        .unwrap()
         .build()
-        .err()
         .unwrap();
-    let errors = match err {
-        FsmError::Multiple(errors) => errors,
-        single => vec![single],
-    };
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::UnknownState { state, .. } if state == "b")),
-    );
+
+    let cardinality = |name: &str| entity.event(&ident(name)).unwrap().cardinality();
+    assert_eq!(cardinality("a"), Cardinality::Once);
+    assert_eq!(cardinality("b"), Cardinality::Multi);
 }
 
 #[test]

--- a/crates/instrumentation-build/example/Cargo.lock
+++ b/crates/instrumentation-build/example/Cargo.lock
@@ -357,6 +357,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-fsm"
+version = "0.1.0"
+dependencies = [
+ "petgraph",
+ "quent-constraints",
+ "quent-schema",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
 dependencies = [
@@ -454,6 +466,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "rustc-hash",
+ "serde",
  "smallvec",
  "thiserror",
 ]
@@ -471,6 +484,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "quent-constraints",
+ "quent-fsm",
  "quent-ref-target",
  "quent-ref-tree",
  "quent-schema",

--- a/crates/instrumentation-build/example/build.rs
+++ b/crates/instrumentation-build/example/build.rs
@@ -23,6 +23,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts = Options {
         event_derives: &["Debug"],
         record_derives: &["Debug"],
+        // To just print the events in this example, we'll be using the callback
+        // exporter. This exporter takes a type-erased event, so in order to
+        // downcast it back to a statically-typed event, this features enables
+        // the generation of the "AnyEvent" type (see main.rs). This is
+        // typically left false when using "real" exporters.
+        any_event: true,
         ..Default::default()
     };
     let GenerateInfo { path, warnings } = generate(&parsed.schema, &opts)?;

--- a/crates/instrumentation-build/example/model.yaml
+++ b/crates/instrumentation-build/example/model.yaml
@@ -43,3 +43,22 @@ entities:
         once:
           upstream: { ref: Server, data: Route }
       closed: once
+
+  Query:
+    doc: A query on the server, modeled as a finite-state machine.
+
+fsms:
+  Query:
+    states:
+      submitted:
+        initial: true
+        attributes:
+          text: string
+          connection: { scope-ref: Connection }
+        to: [running]
+      running:
+        attributes: { rows: u64 }
+        to: [running, done]
+      done:
+        exit: true
+        attributes: { ok: bool }

--- a/crates/instrumentation-build/example/src/main.rs
+++ b/crates/instrumentation-build/example/src/main.rs
@@ -3,7 +3,7 @@
 
 use quent_instrumentation::{EventCallback, ExporterOptions};
 
-use crate::demo::{ConnectionHandle, ConnectionObserver, DemoContext, Event, Uuid};
+use crate::demo::{ConnectionHandle, ConnectionObserver, DemoContext, Uuid};
 
 #[allow(unused)]
 mod demo {
@@ -11,30 +11,32 @@ mod demo {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // The context owns the exporter and exposes one observer per entity type.
     let context: DemoContext = demo::DemoContext::try_new(Some(debug_printing_exporter()))?;
 
-    // Boot a server; its instance id is the target the connection references.
+    // `observer.handle()` creates a fresh entity instance to events emit for.
     let mut server = context.server_observer().handle();
     server.booted()?;
 
     let observer: ConnectionObserver = context.connection_observer();
-
-    // The handle (may) hold per-instance state that enforces once-cardinality,
-    // hence it is mut so it can update its state after producing a once-event.
+    // Once-cardinality events take `&mut self` and may fire only once, tracked
+    // by the handle, hence it is mut:
     let mut conn: ConnectionHandle = observer.handle();
 
+    // One method per entity event:
     conn.opened(
         demo::Endpoint {
             host: "localhost".to_owned(),
             port: 8080,
         },
         Uuid::nil(),
+        // A handle can deal out a reference to the entity it represents:
         server.as_entity_ref(),
     )?;
     conn.data(1234, None)?;
 
-    // `extra` is the schema's `dynamic` field: a runtime-keyed bag of typed
-    // attributes, so callers attach whatever key/values they have on hand.
+    // A `dynamic` schema field maps to `CustomAttributes`, which are
+    // dynamically-typed keys-value pairs:
     let mut extra = demo::CustomAttributes::new();
     extra.add_string("peer_agent", "curl/8.4");
     extra.add_u64("chunk_index", 3);
@@ -47,12 +49,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
     )?;
 
-    // `ref` field carrying data: the server reference plus details of the edge.
+    // `as_entity_ref_with` produces an entity ref that also carries data:
     conn.routed(server.as_entity_ref_with(demo::Route { hops: 3 }))?;
+
+    // An FSM entity's events are transitions into its states.
+    // For now, the generated methods are like any other event.
+    // Their cardinality is derived from the topology at build time.
+    let mut query = context.query_observer().handle();
+    query.submitted("select 1".to_owned(), conn.as_entity_ref())?;
+    query.running(10)?;
+    query.done(true)?;
 
     conn.closed()?;
 
-    // Emitting a once-event a second time fails.
+    // A once-event returns an error if emitted again.
     assert!(conn.closed_emitted());
     assert!(conn.closed().is_err());
 
@@ -62,15 +72,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Return an exporter that debug-prints each emitted event's payload.
 fn debug_printing_exporter() -> ExporterOptions {
     ExporterOptions::Callback(EventCallback::new(|recorded| {
-        if let Some(event) = recorded
-            .event
-            .downcast_ref::<Event<demo::ConnectionEvent>>()
-        {
-            println!("[{} @ {}] {:?}", event.id, event.timestamp, event.data);
-        } else if let Some(event) = recorded.event.downcast_ref::<Event<demo::ServerEvent>>() {
-            println!("[{} @ {}] {:?}", event.id, event.timestamp, event.data);
-        } else {
-            unreachable!()
+        if let Some(event) = demo::AnyEvent::from_any(recorded.event.as_ref()) {
+            println!("{event:?}");
         }
     }))
 }

--- a/crates/instrumentation-build/src/any_event.rs
+++ b/crates/instrumentation-build/src/any_event.rs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generation of `AnyEvent`: a decoder from a type-erased event to the concrete
+//! `Event<T>` for whichever entity produced it.
+
+use convert_case::Case;
+use proc_macro2::TokenStream;
+use quent_schema::Schema;
+use quote::quote;
+use syn::Ident;
+
+use crate::common::{derive_attr, raw_ident, to_case};
+use crate::{GenerateError, Options};
+
+/// Generate the `AnyEvent` enum and its `from_any` decoder.
+///
+/// One variant per entity, each holding a borrowed `Event<{Entity}Event>`.
+/// `from_any` downcasts a `&dyn Any` (e.g. a callback exporter's type-erased
+/// event) to the matching variant, so a single handler can dispatch over every
+/// entity's events with an exhaustive match. The enum carries the same derives
+/// as the event enums ([`Options::event_derives`]).
+///
+/// # Errors
+///
+/// Returns [`GenerateError`] if a derive entry is not a parseable Rust path.
+pub(crate) fn generate_any_event(
+    schema: &Schema,
+    opts: &Options,
+) -> Result<TokenStream, GenerateError> {
+    let derives = derive_attr(opts.event_derives)?;
+
+    // (variant name, event enum name) per entity.
+    let variants: Vec<(Ident, Ident)> = schema
+        .entities()
+        .map(|entity| {
+            let pascal = to_case(entity.name(), Case::Pascal);
+            (
+                raw_ident(pascal.clone()),
+                raw_ident(format!("{pascal}Event")),
+            )
+        })
+        .collect();
+
+    let decls = variants.iter().map(|(variant, event)| {
+        quote! { #variant(&'a ::quent_instrumentation::Event<#event>) }
+    });
+    let arms = variants.iter().map(|(variant, event)| {
+        quote! {
+            if let Some(event) = any.downcast_ref::<::quent_instrumentation::Event<#event>>() {
+                return Some(AnyEvent::#variant(event));
+            }
+        }
+    });
+
+    Ok(quote! {
+        /// A borrowed reference to any entity's event, recovered from a
+        /// type-erased value. One variant per entity.
+        #derives
+        pub enum AnyEvent<'a> {
+            #(#decls),*
+        }
+
+        impl<'a> AnyEvent<'a> {
+            /// Decode a type-erased event into the concrete `Event<T>` for the
+            /// entity that produced it, or `None` if it is not one of this
+            /// schema's events.
+            pub fn from_any(any: &'a (dyn ::core::any::Any)) -> Option<AnyEvent<'a>> {
+                #(#arms)*
+                None
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::pretty;
+    use quent_schema::builder::{EntityBuilder, EventBuilder, SchemaBuilder};
+    use quent_schema::{Cardinality, test_utils::ident};
+
+    #[test]
+    fn emits_a_variant_and_arm_per_entity() {
+        let entity = EntityBuilder::new(ident("Query"))
+            .try_with_event(EventBuilder::new(ident("submitted"), Cardinality::Once).build())
+            .unwrap()
+            .build();
+        let schema = SchemaBuilder::new(ident("Demo"))
+            .try_with_entity(entity)
+            .unwrap()
+            .build();
+        let opts = Options {
+            event_derives: &["Debug"],
+            ..Options::default()
+        };
+        let src = pretty(generate_any_event(&schema, &opts).unwrap());
+        assert!(src.contains("#[derive(Debug)]"));
+        assert!(src.contains("pub enum AnyEvent"));
+        assert!(src.contains("Query(&'a ::quent_instrumentation::Event<QueryEvent>)"));
+        assert!(src.contains("downcast_ref::<::quent_instrumentation::Event<QueryEvent>>()"));
+    }
+}

--- a/crates/instrumentation-build/src/lib.rs
+++ b/crates/instrumentation-build/src/lib.rs
@@ -51,6 +51,7 @@
 //! carrying records or entity refs) must include a `Serialize`-providing
 //! derive; otherwise the generated code will not compile.
 
+mod any_event;
 mod common;
 mod data_type;
 mod events;
@@ -90,6 +91,10 @@ pub struct Options {
     /// File name to write; defaults to `<schema name>.rs` (lowercased) when
     /// `None`.
     pub file_name: Option<String>,
+
+    /// Emit `AnyEvent` and `AnyEvent::from_any`, a decoder from a type-erased
+    /// `&dyn Any` back to the concrete `Event<T>`. Carries [`Self::event_derives`].
+    pub any_event: bool,
 }
 
 impl Default for Options {
@@ -99,6 +104,7 @@ impl Default for Options {
             record_derives: Default::default(),
             out_dir: PathBuf::from(std::env::var("OUT_DIR").unwrap_or_default()),
             file_name: None,
+            any_event: false,
         }
     }
 }
@@ -171,7 +177,12 @@ pub fn generate_str(schema: &Schema, opts: &Options) -> Result<String, GenerateE
     let records = generate_record_types(schema, opts)?;
     let events = generate_event_types(schema, opts)?;
     let runtime = generate_runtime_types(schema)?;
-    let file = syn::parse2::<syn::File>(quote! { #reexports #records #events #runtime })
+    let any_event = if opts.any_event {
+        any_event::generate_any_event(schema, opts)?
+    } else {
+        quote! {}
+    };
+    let file = syn::parse2::<syn::File>(quote! { #reexports #records #events #runtime #any_event })
         .map_err(GenerateError::InvalidGeneratedCode)?;
     Ok(prettyplease::unparse(&file))
 }

--- a/crates/yaml/Cargo.toml
+++ b/crates/yaml/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 indexmap = { workspace = true, features = ["serde"] }
 quent-constraints = { path = "../constraints" }
+quent-fsm = { path = "../fsm" }
 quent-ref-target = { path = "../ref-target" }
 quent-ref-tree = { path = "../ref-tree" }
 quent-schema = { path = "../schema" }

--- a/crates/yaml/src/ast.rs
+++ b/crates/yaml/src/ast.rs
@@ -38,6 +38,32 @@ pub(crate) struct Model {
     pub(crate) records: IndexMap<String, Record>,
     #[serde(default)]
     pub(crate) entities: IndexMap<String, Entity>,
+    /// FSMs keyed by the name of the entity whose events they declare.
+    #[serde(default)]
+    pub(crate) fsms: IndexMap<String, FsmSpec>,
+}
+
+/// An FSM overlaying an entity: its states, keyed by name. Each state becomes
+/// one of the entity's events.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct FsmSpec {
+    pub(crate) states: IndexMap<String, StateSpec>,
+}
+
+/// One state of an FSM: its payload attributes, the states it may transition
+/// to, and whether it is the initial or an exit state.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StateSpec {
+    #[serde(default)]
+    pub(crate) initial: bool,
+    #[serde(default)]
+    pub(crate) exit: bool,
+    #[serde(default)]
+    pub(crate) attributes: IndexMap<String, Field>,
+    #[serde(default)]
+    pub(crate) to: Vec<String>,
 }
 
 /// A record: named fields plus annotations.

--- a/crates/yaml/src/lib.rs
+++ b/crates/yaml/src/lib.rs
@@ -10,6 +10,7 @@
 use std::path::Path;
 
 use quent_constraints::validate;
+use quent_fsm::{FsmConstraint, FsmError};
 use quent_ref_target::{RefTargetConstraint, RefTargetError};
 use quent_ref_tree::{RefTreeConstraint, RefTreeError};
 use quent_schema::Schema;
@@ -66,7 +67,7 @@ pub fn parse_from_str(src: impl AsRef<str>, source: Option<&str>) -> Result<Pars
         return Err(Error::Invalid(sink));
     }
 
-    let report = validate::<(RefTargetConstraint, RefTreeConstraint)>(&schema);
+    let report = validate::<(RefTargetConstraint, RefTreeConstraint, FsmConstraint)>(&schema);
     if let Err(e) = report.base_constraints {
         for record in e.recursive_records {
             sink.error(
@@ -82,12 +83,15 @@ pub fn parse_from_str(src: impl AsRef<str>, source: Option<&str>) -> Result<Pars
             sink.error("", format!("unresolved reference: {reference}"), None);
         }
     }
-    let (ref_target, ref_tree) = report.results;
+    let (ref_target, ref_tree, fsm) = report.results;
     if let Err(e) = ref_target {
         ref_target_diagnostics(e, &mut sink);
     }
     if let Err(e) = ref_tree {
         ref_tree_diagnostics(e, &mut sink);
+    }
+    if let Err(e) = fsm {
+        fsm_diagnostics(e, &mut sink);
     }
     if sink.has_errors() {
         return Err(Error::Invalid(sink));
@@ -136,6 +140,18 @@ fn ref_tree_diagnostics(error: RefTreeError, sink: &mut Diagnostics) {
             errors
                 .into_iter()
                 .for_each(|error| ref_tree_diagnostics(error, sink));
+        }
+        error => sink.error("", error.to_string(), None),
+    }
+}
+
+/// Report one diagnostic per FSM violation, flattening `Multiple`.
+fn fsm_diagnostics(error: FsmError, sink: &mut Diagnostics) {
+    match error {
+        FsmError::Multiple(errors) => {
+            errors
+                .into_iter()
+                .for_each(|error| fsm_diagnostics(error, sink));
         }
         error => sink.error("", error.to_string(), None),
     }

--- a/crates/yaml/src/lower.rs
+++ b/crates/yaml/src/lower.rs
@@ -15,6 +15,7 @@
 
 use indexmap::IndexMap;
 use quent_constraints::Constraint;
+use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmShapeError, StateDecl};
 use quent_ref_target::RefTargetConstraint;
 use quent_ref_tree::RefTreeConstraint;
 use quent_schema::builder::{
@@ -53,8 +54,17 @@ pub(crate) fn lower(model: &Model, sink: &mut Diagnostics) -> Schema {
     let entities: Vec<Entity> = model
         .entities
         .iter()
-        .filter_map(|(name, entity)| entity_of(name, entity, sink))
+        .filter_map(|(name, entity)| entity_of(name, entity, model.fsms.get(name), sink))
         .collect();
+    for name in model.fsms.keys() {
+        if !model.entities.contains_key(name) {
+            sink.error(
+                &format!("fsms.{name}"),
+                format!("`fsms` declares `{name}`, but there is no such entity"),
+                None,
+            );
+        }
+    }
 
     SchemaBuilder::new(name)
         .try_with_records(records)
@@ -95,27 +105,119 @@ fn record_of(name: &str, record: &ast::Record, sink: &mut Diagnostics) -> Option
 }
 
 /// Lower one entity, or `None` (after reporting) if its name is rejected.
-fn entity_of(name: &str, entity: &ast::Entity, sink: &mut Diagnostics) -> Option<Entity> {
+///
+/// An FSM entity's events come from its FSM states (via [`FsmEntityBuilder`],
+/// which derives cardinality); a plain entity's come from its `events:`.
+fn entity_of(
+    name: &str,
+    entity: &ast::Entity,
+    fsm_spec: Option<&ast::FsmSpec>,
+    sink: &mut Diagnostics,
+) -> Option<Entity> {
     let path = format!("entities.{name}");
     let id = type_decl_ident(name, "entities", sink);
-    let events: Vec<_> = entity
-        .events
-        .iter()
-        .filter_map(|(event_name, event)| event_of(event_name, event, &path, sink))
-        .collect();
-    Some(
-        EntityBuilder::new(id?)
-            .try_with_events(events)
-            .expect("event names are unique")
-            .with_annotations(annotations(
-                &entity.doc,
-                &entity.constraints,
-                &entity.metadata,
-                &path,
-                sink,
-            ))
-            .build(),
-    )
+    let anns = annotations_builder(
+        &entity.doc,
+        &entity.constraints,
+        &entity.metadata,
+        &path,
+        sink,
+    );
+
+    match fsm_spec {
+        Some(spec) => {
+            if !entity.events.is_empty() {
+                sink.error(
+                    &path,
+                    "an FSM entity declares its events as FSM states; remove `events:`",
+                    None,
+                );
+            }
+            fsm_entity(id, spec, anns, &format!("fsms.{name}"), sink)
+        }
+        None => {
+            let events: Vec<_> = entity
+                .events
+                .iter()
+                .filter_map(|(event_name, event)| event_of(event_name, event, &path, sink))
+                .collect();
+            Some(
+                EntityBuilder::new(id?)
+                    .try_with_events(events)
+                    .expect("event names are unique")
+                    .with_annotations(anns.build())
+                    .build(),
+            )
+        }
+    }
+}
+
+/// Lower an FSM entity: feed its states into [`FsmEntityBuilder`], which derives
+/// each state event's cardinality and attaches the FSM constraint. Topology
+/// validity is checked later by the FSM constraint.
+fn fsm_entity(
+    id: Option<Identifier>,
+    spec: &ast::FsmSpec,
+    annotations: AnnotationsBuilder,
+    path: &str,
+    sink: &mut Diagnostics,
+) -> Option<Entity> {
+    // Lower the states first, before bailing on a rejected entity name, so one
+    // run still reports problems inside the states.
+    let mut states = Vec::new();
+    let mut complete = true;
+    for (name, state) in &spec.states {
+        let Some(state_id) = ident(name, path, sink) else {
+            complete = false;
+            continue;
+        };
+        let attributes = fields_of(&state.attributes, &format!("{path}.states.{name}"), sink);
+        let to = state
+            .to
+            .iter()
+            .filter_map(|target| ident(target, path, sink))
+            .collect();
+        states.push(StateDecl {
+            name: state_id,
+            attributes,
+            to,
+            initial: state.initial,
+            exit: state.exit,
+        });
+    }
+
+    // A rejected state name leaves a reduced set whose structural checks would
+    // mislead (e.g. reporting a missing initial state), so stop once one is bad.
+    let id = id?;
+    if !complete {
+        return None;
+    }
+
+    let built = FsmEntityBuilder::new(id, annotations)
+        .try_with_states(states)
+        .expect("state names are unique (deserialized from a map)")
+        .build();
+    match built {
+        Ok(entity) => Some(entity),
+        Err(error) => {
+            fsm_shape_error(&error, path, sink);
+            None
+        }
+    }
+}
+
+/// Report an FSM structural error, using the YAML `initial: true` / `exit: true`
+/// wording for the flag problems.
+fn fsm_shape_error(error: &FsmShapeError, path: &str, sink: &mut Diagnostics) {
+    let message = match error {
+        FsmShapeError::NoInitialState => "no state marked `initial: true`".to_string(),
+        FsmShapeError::MultipleInitialStates(_) => {
+            "more than one state marked `initial: true`".to_string()
+        }
+        FsmShapeError::NoExitState => "no state marked `exit: true`".to_string(),
+        other => other.to_string(),
+    };
+    sink.error(path, message, None);
 }
 
 /// Lower one event, or `None` (after reporting) if its name is rejected.
@@ -290,12 +392,25 @@ fn annotations(
     path: &str,
     sink: &mut Diagnostics,
 ) -> Annotations {
+    annotations_builder(doc, constraints, metadata, path, sink).build()
+}
+
+/// Assemble an [`AnnotationsBuilder`] from doc, constraints, and metadata,
+/// reporting problems. Left unbuilt so callers that add more (e.g. an FSM
+/// constraint) can amend it first.
+fn annotations_builder(
+    doc: &Option<String>,
+    constraints: &AnnotationMap,
+    metadata: &AnnotationMap,
+    path: &str,
+    sink: &mut Diagnostics,
+) -> AnnotationsBuilder {
     let mut builder = AnnotationsBuilder::new();
     if let Some(doc) = doc {
         builder.set_docs(doc.clone());
     }
     add_annotations(&mut builder, constraints, metadata, path, sink);
-    builder.build()
+    builder
 }
 
 fn add_annotations(
@@ -308,6 +423,16 @@ fn add_annotations(
     for (name, value) in constraints {
         if name.is_empty() {
             sink.error(path, "constraint name must not be empty", None);
+            continue;
+        }
+        // The FSM constraint is produced only by the builder, from an `fsms:`
+        // block, never written by hand.
+        if name == FsmConstraint::NAME {
+            sink.error(
+                path,
+                "the FSM constraint is set from an `fsms:` block, not written directly",
+                None,
+            );
             continue;
         }
         if let Err(e) = builder.try_insert_constraint(name, value.clone()) {

--- a/crates/yaml/tests/fsm.rs
+++ b/crates/yaml/tests/fsm.rs
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! FSM tests: an `fsms:` overlay declares an entity's events as states, deriving
+//! their cardinality from the topology, and is validated against the entity.
+
+use quent_schema::test_utils::ident;
+use quent_schema::{Cardinality, Schema};
+use quent_yaml::{Error, parse_from_str};
+
+const FSM: &str = "quent.fsm.v0.1.0";
+
+fn schema_of(src: &str) -> Schema {
+    parse_from_str(src, None).expect("parses").schema
+}
+
+fn errors_of(src: &str) -> String {
+    match parse_from_str(src, None) {
+        Err(Error::Invalid(diagnostics)) => diagnostics.to_string(),
+        other => panic!("expected diagnostics, got {other:?}"),
+    }
+}
+
+const QUERY: &str = "\
+quent: alpha
+model: m
+entities:
+  Query:
+    doc: A query.
+fsms:
+  Query:
+    states:
+      submitted:
+        initial: true
+        attributes: { text: string }
+        to: [progress]
+      progress:
+        attributes: { pct: u8 }
+        to: [progress, finished]
+      finished:
+        exit: true
+        attributes: { ok: bool }
+";
+
+#[test]
+fn fsm_builds_events_and_derives_cardinality() {
+    let schema = schema_of(QUERY);
+    let query = schema.entity(&ident("Query")).unwrap();
+    assert!(query.annotations().has_constraint(FSM));
+    assert_eq!(query.events().count(), 3);
+    // `progress` self-loops, so it is Multi; the others are Once.
+    let card = |e: &str| query.event(&ident(e)).unwrap().cardinality();
+    assert!(matches!(card("progress"), Cardinality::Multi));
+    assert!(matches!(card("submitted"), Cardinality::Once));
+    assert!(matches!(card("finished"), Cardinality::Once));
+}
+
+#[test]
+fn fsms_referencing_unknown_entity_is_rejected() {
+    let errors = errors_of(
+        "\
+quent: alpha
+model: m
+fsms:
+  Ghost:
+    states:
+      a: { initial: true, exit: true }
+",
+    );
+    assert!(
+        errors.contains("no such entity") && errors.contains("Ghost"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn fsm_entity_may_not_declare_events() {
+    let errors = errors_of(
+        "\
+quent: alpha
+model: m
+entities:
+  E:
+    events:
+      a: once
+fsms:
+  E:
+    states:
+      a: { initial: true, exit: true }
+",
+    );
+    assert!(
+        errors.contains("declares its events as FSM states"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn fsm_needs_one_initial_state() {
+    let errors = errors_of(
+        "\
+quent: alpha
+model: m
+entities:
+  E:
+    doc: x
+fsms:
+  E:
+    states:
+      a: { exit: true }
+      b: { exit: true }
+",
+    );
+    assert!(
+        errors.contains("no state marked `initial: true`"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn fsm_needs_an_exit_state() {
+    let errors = errors_of(
+        "\
+quent: alpha
+model: m
+entities:
+  E:
+    doc: x
+fsms:
+  E:
+    states:
+      a: { initial: true, to: [a] }
+",
+    );
+    assert!(errors.contains("no state marked `exit: true`"), "{errors}");
+}
+
+#[test]
+fn unreachable_state_is_rejected() {
+    // `b` is a state but nothing reaches it from the initial state.
+    let errors = errors_of(
+        "\
+quent: alpha
+model: m
+entities:
+  E:
+    doc: x
+fsms:
+  E:
+    states:
+      a: { initial: true, exit: true }
+      b: { exit: true, to: [a] }
+",
+    );
+    assert!(errors.contains("unreachable"), "{errors}");
+}


### PR DESCRIPTION
WIP

# Description

Adds FSM support to the YAML DSL: a top-level `fsms:` block declares an entity's events as states, cardinality derived from the topology, lowered through a reusable `FsmEntityBuilder` in `quent-fsm`. Also adds an off-by-default `any_event` codegen option emitting an `AnyEvent` decoder for type-erased events, shown in the example.

## Related Issues

Part of #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)