### PR TITLE
fix(schema): reject entities without events

### DIFF
--- a/crates/constraints/src/entities_without_events.rs
+++ b/crates/constraints/src/entities_without_events.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use quent_schema::visitor::{Cursor, Element, Visitor};
+
+/// Reports every entity that declares no events.
+#[derive(Default)]
+pub(crate) struct EntitiesWithoutEvents {
+    entities: Vec<String>,
+}
+
+impl Visitor for EntitiesWithoutEvents {
+    type Output = Vec<String>;
+
+    fn visit(&mut self, cursor: &Cursor) {
+        if let Element::Entity(entity) = cursor.current()
+            && entity.events().len() == 0
+        {
+            self.entities.push(entity.name().to_string());
+        }
+    }
+
+    fn finish(self) -> Self::Output {
+        self.entities
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quent_schema::Schema;
+    use quent_schema::test_utils::{eventless_entity, schema};
+
+    fn walk(schema: &Schema) -> Vec<String> {
+        schema.walk(EntitiesWithoutEvents::default())
+    }
+
+    #[test]
+    fn entities_without_events_are_reported() {
+        let schema = schema(
+            "S",
+            vec![eventless_entity("A"), eventless_entity("B")],
+            vec![],
+        );
+        assert_eq!(walk(&schema), vec!["A".to_string(), "B".to_string()]);
+    }
+}

--- a/crates/constraints/src/lib.rs
+++ b/crates/constraints/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod utils;
 
+mod entities_without_events;
 mod recursive_record;
 mod unregistered_constraints;
 mod unresolved_refs;
@@ -50,6 +51,8 @@ pub struct BaseConstraintsError {
     pub invalid_references: Vec<String>,
     /// Records that are recursive
     pub recursive_records: Vec<String>,
+    /// Entities that declare no events.
+    pub entities_without_events: Vec<String>,
 }
 impl Display for BaseConstraintsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -58,7 +61,8 @@ impl Display for BaseConstraintsError {
             "base constraints failed to validate:\n{}",
             [
                 utils::bullet_list(&self.invalid_references),
-                utils::bullet_list(&self.recursive_records)
+                utils::bullet_list(&self.recursive_records),
+                utils::bullet_list(&self.entities_without_events),
             ]
             .join("\n")
         )
@@ -120,19 +124,31 @@ pub struct Report<R> {
 /// assert!(report.unregistered_constraints.is_empty());
 /// ```
 pub fn validate<C: Constraints>(schema: &Schema) -> Report<C::Output> {
-    let (invalid_references, unregistered_constraints, recursive_records, results) = schema.walk((
+    let (
+        invalid_references,
+        unregistered_constraints,
+        recursive_records,
+        entities_without_events,
+        results,
+    ) = schema.walk((
         unresolved_refs::UnresolvedReferences::default(),
         unregistered_constraints::UnregisteredConstraints::new(C::NAMES),
         recursive_record::RecursiveRecords::default(),
+        entities_without_events::EntitiesWithoutEvents::default(),
         C::default(),
     ));
     Report {
         unregistered_constraints: unregistered_constraints.into_iter().collect(),
-        base_constraints: match (invalid_references.len(), recursive_records.len()) {
-            (0, 0) => Ok(()),
+        base_constraints: match (
+            invalid_references.len(),
+            recursive_records.len(),
+            entities_without_events.len(),
+        ) {
+            (0, 0, 0) => Ok(()),
             _ => Err(BaseConstraintsError {
                 invalid_references,
                 recursive_records,
+                entities_without_events,
             }),
         },
         results,

--- a/crates/constraints/tests/validator.rs
+++ b/crates/constraints/tests/validator.rs
@@ -5,7 +5,7 @@ use quent_constraints::{Constraint, validate};
 use quent_schema::{
     Annotations, Cardinality, DataType, Field, Schema,
     builder::{AnnotationsBuilder, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder},
-    test_utils::{self, entity, event, field, ident, schema},
+    test_utils::{self, entity, event, eventless_entity, field, ident, record, schema},
     visitor::{Cursor, Visitor},
 };
 
@@ -136,7 +136,8 @@ fn unregistered_constraint_is_reported_once() {
         .try_with_event(event)
         .unwrap()
         .with_annotations(unknown())
-        .build();
+        .build()
+        .unwrap();
     let record_field = Field::new(ident("rf"), DataType::U64, unknown());
     let record = RecordBuilder::new(ident("R"))
         .try_with_field(record_field)
@@ -219,4 +220,19 @@ fn validates_consistency_with_no_constraints() {
 
     let clean = validate::<()>(&empty_schema());
     assert!(clean.base_constraints.is_ok());
+}
+
+#[test]
+fn entity_without_events_fails_base_validation() {
+    let schema = schema("S", vec![eventless_entity("E")], vec![]);
+    let error = validate::<()>(&schema).base_constraints.unwrap_err();
+
+    assert_eq!(error.entities_without_events, vec!["E".to_string()]);
+    assert!(error.to_string().contains("  - E"));
+}
+
+#[test]
+fn empty_record_passes_base_validation() {
+    let schema = schema("S", vec![], vec![record("Empty", vec![])]);
+    assert!(validate::<()>(&schema).base_constraints.is_ok());
 }

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -161,7 +161,7 @@ impl FsmEntityBuilder {
         }
 
         annotations.set_constraint(FsmConstraint::NAME, Some(fsm.constraint_data()?));
-        let entity = entity.with_annotations(annotations.build()).build();
+        let entity = entity.with_annotations(annotations.build()).build()?;
 
         // Validate the full topology now, the same checks the constraint runs
         // during schema validation, so a built entity is always valid.

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -52,6 +52,7 @@ fn entity_with(name: &str, events: Vec<Event>, data: &str) -> Entity {
         .unwrap()
         .with_annotations(fsm_annotations(Some(data.to_string())))
         .build()
+        .unwrap()
 }
 
 fn schema_with(entity: Entity) -> Schema {
@@ -98,7 +99,8 @@ fn missing_data_is_rejected() {
         .try_with_event(event("a", Cardinality::Once))
         .unwrap()
         .with_annotations(fsm_annotations(None))
-        .build();
+        .build()
+        .unwrap();
     let errors = validate(&schema_with(entity));
     assert!(
         errors
@@ -113,7 +115,8 @@ fn invalid_json_is_rejected() {
         .try_with_event(event("a", Cardinality::Once))
         .unwrap()
         .with_annotations(fsm_annotations(Some("{ trash".to_string())))
-        .build();
+        .build()
+        .unwrap();
     let errors = validate(&schema_with(entity));
     assert!(
         errors

--- a/crates/instrumentation-build/src/any_event.rs
+++ b/crates/instrumentation-build/src/any_event.rs
@@ -73,6 +73,7 @@ mod tests {
             .try_with_event(EventBuilder::new(ident(event), Cardinality::Once).build())
             .unwrap()
             .build()
+            .unwrap()
     }
 
     #[test]

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -150,7 +150,8 @@ mod tests {
             .try_with_event(ev)
             .unwrap()
             .with_annotations(docs("entity doc"))
-            .build();
+            .build()
+            .unwrap();
         let s = SchemaBuilder::new(ident("M"))
             .try_with_entity(en)
             .unwrap()
@@ -190,16 +191,6 @@ mod tests {
                 #[doc = "The `ended` event."]
                 Ended
             }
-        };
-        assert_eq!(events_src(&s), pretty(expected));
-    }
-
-    #[test]
-    fn entity_without_events_emits_empty_enum() {
-        let s = schema("M", [entity("E", [])], []);
-        let expected = quote! {
-            #[doc = "Events emitted by `E` entities."]
-            pub enum EEvent {}
         };
         assert_eq!(events_src(&s), pretty(expected));
     }

--- a/crates/instrumentation-build/src/runtime/mod.rs
+++ b/crates/instrumentation-build/src/runtime/mod.rs
@@ -127,7 +127,8 @@ mod tests {
                     .build(),
             )
             .unwrap()
-            .build();
+            .build()
+            .unwrap();
         let s = SchemaBuilder::new(ident("Demo"))
             .try_with_entity(connection)
             .unwrap()

--- a/crates/ref-target/tests/ref-target-constraint.rs
+++ b/crates/ref-target/tests/ref-target-constraint.rs
@@ -34,7 +34,7 @@ fn validate(schema: &Schema) -> Vec<RefTargetError> {
 
 #[test]
 fn ref_to_existing_entity_passes() {
-    let worker = entity("Worker", vec![]);
+    let worker = entity("Worker", vec![event("created", vec![])]);
     let task = entity(
         "Task",
         vec![event(

--- a/crates/resource/tests/resource-constraint.rs
+++ b/crates/resource/tests/resource-constraint.rs
@@ -68,15 +68,11 @@ fn bounds_record(name: &str, resource: &str, fields: &[&str]) -> Record {
 fn resource_entity(name: &str, capacities: &[(&str, &str, bool)], bounds: Option<&str>) -> Entity {
     let mut builder = EntityBuilder::new(ident(name))
         .with_annotations(resource_annotations(definition_data(capacities)));
-    if let Some(bounds) = bounds {
-        builder = builder
-            .try_with_event(event(
-                "operating",
-                [field("bounds", DataType::Record(ident(bounds)))],
-            ))
-            .unwrap();
-    }
-    builder.build()
+    let fields = bounds
+        .map(|bounds| field("bounds", DataType::Record(ident(bounds))))
+        .into_iter();
+    builder = builder.try_with_event(event("operating", fields)).unwrap();
+    builder.build().unwrap()
 }
 
 /// Create an entity with one event referencing `record`.
@@ -99,7 +95,7 @@ fn user_entity(name: &str, fsm: bool, record: &str, on_ref: bool) -> Entity {
     if fsm {
         builder = builder.with_annotations(fsm_annotations());
     }
-    builder.build()
+    builder.build().unwrap()
 }
 
 fn resource_errors(schema: &Schema) -> Vec<ResourceError> {
@@ -271,8 +267,11 @@ fn misplaced_resources_are_rejected() {
     let definition_on_record = schema("App", [], [bad_record]);
 
     let bad_entity = EntityBuilder::new(ident("Worker"))
+        .try_with_event(event("using", []))
+        .unwrap()
         .with_annotations(resource_annotations(usage_data("Memory")))
-        .build();
+        .build()
+        .unwrap();
     let usage_on_entity = schema("App", [bad_entity], []);
 
     let usage_on_schema = SchemaBuilder::new(ident("App"))

--- a/crates/schema/src/builder/entity.rs
+++ b/crates/schema/src/builder/entity.rs
@@ -102,7 +102,29 @@ impl EntityBuilder {
     }
 
     /// Finish building the entity.
-    pub fn build(self) -> Entity {
-        Entity::from_parts(self.name, self.events, self.annotations.build())
+    ///
+    /// # Errors
+    ///
+    /// Errors if the entity declares no events.
+    pub fn build(self) -> Result<Entity, BuilderError> {
+        if self.events.is_empty() {
+            return Err(BuilderError::NoEvents);
+        }
+        Ok(Entity::from_parts(
+            self.name,
+            self.events,
+            self.annotations.build(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_entity_without_events() {
+        let error = EntityBuilder::try_new("E").unwrap().build().unwrap_err();
+        assert_eq!(error, BuilderError::NoEvents);
     }
 }

--- a/crates/schema/src/builder/mod.rs
+++ b/crates/schema/src/builder/mod.rs
@@ -31,6 +31,9 @@ pub enum BuilderError {
     /// A name was empty.
     #[error("name must not be empty")]
     EmptyName,
+    /// No events were added to an entity.
+    #[error("entity must declare at least one event")]
+    NoEvents,
 }
 
 pub(crate) fn insert_unique<K, V>(map: &mut Map<K, V>, key: K, value: V) -> Result<(), BuilderError>

--- a/crates/schema/src/schema/entity.rs
+++ b/crates/schema/src/schema/entity.rs
@@ -45,7 +45,7 @@ impl Entity {
     }
 
     /// The declared events, in declaration order.
-    pub fn events(&self) -> impl Iterator<Item = &Event> + '_ {
+    pub fn events(&self) -> impl ExactSizeIterator<Item = &Event> + '_ {
         self.events.values()
     }
 }

--- a/crates/schema/src/test_utils.rs
+++ b/crates/schema/src/test_utils.rs
@@ -36,6 +36,10 @@ pub fn entity(name: &str, events: impl IntoIterator<Item = Event>) -> Entity {
         .try_with_events(events)
         .unwrap()
         .build()
+        .unwrap()
+}
+pub fn eventless_entity(name: &str) -> Entity {
+    Entity::from_parts(ident(name), Default::default(), Annotations::default())
 }
 pub fn record(name: &str, fields: impl IntoIterator<Item = Field>) -> Record {
     RecordBuilder::new(ident(name))

--- a/crates/yaml/src/lib.rs
+++ b/crates/yaml/src/lib.rs
@@ -69,6 +69,13 @@ pub fn parse_from_str(src: impl AsRef<str>, source: Option<&str>) -> Result<Pars
 
     let report = validate::<(RefTargetConstraint, RefTreeConstraint, FsmConstraint)>(&schema);
     if let Err(e) = report.base_constraints {
+        for entity in e.entities_without_events {
+            sink.error(
+                &format!("entities.{entity}"),
+                format!("entity `{entity}` declares no events"),
+                Some("entities must declare at least one event".to_string()),
+            );
+        }
         for record in e.recursive_records {
             sink.error(
                 &format!("records.{record}"),

--- a/crates/yaml/src/lower.rs
+++ b/crates/yaml/src/lower.rs
@@ -19,7 +19,7 @@ use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmEntityBuilderError, FsmError
 use quent_ref_target::RefTargetConstraint;
 use quent_ref_tree::RefTreeConstraint;
 use quent_schema::builder::{
-    AnnotationsBuilder, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder,
+    AnnotationsBuilder, BuilderError, EntityBuilder, EventBuilder, RecordBuilder, SchemaBuilder,
 };
 use quent_schema::{Annotations, DataType, Entity, Field, Identifier, Record, Schema};
 use serde::Deserialize;
@@ -123,13 +123,26 @@ fn entity_of(name: &str, entity: &ast::Entity, sink: &mut Diagnostics) -> Option
         .iter()
         .filter_map(|(event_name, event)| event_of(event_name, event, &path, sink))
         .collect();
-    Some(
-        EntityBuilder::new(id?)
-            .try_with_events(events)
-            .expect("event names are unique")
-            .with_annotations(anns)
-            .build(),
-    )
+    match EntityBuilder::new(id?)
+        .try_with_events(events)
+        .expect("event names are unique")
+        .with_annotations(anns)
+        .build()
+    {
+        Ok(entity) => Some(entity),
+        Err(BuilderError::NoEvents) => {
+            sink.error(
+                &path,
+                format!("entity `{name}` declares no events"),
+                Some("entities must declare at least one event".to_string()),
+            );
+            None
+        }
+        Err(error) => {
+            sink.error(&path, error.to_string(), None);
+            None
+        }
+    }
 }
 
 /// Lower an FSM entity from its `fsms:` declaration: its states become the

--- a/crates/yaml/tests/diagnostics.rs
+++ b/crates/yaml/tests/diagnostics.rs
@@ -133,6 +133,18 @@ records:
 }
 
 #[test]
+fn entity_without_events() {
+    expect_error(
+        "\
+entities:
+  E:
+    events: {}
+",
+        &["entity `E` declares no events"],
+    );
+}
+
+#[test]
 fn invalid_sibling_names_do_not_panic() {
     // Two records with invalid names must both surface as diagnostics rather
     // than reaching the builder as a shared placeholder and panicking.


### PR DESCRIPTION
# Description

Reject entities without events during construction and base-schema validation.

Written by Codex.