### PR TITLE
feat(instrumentation-build): generate an AnyEvent event decoder

### DIFF
--- a/crates/instrumentation-build/src/any_event.rs
+++ b/crates/instrumentation-build/src/any_event.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generation of `AnyEvent`: a decoder from a type-erased event to the concrete
+//! `Event<T>` for whichever entity produced it.
+
+use convert_case::Case;
+use proc_macro2::TokenStream;
+use quent_schema::Schema;
+use quote::quote;
+use syn::Ident;
+
+use crate::common::{derive_attr, raw_ident, to_case};
+use crate::{GenerateError, Options};
+
+/// Generate `AnyEvent` and its `from_any` decoder, carrying the event enums'
+/// derives ([`Options::event_derives`]).
+///
+/// # Errors
+///
+/// Returns [`GenerateError`] if a derive entry is not a parseable Rust path.
+pub(crate) fn generate_any_event(
+    schema: &Schema,
+    opts: &Options,
+) -> Result<TokenStream, GenerateError> {
+    let derives = derive_attr(opts.event_derives)?;
+
+    let variants: Vec<(Ident, Ident)> = schema
+        .entities()
+        .map(|entity| {
+            let pascal = to_case(entity.name(), Case::Pascal);
+            (
+                raw_ident(pascal.clone()),
+                raw_ident(format!("{pascal}Event")),
+            )
+        })
+        .collect();
+
+    let decls = variants.iter().map(|(variant, event)| {
+        quote! { #variant(&'a ::quent_instrumentation::Event<#event>) }
+    });
+    let arms = variants.iter().map(|(variant, event)| {
+        quote! {
+            if let Some(event) = any.downcast_ref::<::quent_instrumentation::Event<#event>>() {
+                return Some(AnyEvent::#variant(event));
+            }
+        }
+    });
+
+    Ok(quote! {
+        #derives
+        pub enum AnyEvent<'a> {
+            #(#decls),*
+        }
+        impl<'a> AnyEvent<'a> {
+            pub fn from_any(any: &'a (dyn ::core::any::Any)) -> Option<AnyEvent<'a>> {
+                #(#arms)*
+                None
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::pretty;
+    use quent_schema::builder::{EntityBuilder, EventBuilder, SchemaBuilder};
+    use quent_schema::{Cardinality, test_utils::ident};
+
+    fn entity(name: &str, event: &str) -> quent_schema::Entity {
+        EntityBuilder::new(ident(name))
+            .try_with_event(EventBuilder::new(ident(event), Cardinality::Once).build())
+            .unwrap()
+            .build()
+    }
+
+    #[test]
+    fn emits_a_variant_and_arm_per_entity() {
+        let schema = SchemaBuilder::new(ident("Demo"))
+            .try_with_entity(entity("Query", "submitted"))
+            .unwrap()
+            .try_with_entity(entity("Server", "booted"))
+            .unwrap()
+            .build();
+        let opts = Options {
+            event_derives: &["Debug"],
+            ..Options::default()
+        };
+        let expected = quote! {
+            #[derive(Debug)]
+            pub enum AnyEvent<'a> {
+                Query(&'a ::quent_instrumentation::Event<QueryEvent>),
+                Server(&'a ::quent_instrumentation::Event<ServerEvent>)
+            }
+
+            impl<'a> AnyEvent<'a> {
+                pub fn from_any(any: &'a (dyn ::core::any::Any)) -> Option<AnyEvent<'a>> {
+                    if let Some(event) =
+                        any.downcast_ref::<::quent_instrumentation::Event<QueryEvent>>()
+                    {
+                        return Some(AnyEvent::Query(event));
+                    }
+                    if let Some(event) =
+                        any.downcast_ref::<::quent_instrumentation::Event<ServerEvent>>()
+                    {
+                        return Some(AnyEvent::Server(event));
+                    }
+                    None
+                }
+            }
+        };
+        assert_eq!(
+            pretty(generate_any_event(&schema, &opts).unwrap()),
+            pretty(expected)
+        );
+    }
+}

--- a/crates/instrumentation-build/src/lib.rs
+++ b/crates/instrumentation-build/src/lib.rs
@@ -51,6 +51,7 @@
 //! carrying records or entity refs) must include a `Serialize`-providing
 //! derive; otherwise the generated code will not compile.
 
+mod any_event;
 mod common;
 mod data_type;
 mod events;
@@ -90,6 +91,10 @@ pub struct Options {
     /// File name to write; defaults to `<schema name>.rs` (lowercased) when
     /// `None`.
     pub file_name: Option<String>,
+
+    /// Emit `AnyEvent` and `AnyEvent::from_any`, a decoder from a type-erased
+    /// `&dyn Any` back to the concrete `Event<T>`. Carries [`Self::event_derives`].
+    pub any_event: bool,
 }
 
 impl Default for Options {
@@ -99,6 +104,7 @@ impl Default for Options {
             record_derives: Default::default(),
             out_dir: PathBuf::from(std::env::var("OUT_DIR").unwrap_or_default()),
             file_name: None,
+            any_event: false,
         }
     }
 }
@@ -171,7 +177,12 @@ pub fn generate_str(schema: &Schema, opts: &Options) -> Result<String, GenerateE
     let records = generate_record_types(schema, opts)?;
     let events = generate_event_types(schema, opts)?;
     let runtime = generate_runtime_types(schema)?;
-    let file = syn::parse2::<syn::File>(quote! { #reexports #records #events #runtime })
+    let any_event = if opts.any_event {
+        any_event::generate_any_event(schema, opts)?
+    } else {
+        quote! {}
+    };
+    let file = syn::parse2::<syn::File>(quote! { #reexports #records #events #runtime #any_event })
         .map_err(GenerateError::InvalidGeneratedCode)?;
     Ok(prettyplease::unparse(&file))
 }


### PR DESCRIPTION
# Description

Adds an off-by-default `any_event` option to codegen that emits `AnyEvent` plus `AnyEvent::from_any`, decoding a type-erased `&dyn Any` back to the concrete `Event<T>` for whichever entity produced it (e.g. a callback exporter receiving every entity's events on one channel). It depends only on `std::any`, not the exporter, and carries the event enums' derives.

## Related Issues

Part of #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)