### PR TITLE
refactor(nvtx): drop quent- prefix from nvtx integration crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvtx-events"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "nvtx-injection"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "cc",
+ "nvtx-events",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,23 +2810,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "quent-nvtx-events"
-version = "0.1.0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "quent-nvtx-injection"
-version = "0.1.0"
-dependencies = [
- "bindgen",
- "cc",
- "quent-nvtx-events",
- "thiserror",
 ]
 
 [[package]]

--- a/integrations/nvtx/README.md
+++ b/integrations/nvtx/README.md
@@ -3,17 +3,17 @@ SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Quent NVTX integration
+# NVTX integration
 
 Captures NVTX events (ranges, marks, domains, registered strings, categories,
 thread names, resources, and the core payload union) from an instrumented
-application and turns them into Quent events — with **no application code
+application and turns them into structured events — with **no application code
 changes**. NVTX loads the capture library at runtime via the
 `NVTX_INJECTION64_PATH` environment variable.
 
 **Linux 64-bit only.** Injection relies on the ELF weak-symbol /
 `NVTX_INJECTION64_PATH` mechanism, which excludes Windows and 32-bit targets;
-`quent-nvtx-injection` enforces this with a `compile_error!`.
+`nvtx-injection` enforces this with a `compile_error!`.
 
 ## Contents
 
@@ -26,10 +26,10 @@ changes**. NVTX loads the capture library at runtime via the
 
 | Crate | Path | Role |
 |-------|------|------|
-| `quent-nvtx-events` | `events/` | The verbatim, Quent-agnostic NVTX event **vocabulary** (`NvtxEvent` + attribute/payload types). Pure Rust — no C, no NVTX headers, and nothing Quent-internal — so it can be offered upstream to the NVTX Rust crates later. |
-| `quent-nvtx-injection` | `injection/` | The Quent-agnostic injection **cdylib** NVTX loads. Exports `InitializeInjectionNvtx2`, fills the NVTX callback tables, converts each call into a verbatim `NvtxEvent`, and hands it to a sink-agnostic `Fn(NvtxEvent)` hook. This is the only crate bound to the NVTX C ABI. |
+| `nvtx-events` | `events/` | The verbatim, application-agnostic NVTX event **vocabulary** (`NvtxEvent` + attribute/payload types). Pure Rust — no C, no NVTX headers, and nothing product-specific — so it can be offered upstream to the NVTX Rust crates later. |
+| `nvtx-injection` | `injection/` | The application-agnostic injection **cdylib** NVTX loads. Exports `InitializeInjectionNvtx2`, fills the NVTX callback tables, converts each call into a verbatim `NvtxEvent`, and hands it to a sink-agnostic `Fn(NvtxEvent)` hook. This is the only crate bound to the NVTX C ABI. |
 
-> A third crate — the bridge that wires captured events into Quent's event
+> A third crate — the bridge that wires captured events into a consumer's event
 > pipeline and provides the self-configuring capture cdylib you actually load —
 > follows in a later change.
 
@@ -48,8 +48,8 @@ changes**. NVTX loads the capture library at runtime via the
    the app are synthesized so the observed application still behaves correctly.
 
 Injection is **sink-agnostic** — it does not know where events go. A downstream
-crate installs the hook (into an ndjson file, Quent's pipeline, an in-memory
-collector for tests, etc.).
+crate installs the hook (into an ndjson file, a consumer's pipeline, an
+in-memory collector for tests, etc.).
 
 ### Captured surface
 
@@ -92,14 +92,14 @@ the pinned `nvtx-c` / `libclang` packages on the path.
 
 ## Upstreaming
 
-`quent-nvtx-events` and `quent-nvtx-injection` are kept deliberately
-Quent-agnostic — the vocabulary depends only on `serde`, and injection depends
-only on the vocabulary — because both are **very likely to be contributed
-upstream to the NVTX Rust crates**: the event vocabulary and a consumer/`tools`
-surface (the injection ABI the current `nvtx-sys` producer-only crate does not
-expose). If and when that lands upstream, Quent would depend on those crates
-instead of vendoring these two here.
+`nvtx-events` and `nvtx-injection` are kept deliberately application-agnostic —
+the vocabulary depends only on `serde`, and injection depends only on the
+vocabulary — because both are **very likely to be contributed upstream to the
+NVTX Rust crates**: the event vocabulary and a consumer/`tools` surface (the
+injection ABI the current `nvtx-sys` producer-only crate does not expose). If
+and when that lands upstream, a consumer would depend on those crates instead
+of vendoring these two here.
 
-This is a parallel effort and **not a blocker** for landing NVTX capture in
-Quent; the crates are structured now so that switching over later is a clean
+This is a parallel effort and **not a blocker** for landing NVTX capture in this
+repo; the crates are structured now so that switching over later is a clean
 dependency swap.

--- a/integrations/nvtx/events/Cargo.toml
+++ b/integrations/nvtx/events/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "quent-nvtx-events"
+name = "nvtx-events"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true

