### PR TITLE
chore: setup basic codeowners file for easy default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owners for everything outside /ui
+* @johanpel @dhruv9vats @mbrobbel
+
+# UI
+/ui/ @johallar @cmatzenbach


### PR DESCRIPTION
# Description
Adds CODEOWNERS so github can figure out reviewer assignments

Note: github picks up CODEOWNERS from the main branch so didn't for this PR

## Related Issues
Fixes: https://github.com/rapidsai/quent/issues/71

## Testing
N/A

## Screenshots
N/A
