### PR TITLE
refactor(fsm): align quent-fsm builder with quent-schema builder patterns

### DIFF
--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use quent_constraints::Constraint;
 use quent_schema::builder::{AnnotationsBuilder, BuilderError, EntityBuilder, EventBuilder};
 use quent_schema::{Annotations, Cardinality, Entity, Field, Identifier};
@@ -42,8 +44,9 @@ pub enum FsmEntityBuilderError {
     MultipleInitialStates(Vec<Identifier>),
     #[error("no state is marked as an exit state")]
     NoExitState,
-    /// A duplicate state name, or a duplicate attribute name within a state,
-    /// reached the schema builder.
+    #[error("duplicate state `{0}`")]
+    DuplicateState(Identifier),
+    /// A duplicate attribute name within a state reached the schema builder.
     #[error(transparent)]
     Build(#[from] BuilderError),
     /// The FSM topology failed to serialize to its constraint payload.
@@ -90,15 +93,25 @@ impl FsmEntityBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`FsmEntityBuilderError`] if there is not exactly one initial
-    /// state, no exit state, a state has a duplicate attribute name, the
-    /// topology fails to serialize, or the topology is invalid.
+    /// Returns [`FsmEntityBuilderError`] if a state name is declared twice,
+    /// there is not exactly one initial state, no exit state, a state has a
+    /// duplicate attribute name, the topology fails to serialize, or the
+    /// topology is invalid.
     pub fn build(self) -> Result<Entity, FsmEntityBuilderError> {
         let Self {
             id,
             mut annotations,
             states,
         } = self;
+
+        // Reject duplicate state names up front, before the structural checks
+        // could misattribute them (e.g. two states both marked initial).
+        let mut seen = HashSet::new();
+        for state in &states {
+            if !seen.insert(&state.name) {
+                return Err(FsmEntityBuilderError::DuplicateState(state.name.clone()));
+            }
+        }
 
         let initials: Vec<Identifier> = states
             .iter()

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -1,63 +1,188 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use quent_schema::{Entity, Identifier};
+use quent_constraints::Constraint;
+use quent_schema::builder::{AnnotationsBuilder, BuilderError, EntityBuilder, EventBuilder};
+use quent_schema::{Annotations, Cardinality, Entity, Field, Identifier};
+use thiserror::Error;
 
-use crate::{ExitStates, Fsm, FsmError, Transition, check_entity};
+use crate::{ExitStates, Fsm, FsmConstraint, FsmError, Transition, check_entity};
 
-/// Builds an [`Fsm`] for a specific [`Entity`], validating it on
-/// [`FsmBuilder::build`].
-pub struct FsmBuilder<'a> {
-    entity: &'a Entity,
-    initial_state: Identifier,
-    transitions: Vec<Transition>,
-    exit_from_states: ExitStates,
+/// A declared state of an FSM entity.
+pub struct StateDecl {
+    /// State name, used verbatim as the state event's name.
+    pub name: Identifier,
+    /// Fields of the state event.
+    pub attributes: Vec<Field>,
+    /// States this state transitions to.
+    pub to: Vec<Identifier>,
+    /// Whether the FSM begins in this state.
+    pub initial: bool,
+    /// Whether the FSM may exit from this state.
+    pub exit: bool,
 }
 
-impl<'a> FsmBuilder<'a> {
-    pub(crate) fn new(
-        entity: &'a Entity,
-        initial_state: Identifier,
-        exit_state: Identifier,
-    ) -> Self {
+/// Builds an FSM [`Entity`] from its states: each state becomes one event whose
+/// cardinality is derived from the topology, plus the FSM constraint.
+///
+/// [`Self::build`] validates the topology with the same checks as
+/// [`crate::FsmConstraint`], so a built entity is always valid.
+pub struct FsmEntityBuilder {
+    id: Identifier,
+    annotations: AnnotationsBuilder,
+    states: Vec<StateDecl>,
+}
+
+/// A problem that prevents building a valid FSM entity.
+#[derive(Debug, Error)]
+pub enum FsmEntityBuilderError {
+    #[error("no state is marked as the initial state")]
+    NoInitialState,
+    #[error("more than one state is marked as the initial state")]
+    MultipleInitialStates(Vec<Identifier>),
+    #[error("no state is marked as an exit state")]
+    NoExitState,
+    /// A duplicate attribute name within a state reached the schema builder.
+    #[error(transparent)]
+    Build(#[from] BuilderError),
+    /// The FSM topology failed to serialize to its constraint payload.
+    #[error(transparent)]
+    Serialize(#[from] serde_json::Error),
+    /// The FSM topology is invalid (unreachable state, no path to an exit, ...).
+    #[error(transparent)]
+    Invalid(#[from] FsmError),
+}
+
+impl FsmEntityBuilder {
+    /// Begin an FSM entity named `id`.
+    pub fn new(id: Identifier) -> Self {
         Self {
-            entity,
-            initial_state,
-            transitions: Vec::new(),
-            exit_from_states: ExitStates {
-                state: exit_state,
-                others: Vec::new(),
-            },
+            id,
+            annotations: AnnotationsBuilder::new(),
+            states: Vec::new(),
         }
     }
 
-    /// Add a transition from `source` to `target`.
-    pub fn transition(mut self, source: Identifier, target: Identifier) -> Self {
-        self.transitions.push(Transition { source, target });
+    /// Set the entity's annotations, replacing any set so far, and return the
+    /// builder for chaining. The FSM constraint is added to them on
+    /// [`Self::build`].
+    pub fn with_annotations(mut self, annotations: Annotations) -> Self {
+        self.annotations = AnnotationsBuilder::from_annotations(&annotations);
         self
     }
 
-    /// Add another state the FSM may exit from (i.e. the FSM entity goes out of
-    /// existence).
-    pub fn exit_from(mut self, state: Identifier) -> Self {
-        self.exit_from_states.others.push(state);
-        self
+    /// Add a state.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_insert_state(&mut self, state: StateDecl) -> Result<&mut Self, BuilderError> {
+        if self.states.iter().any(|s| s.name == state.name) {
+            return Err(BuilderError::DuplicateName(state.name.to_string()));
+        }
+        self.states.push(state);
+        Ok(self)
     }
 
-    /// Validate the FSM topology against the entity and return the FSM
-    /// constraint, or return any violations found.
-    pub fn build(self) -> Result<Fsm, FsmError> {
-        let fsm = Fsm {
-            initial_state: self.initial_state,
-            transitions: self.transitions,
-            exit_from_states: self.exit_from_states,
+    /// Add a state, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors if its name is already declared.
+    pub fn try_with_state(mut self, state: StateDecl) -> Result<Self, BuilderError> {
+        self.try_insert_state(state)?;
+        Ok(self)
+    }
+
+    /// Add several states, returning the builder for chaining.
+    ///
+    /// # Errors
+    ///
+    /// Errors on the first duplicate name.
+    pub fn try_with_states(
+        mut self,
+        states: impl IntoIterator<Item = StateDecl>,
+    ) -> Result<Self, BuilderError> {
+        for state in states {
+            self.try_insert_state(state)?;
+        }
+        Ok(self)
+    }
+
+    /// Assemble and validate the entity: derive each state event's cardinality
+    /// from the topology, attach the events and the FSM constraint, then check
+    /// the topology.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FsmEntityBuilderError`] if there is not exactly one initial
+    /// state, no exit state, a state has a duplicate attribute name, the
+    /// topology fails to serialize, or the topology is invalid.
+    pub fn build(self) -> Result<Entity, FsmEntityBuilderError> {
+        let Self {
+            id,
+            mut annotations,
+            states,
+        } = self;
+
+        let initials: Vec<Identifier> = states
+            .iter()
+            .filter(|s| s.initial)
+            .map(|s| s.name.clone())
+            .collect();
+        let initial = match initials.as_slice() {
+            [one] => one.clone(),
+            [] => return Err(FsmEntityBuilderError::NoInitialState),
+            _ => return Err(FsmEntityBuilderError::MultipleInitialStates(initials)),
         };
+
+        let exits: Vec<Identifier> = states
+            .iter()
+            .filter(|s| s.exit)
+            .map(|s| s.name.clone())
+            .collect();
+        let Some((first_exit, other_exits)) = exits.split_first() else {
+            return Err(FsmEntityBuilderError::NoExitState);
+        };
+
+        let transitions: Vec<Transition> = states
+            .iter()
+            .flat_map(|state| {
+                let source = state.name.clone();
+                state
+                    .to
+                    .iter()
+                    .map(move |target| Transition::new(source.clone(), target.clone()))
+            })
+            .collect();
+        let fsm = Fsm::new(
+            initial,
+            transitions,
+            ExitStates::new(first_exit.clone(), other_exits.to_vec()),
+        );
+
+        let mut entity = EntityBuilder::new(id);
+        for state in states {
+            // An isolated state has no place on the topology; the FSM constraint
+            // reports it, so `Once` here is only a stand-in.
+            let cardinality = fsm.cardinality(&state.name).unwrap_or(Cardinality::Once);
+            let event = EventBuilder::new(state.name, cardinality)
+                .try_with_fields(state.attributes)?
+                .build();
+            entity = entity.try_with_event(event)?;
+        }
+
+        annotations.set_constraint(FsmConstraint::NAME, Some(fsm.constraint_data()?));
+        let entity = entity.with_annotations(annotations.build()).build();
+
+        // Validate the full topology now, the same checks the constraint runs
+        // during schema validation, so a built entity is always valid.
         let mut errors = Vec::new();
-        check_entity(self.entity, &fsm, &mut errors);
+        check_entity(&entity, &fsm, &mut errors);
         match errors.len() {
-            0 => Ok(fsm),
-            1 => Err(errors.pop().unwrap()),
-            _ => Err(FsmError::Multiple(errors)),
+            0 => Ok(entity),
+            1 => Err(FsmEntityBuilderError::Invalid(errors.pop().unwrap())),
+            _ => Err(FsmEntityBuilderError::Invalid(FsmError::Multiple(errors))),
         }
     }
 }

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -42,7 +42,8 @@ pub enum FsmEntityBuilderError {
     MultipleInitialStates(Vec<Identifier>),
     #[error("no state is marked as an exit state")]
     NoExitState,
-    /// A duplicate attribute name within a state reached the schema builder.
+    /// A duplicate state name, or a duplicate attribute name within a state,
+    /// reached the schema builder.
     #[error(transparent)]
     Build(#[from] BuilderError),
     /// The FSM topology failed to serialize to its constraint payload.
@@ -72,41 +73,15 @@ impl FsmEntityBuilder {
     }
 
     /// Add a state.
-    ///
-    /// # Errors
-    ///
-    /// Errors if its name is already declared.
-    pub fn try_insert_state(&mut self, state: StateDecl) -> Result<&mut Self, BuilderError> {
-        if self.states.iter().any(|s| s.name == state.name) {
-            return Err(BuilderError::DuplicateName(state.name.to_string()));
-        }
+    pub fn with_state(mut self, state: StateDecl) -> Self {
         self.states.push(state);
-        Ok(self)
+        self
     }
 
-    /// Add a state, returning the builder for chaining.
-    ///
-    /// # Errors
-    ///
-    /// Errors if its name is already declared.
-    pub fn try_with_state(mut self, state: StateDecl) -> Result<Self, BuilderError> {
-        self.try_insert_state(state)?;
-        Ok(self)
-    }
-
-    /// Add several states, returning the builder for chaining.
-    ///
-    /// # Errors
-    ///
-    /// Errors on the first duplicate name.
-    pub fn try_with_states(
-        mut self,
-        states: impl IntoIterator<Item = StateDecl>,
-    ) -> Result<Self, BuilderError> {
-        for state in states {
-            self.try_insert_state(state)?;
-        }
-        Ok(self)
+    /// Add several states.
+    pub fn with_states(mut self, states: impl IntoIterator<Item = StateDecl>) -> Self {
+        self.states.extend(states);
+        self
     }
 
     /// Assemble and validate the entity: derive each state event's cardinality

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 
 mod builder;
 
-pub use builder::FsmBuilder;
+pub use builder::{FsmEntityBuilder, FsmEntityBuilderError, StateDecl};
 
 /// A directed transition between two named states in an [`Fsm`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -32,6 +32,10 @@ pub struct Transition {
 }
 
 impl Transition {
+    pub(crate) fn new(source: Identifier, target: Identifier) -> Self {
+        Self { source, target }
+    }
+
     /// The name of the source state.
     pub fn source(&self) -> &Identifier {
         &self.source
@@ -51,6 +55,12 @@ struct ExitStates {
     others: Vec<Identifier>,
 }
 
+impl ExitStates {
+    pub(crate) fn new(state: Identifier, others: Vec<Identifier>) -> Self {
+        Self { state, others }
+    }
+}
+
 /// The state-transition topology of a finite state machine.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fsm {
@@ -65,15 +75,16 @@ pub struct Fsm {
 }
 
 impl Fsm {
-    /// Return a builder for an [`Fsm`] constraint over `entity`, beginning in
-    /// `initial_state` and able to exit from `exit_state`. Further exit states
-    /// can be added on the builder.
-    pub fn builder(
-        entity: &Entity,
+    pub(crate) fn new(
         initial_state: Identifier,
-        exit_state: Identifier,
-    ) -> FsmBuilder<'_> {
-        FsmBuilder::new(entity, initial_state, exit_state)
+        transitions: Vec<Transition>,
+        exit_from_states: ExitStates,
+    ) -> Self {
+        Self {
+            initial_state,
+            transitions,
+            exit_from_states,
+        }
     }
 
     /// The name of the initial state this FSM transitions into when it comes
@@ -93,6 +104,52 @@ impl Fsm {
     /// The states from which this FSM can exit to go out of existence.
     pub fn exit_from_states(&self) -> impl Iterator<Item = &Identifier> {
         std::iter::once(&self.exit_from_states.state).chain(self.exit_from_states.others.iter())
+    }
+
+    /// This FSM encoded as its [`FsmConstraint`] payload (JSON).
+    ///
+    /// # Errors
+    ///
+    /// Errors if the topology fails to serialize.
+    pub(crate) fn constraint_data(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// The cardinality a state's event must have: [`Cardinality::Multi`] if the
+    /// state lies on a cycle, [`Cardinality::Once`] otherwise, or `None` if the
+    /// name is not a state of this FSM.
+    pub fn cardinality(&self, state: &Identifier) -> Option<Cardinality> {
+        if !self.states().any(|s| s == state) {
+            return None;
+        }
+        Some(if find_cyclic(&self.graph(), self).contains(state) {
+            Cardinality::Multi
+        } else {
+            Cardinality::Once
+        })
+    }
+
+    /// Every state named by this FSM: the initial state, every transition
+    /// endpoint, and every exit state. May yield duplicates.
+    fn states(&self) -> impl Iterator<Item = &Identifier> {
+        std::iter::once(&self.initial_state)
+            .chain(self.transitions.iter().flat_map(|t| [&t.source, &t.target]))
+            .chain(self.exit_from_states())
+    }
+
+    /// The transition graph with synthetic `Init` and `Exit` nodes.
+    fn graph(&self) -> DiGraphMap<GraphNode<'_>, ()> {
+        std::iter::once((GraphNode::Init, GraphNode::Named(&self.initial_state), ()))
+            .chain(
+                self.transitions
+                    .iter()
+                    .map(|t| (GraphNode::Named(&t.source), GraphNode::Named(&t.target), ())),
+            )
+            .chain(
+                self.exit_from_states()
+                    .map(|x| (GraphNode::Named(x), GraphNode::Exit, ())),
+            )
+            .collect()
     }
 }
 
@@ -202,10 +259,7 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
         .collect();
 
     // Gather every state named
-    let states: HashSet<&Identifier> = std::iter::once(&fsm.initial_state)
-        .chain(fsm.transitions.iter().flat_map(|t| [&t.source, &t.target]))
-        .chain(fsm.exit_from_states())
-        .collect();
+    let states: HashSet<&Identifier> = fsm.states().collect();
 
     // Requirement 2: every state name corresponds to an entity event name.
     for &state in states.difference(&event_names) {
@@ -224,18 +278,7 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
     }
 
     // Graph of states + transitions
-    let graph: DiGraphMap<GraphNode, ()> =
-        std::iter::once((GraphNode::Init, GraphNode::Named(&fsm.initial_state), ()))
-            .chain(
-                fsm.transitions
-                    .iter()
-                    .map(|t| (GraphNode::Named(&t.source), GraphNode::Named(&t.target), ())),
-            )
-            .chain(
-                fsm.exit_from_states()
-                    .map(|x| (GraphNode::Named(x), GraphNode::Exit, ())),
-            )
-            .collect();
+    let graph = fsm.graph();
 
     // Requirement 4: every state is reachable from the initial state.
     let reachable_from_init: HashSet<GraphNode> =

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -353,7 +353,10 @@ fn builder_rejects_malformed_states() {
         .with_state(state("a", &[], true, false))
         .build()
         .unwrap_err();
-    assert!(matches!(duplicate, FsmEntityBuilderError::DuplicateState(_)));
+    assert!(matches!(
+        duplicate,
+        FsmEntityBuilderError::DuplicateState(_)
+    ));
 }
 
 #[test]

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use quent_constraints::Constraint as _;
-use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmError, StateDecl};
+use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmEntityBuilderError, FsmError, StateDecl};
 use quent_schema::{
     Annotations, Cardinality, Entity, Event, Schema,
-    builder::{AnnotationsBuilder, EntityBuilder},
+    builder::{AnnotationsBuilder, BuilderError, EntityBuilder},
     test_utils::{entity as bare_entity, event_with, ident, schema},
 };
 
@@ -323,6 +323,39 @@ fn cardinality_is_derived_from_cycles() {
     let cardinality = |name: &str| entity.event(&ident(name)).unwrap().cardinality();
     assert_eq!(cardinality("a"), Cardinality::Once);
     assert_eq!(cardinality("b"), Cardinality::Multi);
+}
+
+#[test]
+fn builder_rejects_malformed_states() {
+    let no_initial = FsmEntityBuilder::new(ident("E"))
+        .try_with_states([state("a", &[], false, true)])
+        .unwrap()
+        .build()
+        .unwrap_err();
+    assert!(matches!(no_initial, FsmEntityBuilderError::NoInitialState));
+
+    let many_initial = FsmEntityBuilder::new(ident("E"))
+        .try_with_states([state("a", &[], true, false), state("b", &[], true, true)])
+        .unwrap()
+        .build()
+        .unwrap_err();
+    assert!(matches!(
+        many_initial,
+        FsmEntityBuilderError::MultipleInitialStates(_)
+    ));
+
+    let no_exit = FsmEntityBuilder::new(ident("E"))
+        .try_with_states([state("a", &["a"], true, false)])
+        .unwrap()
+        .build()
+        .unwrap_err();
+    assert!(matches!(no_exit, FsmEntityBuilderError::NoExitState));
+
+    let duplicate = FsmEntityBuilder::new(ident("E"))
+        .try_with_state(state("a", &[], true, true))
+        .unwrap()
+        .try_with_state(state("a", &[], false, false));
+    assert!(matches!(duplicate, Err(BuilderError::DuplicateName(_))));
 }
 
 #[test]

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -5,7 +5,7 @@ use quent_constraints::Constraint as _;
 use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmEntityBuilderError, FsmError, StateDecl};
 use quent_schema::{
     Annotations, Cardinality, Entity, Event, Schema,
-    builder::{AnnotationsBuilder, BuilderError, EntityBuilder},
+    builder::{AnnotationsBuilder, EntityBuilder},
     test_utils::{entity as bare_entity, event_with, ident, schema},
 };
 
@@ -346,15 +346,14 @@ fn builder_rejects_malformed_states() {
         .unwrap_err();
     assert!(matches!(no_exit, FsmEntityBuilderError::NoExitState));
 
+    // A duplicate that is also marked initial must report the duplicate, not
+    // `MultipleInitialStates`.
     let duplicate = FsmEntityBuilder::new(ident("E"))
         .with_state(state("a", &[], true, true))
-        .with_state(state("a", &[], false, false))
+        .with_state(state("a", &[], true, false))
         .build()
         .unwrap_err();
-    assert!(matches!(
-        duplicate,
-        FsmEntityBuilderError::Build(BuilderError::DuplicateName(_))
-    ));
+    assert!(matches!(duplicate, FsmEntityBuilderError::DuplicateState(_)));
 }
 
 #[test]

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -295,11 +295,10 @@ fn entity_without_fsm_constraint_is_ignored() {
 #[test]
 fn builder_produces_entity_with_state_events() {
     let entity = FsmEntityBuilder::new(ident("E"))
-        .try_with_states([
+        .with_states([
             state("a", &["b"], true, false),
             state("b", &[], false, true),
         ])
-        .unwrap()
         .build()
         .unwrap();
 
@@ -312,11 +311,10 @@ fn builder_produces_entity_with_state_events() {
 fn cardinality_is_derived_from_cycles() {
     // a -> b, b -> b: a sits off any cycle (Once), b self-loops (Multi).
     let entity = FsmEntityBuilder::new(ident("E"))
-        .try_with_states([
+        .with_states([
             state("a", &["b"], true, false),
             state("b", &["b"], false, true),
         ])
-        .unwrap()
         .build()
         .unwrap();
 
@@ -328,15 +326,13 @@ fn cardinality_is_derived_from_cycles() {
 #[test]
 fn builder_rejects_malformed_states() {
     let no_initial = FsmEntityBuilder::new(ident("E"))
-        .try_with_states([state("a", &[], false, true)])
-        .unwrap()
+        .with_states([state("a", &[], false, true)])
         .build()
         .unwrap_err();
     assert!(matches!(no_initial, FsmEntityBuilderError::NoInitialState));
 
     let many_initial = FsmEntityBuilder::new(ident("E"))
-        .try_with_states([state("a", &[], true, false), state("b", &[], true, true)])
-        .unwrap()
+        .with_states([state("a", &[], true, false), state("b", &[], true, true)])
         .build()
         .unwrap_err();
     assert!(matches!(
@@ -345,17 +341,20 @@ fn builder_rejects_malformed_states() {
     ));
 
     let no_exit = FsmEntityBuilder::new(ident("E"))
-        .try_with_states([state("a", &["a"], true, false)])
-        .unwrap()
+        .with_states([state("a", &["a"], true, false)])
         .build()
         .unwrap_err();
     assert!(matches!(no_exit, FsmEntityBuilderError::NoExitState));
 
     let duplicate = FsmEntityBuilder::new(ident("E"))
-        .try_with_state(state("a", &[], true, true))
-        .unwrap()
-        .try_with_state(state("a", &[], false, false));
-    assert!(matches!(duplicate, Err(BuilderError::DuplicateName(_))));
+        .with_state(state("a", &[], true, true))
+        .with_state(state("a", &[], false, false))
+        .build()
+        .unwrap_err();
+    assert!(matches!(
+        duplicate,
+        FsmEntityBuilderError::Build(BuilderError::DuplicateName(_))
+    ));
 }
 
 #[test]

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use quent_constraints::Constraint as _;
-use quent_fsm::{Fsm, FsmConstraint, FsmError};
+use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmError, StateDecl};
 use quent_schema::{
     Annotations, Cardinality, Entity, Event, Schema,
     builder::{AnnotationsBuilder, EntityBuilder},
@@ -11,6 +11,16 @@ use quent_schema::{
 
 fn event(name: &str, cardinality: Cardinality) -> Event {
     event_with(name, cardinality, vec![])
+}
+
+fn state(name: &str, to: &[&str], initial: bool, exit: bool) -> StateDecl {
+    StateDecl {
+        name: ident(name),
+        attributes: vec![],
+        to: to.iter().map(|s| ident(s)).collect(),
+        initial,
+        exit,
+    }
 }
 
 // Build the constraint's JSON directly so we can build it in an invalid way.
@@ -283,43 +293,36 @@ fn entity_without_fsm_constraint_is_ignored() {
 }
 
 #[test]
-fn builder_produces_valid_fsm_and_exposes_data() {
-    let entity = bare_entity(
-        "E",
-        vec![event("a", Cardinality::Once), event("b", Cardinality::Once)],
-    );
-    let fsm = Fsm::builder(&entity, ident("a"), ident("b"))
-        .transition(ident("a"), ident("b"))
+fn builder_produces_entity_with_state_events() {
+    let entity = FsmEntityBuilder::new(ident("E"))
+        .try_with_states([
+            state("a", &["b"], true, false),
+            state("b", &[], false, true),
+        ])
+        .unwrap()
         .build()
         .unwrap();
 
-    assert_eq!(fsm.initial_state(), &ident("a"));
-    assert_eq!(fsm.transitions().len(), 1);
-    assert_eq!(fsm.transitions()[0].source(), &ident("a"));
-    assert_eq!(fsm.transitions()[0].target(), &ident("b"));
-    assert_eq!(
-        fsm.exit_from_states().collect::<Vec<_>>(),
-        vec![&ident("b")],
-    );
+    let names: Vec<_> = entity.events().map(|e| e.name().to_string()).collect();
+    assert_eq!(names, vec!["a", "b"]);
+    assert!(entity.annotations().has_constraint(FsmConstraint::NAME));
 }
 
 #[test]
-fn builder_rejects_unknown_event() {
-    // b is not an event
-    let entity = bare_entity("E", vec![event("a", Cardinality::Once)]);
-    let err = Fsm::builder(&entity, ident("b"), ident("b"))
+fn cardinality_is_derived_from_cycles() {
+    // a -> b, b -> b: a sits off any cycle (Once), b self-loops (Multi).
+    let entity = FsmEntityBuilder::new(ident("E"))
+        .try_with_states([
+            state("a", &["b"], true, false),
+            state("b", &["b"], false, true),
+        ])
+        .unwrap()
         .build()
-        .err()
         .unwrap();
-    let errors = match err {
-        FsmError::Multiple(errors) => errors,
-        single => vec![single],
-    };
-    assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, FsmError::UnknownState { state, .. } if state == "b")),
-    );
+
+    let cardinality = |name: &str| entity.event(&ident(name)).unwrap().cardinality();
+    assert_eq!(cardinality("a"), Cardinality::Once);
+    assert_eq!(cardinality("b"), Cardinality::Multi);
 }
 
 #[test]


### PR DESCRIPTION
# Description

Aligns `quent-fsm`'s builder with the `quent-schema` builder idioms.

## Related Issues

Part of #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)