--- a/integrations/nvtx/events/src/attributes.rs
+++ b/integrations/nvtx/events/src/attributes.rs
@@ -40,7 +40,7 @@ pub struct NvtxColor {
 
 /// Captured subset of `nvtxEventAttributes_t`.
 ///
-/// Only the members Quent reconstructs from are retained (`category`, `color`,
+/// Only the members a consumer reconstructs from are retained (`category`, `color`,
 /// `message`, `payload`); all are stored verbatim with no capture-time
 /// resolution or decoding.
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/integrations/nvtx/events/src/lib.rs
+++ b/integrations/nvtx/events/src/lib.rs
@@ -1,19 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verbatim, Quent-agnostic NVTX event vocabulary.
+//! Verbatim, application-agnostic NVTX event vocabulary.
 //!
 //! Every downstream NVTX crate speaks this shared contract: the injection cdylib
-//! produces [`NvtxEvent`]s and the bridge forwards them into Quent. Events are
+//! produces [`NvtxEvent`]s and the bridge forwards them to a consumer. Events are
 //! captured **verbatim** — every handle (domain / category / resource /
 //! registered-string id) is a raw integer, and no name resolution or payload
 //! decoding happens at capture time. Handles are resolved from the event stream
 //! by a later analysis stage.
 //!
-//! The crate deliberately depends on nothing Quent-internal (optionally only
+//! The crate deliberately depends on nothing product-specific (optionally only
 //! `serde`, behind the default `serde` feature) so it stays cleanly separable and
 //! could be offered upstream to the NVTX Rust crates later. Adapting these events
-//! into Quent's pipeline — entity naming, the event wrapper — is the bridge
+//! into a consumer's pipeline — entity naming, the event wrapper — is the bridge
 //! crate's responsibility, not this crate's.
 
 mod attributes;

--- a/integrations/nvtx/injection/Cargo.toml
+++ b/integrations/nvtx/injection/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "quent-nvtx-injection"
+name = "nvtx-injection"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
@@ -13,7 +13,7 @@ publish.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-quent-nvtx-events = { path = "../events" }
+nvtx-events = { path = "../events" }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/integrations/nvtx/injection/build.rs
+++ b/integrations/nvtx/injection/build.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Build script for `quent-nvtx-injection`.
+//! Build script for `nvtx-injection`.
 //!
 //! Runs `bindgen` over the NVTX injection ABI and writes the result to
 //! `$OUT_DIR/bindings.rs`, which `lib.rs` `include!`s. The NVTX headers and
@@ -34,7 +34,7 @@ fn generate_bindings() -> Result<(), Box<dyn std::error::Error>> {
 
     let prefix = PathBuf::from(std::env::var("CONDA_PREFIX").map_err(|_| {
         "CONDA_PREFIX is unset — build this crate inside the pixi env (e.g. \
-         `pixi run cargo build -p quent-nvtx-injection`) so the pinned nvtx-c \
+         `pixi run cargo build -p nvtx-injection`) so the pinned nvtx-c \
          headers and libclang are on the path"
     })?);
 
@@ -88,7 +88,5 @@ fn generate_bindings() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "static-injection")]
 fn compile_symbol_shim() {
     println!("cargo::rerun-if-changed=c/symbol.c");
-    cc::Build::new()
-        .file("c/symbol.c")
-        .compile("quent_nvtx_symbol");
+    cc::Build::new().file("c/symbol.c").compile("nvtx_symbol");
 }

