### PR TITLE
ci: run zizmor directly

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,12 +7,13 @@ permissions:
   contents: read
 
 jobs:
-  pre-commit:
-    name: pre-commit
+  github-actions-security:
+    name: GitHub Actions Security
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - name: Run zizmor
+        run: uvx "zizmor@1.27.0" --format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
-# SPDX-License-Identifier: Apache-2.0
-repos:
-  - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
-    hooks:
-      - id: zizmor


### PR DESCRIPTION
# Description

Replace the CI pre-commit wrapper with a direct pinned zizmor invocation.

🤖 Generated with Codex
