### PR TITLE
chore(ts): format bindings

### DIFF
--- a/examples/simulator/server/ts-bindings/CategoricalDecl.ts
+++ b/examples/simulator/server/ts-bindings/CategoricalDecl.ts
@@ -9,28 +9,29 @@ import type { MeasureDecl } from "./MeasureDecl";
  * Dimension keys are expected to be a small enumerable set; unbounded key
  * cardinality is a downstream misuse.
  */
-export type CategoricalDecl = { 
-/**
- * The FSM type whose states are broken down. References an entry in the
- * application's FSM type declarations (e.g. `QueryBundle` fsm_types) for
- * the state graph, names, and ordering.
- */
-entity_type_name: string, 
-/**
- * Display name of the dimension, e.g. an application may use a dimension
- * describing where an entity's data resides.
- */
-dimension_name: string, 
-/**
- * The dimension keys in stable stacking/legend order.
- */
-dimension_keys: Array<DimensionKeyDecl>, 
-/**
- * The measures present in this response.
- */
-measures: Array<MeasureDecl>, 
-/**
- * The measure the UI should select by default; must name an entry in
- * `measures`. `None` means the first declared measure.
- */
-default_measure: string | null, };
+export type CategoricalDecl = {
+  /**
+   * The FSM type whose states are broken down. References an entry in the
+   * application's FSM type declarations (e.g. `QueryBundle` fsm_types) for
+   * the state graph, names, and ordering.
+   */
+  entity_type_name: string;
+  /**
+   * Display name of the dimension, e.g. an application may use a dimension
+   * describing where an entity's data resides.
+   */
+  dimension_name: string;
+  /**
+   * The dimension keys in stable stacking/legend order.
+   */
+  dimension_keys: Array<DimensionKeyDecl>;
+  /**
+   * The measures present in this response.
+   */
+  measures: Array<MeasureDecl>;
+  /**
+   * The measure the UI should select by default; must name an entry in
+   * `measures`. `None` means the first declared measure.
+   */
+  default_measure: string | null;
+};

--- a/examples/simulator/server/ts-bindings/CategoricalSeries.ts
+++ b/examples/simulator/server/ts-bindings/CategoricalSeries.ts
@@ -6,4 +6,8 @@
  *
  * Absent inner entries mean all-zero bins.
  */
-export type CategoricalSeries = { values: { [key in string]: { [key in string]: { [key in string]: Array<number> } } }, };
+export type CategoricalSeries = {
+  values: {
+    [key in string]: { [key in string]: { [key in string]: Array<number> } };
+  };
+};

--- a/examples/simulator/server/ts-bindings/CategoricalTimelineRequest.ts
+++ b/examples/simulator/server/ts-bindings/CategoricalTimelineRequest.ts
@@ -4,16 +4,17 @@ import type { TimelineConfig } from "./TimelineConfig";
 /**
  * Request for a categorical timeline.
  */
-export type CategoricalTimelineRequest<GlobalParams> = { 
-/**
- * Names of the measures to compute. Empty means all declared measures.
- */
-measures: Array<string>, 
-/**
- * The configuration of the window and number of bins.
- */
-config: TimelineConfig, 
-/**
- * Global application-specific parameters, e.g. filters.
- */
-app_params: GlobalParams, };
+export type CategoricalTimelineRequest<GlobalParams> = {
+  /**
+   * Names of the measures to compute. Empty means all declared measures.
+   */
+  measures: Array<string>;
+  /**
+   * The configuration of the window and number of bins.
+   */
+  config: TimelineConfig;
+  /**
+   * Global application-specific parameters, e.g. filters.
+   */
+  app_params: GlobalParams;
+};

--- a/examples/simulator/server/ts-bindings/DataFlowTimelineBinned.ts
+++ b/examples/simulator/server/ts-bindings/DataFlowTimelineBinned.ts
@@ -9,19 +9,20 @@ import type { CategoricalSeries } from "./CategoricalSeries";
  * `AnalyzerError::Unsupported` instead (HTTP 501), which the UI treats as
  * "hide the view".
  */
-export type DataFlowTimelineBinned = { 
-/**
- * The configuration of the binned timeline.
- *
- * This may slightly differ from the requested configuration to ensure
- * bounds are not exceeded and bin sizes are equal.
- */
-config: BinnedSpanSec, 
-/**
- * Presentation metadata declared by the analyzer.
- */
-decl: CategoricalDecl, 
-/**
- * Categorical series keyed by operator id.
- */
-operators: { [key in string]: CategoricalSeries }, };
+export type DataFlowTimelineBinned = {
+  /**
+   * The configuration of the binned timeline.
+   *
+   * This may slightly differ from the requested configuration to ensure
+   * bounds are not exceeded and bin sizes are equal.
+   */
+  config: BinnedSpanSec;
+  /**
+   * Presentation metadata declared by the analyzer.
+   */
+  decl: CategoricalDecl;
+  /**
+   * Categorical series keyed by operator id.
+   */
+  operators: { [key in string]: CategoricalSeries };
+};

--- a/examples/simulator/server/ts-bindings/DimensionKeyDecl.ts
+++ b/examples/simulator/server/ts-bindings/DimensionKeyDecl.ts
@@ -3,12 +3,13 @@
 /**
  * One key of the application-defined dimension of a categorical timeline.
  */
-export type DimensionKeyDecl = { 
-/**
- * The key used in [`CategoricalSeries::values`].
- */
-key: string, 
-/**
- * Human-friendly display name.
- */
-display_name: string, };
+export type DimensionKeyDecl = {
+  /**
+   * The key used in [`CategoricalSeries::values`].
+   */
+  key: string;
+  /**
+   * Human-friendly display name.
+   */
+  display_name: string;
+};

--- a/examples/simulator/server/ts-bindings/MeasureDecl.ts
+++ b/examples/simulator/server/ts-bindings/MeasureDecl.ts
@@ -5,20 +5,21 @@ import type { CapacityKind } from "./CapacityKind";
  * A measure declared by the downstream analyzer for a categorical timeline,
  * e.g. an entity count or a number of bytes.
  */
-export type MeasureDecl = { 
-/**
- * Unique name; key into [`CategoricalSeries::values`].
- */
-name: string, 
-/**
- * Human-friendly display name.
- */
-display_name: string, 
-/**
- * Key into the application's quantity specs map for unit formatting.
- */
-quantity: string, 
-/**
- * Display semantics of a bin value (Occupancy = time-weighted level).
- */
-kind: CapacityKind, };
+export type MeasureDecl = {
+  /**
+   * Unique name; key into [`CategoricalSeries::values`].
+   */
+  name: string;
+  /**
+   * Human-friendly display name.
+   */
+  display_name: string;
+  /**
+   * Key into the application's quantity specs map for unit formatting.
+   */
+  quantity: string;
+  /**
+   * Display semantics of a bin value (Occupancy = time-weighted level).
+   */
+  kind: CapacityKind;
+};


### PR DESCRIPTION
#393 merged generated ts bindings that weren't formatted using the changes of #421, this fixes them.

cc. @johallar @cmatzenbach could we please consider #255 to avoid these issues altogether?