--- a/integrations/nvtx/injection/src/callbacks.rs
+++ b/integrations/nvtx/injection/src/callbacks.rs
@@ -296,7 +296,7 @@ fn warn_wide_surface_once() {
     static WARNED: AtomicBool = AtomicBool::new(false);
     if !WARNED.swap(true, Ordering::Relaxed) {
         eprintln!(
-            "quent-nvtx: a wide-char (Unicode) NVTX call was seen but not captured; only the \
+            "nvtx-injection: a wide-char (Unicode) NVTX call was seen but not captured; only the \
              ASCII surface is decoded. This warning fires once."
         );
     }

--- a/integrations/nvtx/injection/src/convert.rs
+++ b/integrations/nvtx/injection/src/convert.rs
@@ -21,7 +21,7 @@ use std::mem::{offset_of, size_of};
 use std::os::raw::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use quent_nvtx_events::{
+use nvtx_events::{
     NvtxColor, NvtxEvent, NvtxEventAttributes, NvtxMessage, NvtxPayload, NvtxPayloadValue,
 };
 
@@ -440,7 +440,7 @@ fn warn_unsupported_message_once() {
     static WARNED: AtomicBool = AtomicBool::new(false);
     if !WARNED.swap(true, Ordering::Relaxed) {
         eprintln!(
-            "quent-nvtx: an unsupported NVTX message encoding (e.g. wide-char/Unicode) was \
+            "nvtx-injection: an unsupported NVTX message encoding (e.g. wide-char/Unicode) was \
              dropped; only the domain-scoped ASCII surface is captured. This warning \
              fires once."
         );
@@ -506,7 +506,7 @@ unsafe fn read_resource(attr: *const nvtxResourceAttributes_t) -> (i32, u64, Opt
 ///   one-time process-global diagnostic is emitted (see [`warn_lossy_once`]) so
 ///   the fidelity loss is observable. True byte-verbatim capture (raw
 ///   `Vec<u8>`) is deferred to avoid a breaking change to the public
-///   `quent-nvtx-events` vocabulary.
+///   `nvtx-events` vocabulary.
 ///
 /// # Safety
 /// `ptr` must be null or a valid NUL-terminated C string readable for this call.
@@ -540,7 +540,7 @@ fn warn_lossy_once() {
     static WARNED: AtomicBool = AtomicBool::new(false);
     if !WARNED.swap(true, Ordering::Relaxed) {
         eprintln!(
-            "quent-nvtx: a non-UTF-8 NVTX string was captured lossily (invalid bytes replaced \
+            "nvtx-injection: a non-UTF-8 NVTX string was captured lossily (invalid bytes replaced \
              with U+FFFD); byte-verbatim capture is deferred. This warning fires once."
         );
     }
@@ -551,7 +551,7 @@ mod tests {
     use std::ffi::CString;
     use std::mem::{offset_of, size_of};
 
-    use quent_nvtx_events::{
+    use nvtx_events::{
         NvtxColor, NvtxEvent, NvtxEventAttributes, NvtxMessage, NvtxPayload, NvtxPayloadValue,
     };
 

--- a/integrations/nvtx/injection/src/init.rs
+++ b/integrations/nvtx/injection/src/init.rs
@@ -9,7 +9,7 @@ use std::os::raw::{c_char, c_int, c_uint, c_void};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use quent_nvtx_events::NvtxEvent;
+use nvtx_events::NvtxEvent;
 use thiserror::Error;
 
 use crate::bindings::{
@@ -353,7 +353,7 @@ unsafe fn install_core2(get_module_table: GetModuleTableFn) -> bool {
         // The cdylib installs no tracing subscriber, so surface the partial
         // install rather than capturing a silently incomplete domain surface.
         eprintln!(
-            "quent-nvtx: installed {done}/{} CORE2 domain callbacks (table reports {size} \
+            "nvtx-injection: installed {done}/{} CORE2 domain callbacks (table reports {size} \
              slots); the rest are domain calls the running NVTX does not expose and will not \
              be captured",
             installed.len()
@@ -385,7 +385,7 @@ unsafe fn install_core(get_module_table: GetModuleTableFn) {
         // The cdylib installs no tracing subscriber, so emit an unconditional
         // diagnostic instead of failing quietly.
         eprintln!(
-            "quent-nvtx: NVTX CORE callback table unavailable; default-domain and OS-thread-name \
+            "nvtx-injection: NVTX CORE callback table unavailable; default-domain and OS-thread-name \
              events will not be captured"
         );
         return;

--- a/integrations/nvtx/injection/src/lib.rs
+++ b/integrations/nvtx/injection/src/lib.rs
@@ -1,20 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Quent-agnostic NVTX injection cdylib.
+//! Application-agnostic NVTX injection cdylib.
 //!
 //! NVTX loads this library via `NVTX_INJECTION64_PATH` and calls the exported
 //! [`InitializeInjectionNvtx2`](crate::InitializeInjectionNvtx2) entry, which
 //! installs the CORE/CORE2 callback tables one-shot. Push/pop calls are
-//! converted to verbatim [`NvtxEvent`](quent_nvtx_events::NvtxEvent)s and handed
+//! converted to verbatim [`NvtxEvent`](nvtx_events::NvtxEvent)s and handed
 //! to a sink-agnostic `Fn(NvtxEvent)` hook installed via
 //! [`install_hook`](crate::install_hook). This crate depends on nothing
-//! Quent-internal except `quent-nvtx-events`, so it stays separable/upstreamable.
+//! product-specific except `nvtx-events`, so it stays separable/upstreamable.
 
 // Linux 64-bit only. NVTX injection relies on the ELF weak-symbol /
 // NVTX_INJECTION64_PATH mechanism; Windows and 32-bit are out of scope.
 #[cfg(not(all(target_os = "linux", target_pointer_width = "64")))]
-compile_error!("quent-nvtx-injection supports Linux 64-bit only");
+compile_error!("nvtx-injection supports Linux 64-bit only");
 
 #[allow(nonstandard_style, dead_code)]
 mod bindings {


### PR DESCRIPTION
## Drop the \`quent-\` prefix from the NVTX integration crates

Rename-only change (no behavior change) ahead of upstreaming the NVTX capture crates to the NVTX Rust ecosystem:

- `quent-nvtx-events` → `nvtx-events`
- `quent-nvtx-injection` → `nvtx-injection`

### What changed

- Package names, the `nvtx-injection` → `nvtx-events` path dependency, `use nvtx_events::` paths, intra-doc links, `compile_error!`, and the build-script `-p` hint + `cc` archive name (\`nvtx_symbol\`).
- De-quented the docs/prose to product-neutral wording (README title,"application-agnostic", "product-specific", "a consumer's pipeline").
- Runtime diagnostic prefix `quent-nvtx:` → `nvtx-injection:`.
- The crate directories (`events`, `injection`) were already un-prefixed, so the workspace member paths and the produced `.so` `.a` filenames are unchanged (both derive from the package name).