### PR TITLE
feat(instrumentation-build): generate namespaced APIs 

### DIFF
--- a/crates/instrumentation-build/src/any_event.rs
+++ b/crates/instrumentation-build/src/any_event.rs
@@ -35,9 +35,7 @@ pub(crate) fn generate_any_event(
         })
         .collect();
     let children: Vec<(Ident, Ident)> = namespace
-        .children()
-        .iter()
-        .filter(|child| child.has_entities())
+        .children_with_entities()
         .map(|child| {
             let segment = child
                 .path()

--- a/crates/instrumentation-build/src/any_event.rs
+++ b/crates/instrumentation-build/src/any_event.rs
@@ -6,11 +6,13 @@
 
 use convert_case::Case;
 use proc_macro2::TokenStream;
-use quent_schema::Schema;
 use quote::quote;
 use syn::Ident;
 
-use crate::common::{derive_attr, raw_ident, to_case};
+use crate::common::{
+    derive_attr, module_ident, path_name_pascal, raw_ident, relative_type_path, to_case,
+};
+use crate::namespace::Namespace;
 use crate::{GenerateError, Options};
 
 /// Generate `AnyEvent` and its `from_any` decoder, carrying the event enums'
@@ -20,20 +22,34 @@ use crate::{GenerateError, Options};
 ///
 /// Returns [`GenerateError`] if a derive entry is not a parseable Rust path.
 pub(crate) fn generate_any_event(
-    schema: &Schema,
+    namespace: &Namespace<'_>,
     opts: &Options,
 ) -> Result<TokenStream, GenerateError> {
-    let variants: Vec<(Ident, Ident)> = schema
+    let variants: Vec<(Ident, TokenStream)> = namespace
         .entities()
+        .iter()
         .map(|entity| {
-            let pascal = to_case(entity.path().name(), Case::Pascal);
+            let variant = raw_ident(path_name_pascal(entity.path()));
+            let event = relative_type_path(entity.path(), namespace.path(), "Event");
+            (variant, event)
+        })
+        .collect();
+    let children: Vec<(Ident, Ident)> = namespace
+        .children()
+        .iter()
+        .filter(|child| child.has_entities())
+        .map(|child| {
+            let segment = child
+                .path()
+                .last()
+                .expect("child namespaces extend their parent");
             (
-                raw_ident(pascal.clone()),
-                raw_ident(format!("{pascal}Event")),
+                raw_ident(to_case(segment, Case::Pascal)),
+                module_ident(segment),
             )
         })
         .collect();
-    if variants.is_empty() {
+    if variants.is_empty() && children.is_empty() {
         return Ok(quote! {});
     }
 
@@ -41,10 +57,20 @@ pub(crate) fn generate_any_event(
     let decls = variants.iter().map(|(variant, event)| {
         quote! { #variant(&'a ::quent_instrumentation::Event<#event>) }
     });
-    let arms = variants.iter().map(|(variant, event)| {
+    let child_decls = children.iter().map(|(variant, module)| {
+        quote! { #variant(#module::AnyEvent<'a>) }
+    });
+    let direct_arms = variants.iter().map(|(variant, event)| {
         quote! {
             if let Some(event) = any.downcast_ref::<::quent_instrumentation::Event<#event>>() {
-                return Some(AnyEvent::#variant(event));
+                return Some(Self::#variant(event));
+            }
+        }
+    });
+    let child_arms = children.iter().map(|(variant, module)| {
+        quote! {
+            if let Some(event) = #module::AnyEvent::from_any(any) {
+                return Some(Self::#variant(event));
             }
         }
     });
@@ -52,11 +78,13 @@ pub(crate) fn generate_any_event(
     Ok(quote! {
         #derives
         pub enum AnyEvent<'a> {
-            #(#decls),*
+            #(#decls,)*
+            #(#child_decls,)*
         }
         impl<'a> AnyEvent<'a> {
-            pub fn from_any(any: &'a (dyn ::core::any::Any)) -> Option<AnyEvent<'a>> {
-                #(#arms)*
+            pub fn from_any(any: &'a dyn ::core::any::Any) -> Option<Self> {
+                #(#direct_arms)*
+                #(#child_arms)*
                 None
             }
         }
@@ -67,31 +95,21 @@ pub(crate) fn generate_any_event(
 mod tests {
     use super::*;
     use crate::common::pretty;
-    use quent_schema::builder::{EntityBuilder, EventBuilder, SchemaBuilder};
-    use quent_schema::{Cardinality, test_utils::ident};
-
-    fn entity(name: &str, event: &str) -> quent_schema::Entity {
-        EntityBuilder::new(ident(name))
-            .with_event(
-                EventBuilder::new(ident(event), Cardinality::Once)
-                    .build()
-                    .unwrap(),
-            )
-            .build()
-            .unwrap()
-    }
+    use quent_schema::builder::SchemaBuilder;
+    use quent_schema::test_utils::{entity, event, ident};
 
     #[test]
     fn emits_a_variant_and_arm_per_entity() {
         let schema = SchemaBuilder::new(ident("Demo"))
-            .with_entity(entity("Query", "submitted"))
-            .with_entity(entity("Server", "booted"))
+            .with_entity(entity("Query", [event("submitted", [])]))
+            .with_entity(entity("Server", [event("booted", [])]))
             .build()
             .unwrap();
         let opts = Options {
             event_derives: &["Debug"],
             ..Options::default()
         };
+        let namespaces = Namespace::root(&schema);
         let expected = quote! {
             #[derive(Debug)]
             pub enum AnyEvent<'a> {
@@ -100,23 +118,23 @@ mod tests {
             }
 
             impl<'a> AnyEvent<'a> {
-                pub fn from_any(any: &'a (dyn ::core::any::Any)) -> Option<AnyEvent<'a>> {
+                pub fn from_any(any: &'a dyn ::core::any::Any) -> Option<Self> {
                     if let Some(event) =
                         any.downcast_ref::<::quent_instrumentation::Event<QueryEvent>>()
                     {
-                        return Some(AnyEvent::Query(event));
+                        return Some(Self::Query(event));
                     }
                     if let Some(event) =
                         any.downcast_ref::<::quent_instrumentation::Event<ServerEvent>>()
                     {
-                        return Some(AnyEvent::Server(event));
+                        return Some(Self::Server(event));
                     }
                     None
                 }
             }
         };
         assert_eq!(
-            pretty(generate_any_event(&schema, &opts).unwrap()),
+            pretty(generate_any_event(&namespaces, &opts).unwrap()),
             pretty(expected)
         );
     }
@@ -124,9 +142,10 @@ mod tests {
     #[test]
     fn emits_nothing_without_entities() {
         let schema = SchemaBuilder::new(ident("Demo")).build().unwrap();
+        let namespaces = Namespace::root(&schema);
 
         assert!(
-            generate_any_event(&schema, &Options::default())
+            generate_any_event(&namespaces, &Options::default())
                 .unwrap()
                 .is_empty()
         );

--- a/crates/instrumentation-build/src/common.rs
+++ b/crates/instrumentation-build/src/common.rs
@@ -5,7 +5,7 @@
 
 use convert_case::{Boundary, Case, Casing};
 use proc_macro2::{Span, TokenStream};
-use quent_schema::Identifier;
+use quent_schema::{Identifier, Path};
 use quote::quote;
 use syn::Ident;
 
@@ -50,6 +50,46 @@ pub(crate) fn to_case(id: &Identifier, case: Case) -> String {
     id.to_string()
         .remove_boundaries(&Boundary::digits())
         .to_case(case)
+}
+
+/// Return the Pascal-case type name for the final path segment.
+pub(crate) fn path_name_pascal(path: &Path) -> String {
+    to_case(path.name(), Case::Pascal)
+}
+
+/// Return the Rust module name for a path segment.
+pub(crate) fn module_ident(segment: &Identifier) -> Ident {
+    raw_ident(to_case(segment, Case::Snake))
+}
+
+/// Return a generated type path relative to `source_namespace`.
+pub(crate) fn relative_type_path(
+    path: &Path,
+    source_namespace: &[Identifier],
+    suffix: &str,
+) -> TokenStream {
+    let common = path
+        .namespace()
+        .iter()
+        .zip(source_namespace)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut segments = Vec::new();
+    segments.extend((common..source_namespace.len()).map(|_| quote! { super }));
+    for segment in &path.namespace()[common..] {
+        let module = module_ident(segment);
+        segments.push(quote! { #module });
+    }
+    let ty = raw_ident(format!("{}{}", path_name_pascal(path), suffix));
+    segments.push(quote! { #ty });
+    quote! { #(#segments)::* }
+}
+
+/// Return a root type path relative to `source_namespace`.
+pub(crate) fn relative_root_type(name: &str, source_namespace: &[Identifier]) -> TokenStream {
+    let parents = source_namespace.iter().map(|_| quote! { super });
+    let ty = raw_ident(name.to_owned());
+    quote! { #(#parents::)* #ty }
 }
 
 /// Build an identifier from an already-cased name, raw-escaping Rust keywords.

--- a/crates/instrumentation-build/src/data_type.rs
+++ b/crates/instrumentation-build/src/data_type.rs
@@ -3,13 +3,12 @@
 
 //! Mapping from schema [`DataType`]s to Rust type tokens.
 
-use convert_case::Case;
 use proc_macro2::TokenStream;
 use quent_ref_target::RefTarget;
 use quent_schema::{Annotations, DataType};
 use quote::quote;
 
-use crate::common::{raw_ident, to_case};
+use crate::common::{relative_root_type, relative_type_path};
 
 /// Maximum nesting depth of `Option`/`List`/`EntityRef` wrappers a single field
 /// type may have, far above any realistic schema. Self-referential records are
@@ -23,7 +22,11 @@ pub(crate) const MAX_TYPE_DEPTH: usize = 64;
 /// # Panics
 ///
 /// Panics if `ty` nests deeper than [`MAX_TYPE_DEPTH`].
-pub(crate) fn map_data_type(ty: &DataType, depth: usize) -> TokenStream {
+pub(crate) fn map_data_type(
+    ty: &DataType,
+    depth: usize,
+    source_namespace: &[quent_schema::Identifier],
+) -> TokenStream {
     assert!(
         depth <= MAX_TYPE_DEPTH,
         "field type nesting exceeds the maximum depth of {MAX_TYPE_DEPTH}"
@@ -43,23 +46,20 @@ pub(crate) fn map_data_type(ty: &DataType, depth: usize) -> TokenStream {
         DataType::F32 => quote! { f32 },
         DataType::F64 => quote! { f64 },
         DataType::Option(inner) => {
-            let inner = map_data_type(inner, depth + 1);
+            let inner = map_data_type(inner, depth + 1, source_namespace);
             quote! { Option<#inner> }
         }
         DataType::List(inner) => {
-            let inner = map_data_type(inner, depth + 1);
+            let inner = map_data_type(inner, depth + 1, source_namespace);
             quote! { Vec<#inner> }
         }
-        DataType::Record(name) => {
-            let ident = raw_ident(to_case(name.name(), Case::Pascal));
-            quote! { #ident }
-        }
+        DataType::Record(path) => relative_type_path(path, source_namespace, ""),
         DataType::DynamicRecord => quote! { ::quent_instrumentation::DynamicAttributes },
         DataType::EntityRef { data, annotations } => {
-            let target = ref_target_marker(annotations);
+            let target = ref_target_marker(annotations, source_namespace);
             match data {
                 Some(inner) => {
-                    let inner = map_data_type(inner, depth + 1);
+                    let inner = map_data_type(inner, depth + 1, source_namespace);
                     quote! { ::quent_instrumentation::EntityRef<#target, #inner> }
                 }
                 None => quote! { ::quent_instrumentation::EntityRef<#target> },
@@ -71,13 +71,13 @@ pub(crate) fn map_data_type(ty: &DataType, depth: usize) -> TokenStream {
 /// The target-entity marker type for an entity reference, taken from its
 /// ref-target constraint, or the `AnyEntity` marker when it is not restricted
 /// to a target entity.
-fn ref_target_marker(annotations: &Annotations) -> TokenStream {
+fn ref_target_marker(
+    annotations: &Annotations,
+    source_namespace: &[quent_schema::Identifier],
+) -> TokenStream {
     match RefTarget::from_annotations(annotations) {
-        Some(entity) => {
-            let marker = raw_ident(to_case(entity.as_ref().name(), Case::Pascal));
-            quote! { #marker }
-        }
-        None => quote! { AnyEntity },
+        Some(entity) => relative_type_path(entity.as_ref(), source_namespace, ""),
+        None => relative_root_type("AnyEntity", source_namespace),
     }
 }
 
@@ -95,7 +95,7 @@ mod tests {
         for _ in 0..(MAX_TYPE_DEPTH + 5) {
             ty = DataType::Option(Box::new(ty));
         }
-        let _ = map_data_type(&ty, 0);
+        let _ = map_data_type(&ty, 0, &[]);
     }
 
     #[test]
@@ -108,7 +108,7 @@ mod tests {
             data: Some(Box::new(DataType::U64)),
             annotations: annotations.build().unwrap(),
         };
-        let tokens = map_data_type(&ty, 0).to_string();
+        let tokens = map_data_type(&ty, 0, &[]).to_string();
         assert!(tokens.contains("EntityRef < Cluster , u64 >"), "{tokens}");
     }
 }

--- a/crates/instrumentation-build/src/events.rs
+++ b/crates/instrumentation-build/src/events.rs
@@ -5,30 +5,22 @@
 
 use convert_case::Case;
 use proc_macro2::TokenStream;
-use quent_schema::{Entity, Schema};
+use quent_schema::Entity;
 use quote::quote;
 
-use crate::common::{derive_attr, doc_attr, doc_attr_or, raw_ident, to_case};
+use crate::common::{derive_attr, doc_attr, doc_attr_or, path_name_pascal, raw_ident, to_case};
 use crate::data_type::map_data_type;
 use crate::{GenerateError, Options};
 
-pub(crate) fn generate_event_types(
-    schema: &Schema,
+pub(crate) fn entity_event_enum(
+    entity: &Entity,
     opts: &Options,
 ) -> Result<TokenStream, GenerateError> {
-    let enums: Vec<TokenStream> = schema
-        .entities()
-        .map(|entity| entity_event_enum(entity, opts))
-        .collect::<Result<_, _>>()?;
-    Ok(quote! { #(#enums)* })
-}
-
-fn entity_event_enum(entity: &Entity, opts: &Options) -> Result<TokenStream, GenerateError> {
-    let entity_pascal = to_case(entity.path().name(), Case::Pascal);
+    let entity_pascal = path_name_pascal(entity.path());
     let enum_ident = raw_ident(format!("{entity_pascal}Event"));
     let docs = doc_attr_or(
         entity.annotations().docs(),
-        &format!("Events emitted by `{entity_pascal}` entities."),
+        &format!("Events emitted by `{}` entities.", entity.path()),
     );
     let derives = derive_attr(opts.event_derives)?;
     let variants: Vec<TokenStream> = entity
@@ -43,7 +35,7 @@ fn entity_event_enum(entity: &Entity, opts: &Options) -> Result<TokenStream, Gen
                 .fields()
                 .map(|field| {
                     let name = raw_ident(to_case(field.name(), Case::Snake));
-                    let ty = map_data_type(field.ty(), 0);
+                    let ty = map_data_type(field.ty(), 0, entity.path().namespace());
                     let field_docs = doc_attr(field.annotations().docs());
                     quote! { #field_docs #name: #ty }
                 })
@@ -69,11 +61,11 @@ mod tests {
     use super::*;
     use crate::common::pretty;
     use quent_schema::builder::{AnnotationsBuilder, EntityBuilder, EventBuilder, SchemaBuilder};
-    use quent_schema::test_utils::{entity, event, field, ident, schema};
+    use quent_schema::test_utils::{entity, event, field, ident, record_type, schema};
     use quent_schema::{Annotations, Cardinality, DataType, Field};
 
-    fn events_src(s: &Schema) -> String {
-        pretty(generate_event_types(s, &Options::default()).unwrap())
+    fn event_src(entity: &Entity) -> String {
+        pretty(entity_event_enum(entity, &Options::default()).unwrap())
     }
 
     #[test]
@@ -91,7 +83,7 @@ mod tests {
                         field("n", DataType::U32),
                         field("opt", DataType::Option(Box::new(DataType::I32))),
                         field("list", DataType::List(Box::new(DataType::String))),
-                        field("rec", DataType::Record(ident("SomeRecord").into())),
+                        field("rec", record_type("SomeRecord")),
                         field("dynrec", DataType::DynamicRecord),
                         field(
                             "eref",
@@ -130,7 +122,7 @@ mod tests {
                 }
             }
         };
-        assert_eq!(events_src(&s), pretty(expected));
+        assert_eq!(event_src(s.entities().next().unwrap()), pretty(expected));
     }
 
     #[test]
@@ -162,32 +154,7 @@ mod tests {
                 }
             }
         };
-        assert_eq!(events_src(&s), pretty(expected));
-    }
-
-    #[test]
-    fn multiple_entities_emit_in_declaration_order() {
-        let s = schema(
-            "M",
-            [
-                entity("Alpha", [event("started", [field("id", DataType::U32)])]),
-                entity("Beta", [event("ended", [])]),
-            ],
-            [],
-        );
-        let expected = quote! {
-            #[doc = "Events emitted by `Alpha` entities."]
-            pub enum AlphaEvent {
-                #[doc = "The `started` event."]
-                Started { id: u32 }
-            }
-            #[doc = "Events emitted by `Beta` entities."]
-            pub enum BetaEvent {
-                #[doc = "The `ended` event."]
-                Ended
-            }
-        };
-        assert_eq!(events_src(&s), pretty(expected));
+        assert_eq!(event_src(s.entities().next().unwrap()), pretty(expected));
     }
 
     #[test]
@@ -227,7 +194,7 @@ mod tests {
                 }
             }
         };
-        assert_eq!(events_src(&s), pretty(expected));
+        assert_eq!(event_src(s.entities().next().unwrap()), pretty(expected));
     }
 
     #[test]
@@ -261,6 +228,6 @@ mod tests {
                 }
             }
         };
-        assert_eq!(events_src(&s), pretty(expected));
+        assert_eq!(event_src(s.entities().next().unwrap()), pretty(expected));
     }
 }

--- a/crates/instrumentation-build/src/lib.rs
+++ b/crates/instrumentation-build/src/lib.rs
@@ -40,9 +40,6 @@
 //!
 //! # Restrictions
 //!
-//! Qualified record and entity paths are not supported; generation fails with
-//! [`GenerateError::UnsupportedTypePath`].
-//!
 //! The schema does not limit how many events an entity declares, but this
 //! generator caps once-cardinality
 //! ([`Cardinality::Once`](quent_schema::Cardinality::Once)) events at 64 per
@@ -58,6 +55,7 @@ mod any_event;
 mod common;
 mod data_type;
 mod events;
+mod namespace;
 mod records;
 mod runtime;
 
@@ -66,10 +64,6 @@ use std::path::PathBuf;
 use quent_constraints::{BaseConstraintsError, Report, validate};
 use quent_schema::{Path, Schema};
 use quote::quote;
-
-use events::generate_event_types;
-use records::generate_record_types;
-use runtime::generate_runtime_types;
 
 /// Options controlling instrumentation library generation.
 pub struct Options {
@@ -95,10 +89,10 @@ pub struct Options {
     /// `None`.
     pub file_name: Option<String>,
 
-    /// Emit `AnyEvent` and `AnyEvent::from_any`, a decoder from a type-erased
-    /// `&dyn Any` back to the concrete `Event<T>`. Carries [`Self::event_derives`].
+    /// Emit root and namespace-local `AnyEvent` enums that decode type-erased
+    /// events. Each enum carries [`Self::event_derives`].
     ///
-    /// No aggregate is emitted when the schema declares no events.
+    /// No aggregate is emitted for a namespace without events.
     pub any_event: bool,
 }
 
@@ -128,11 +122,6 @@ pub enum GenerateError {
     },
     #[error("generated code did not form a valid Rust file")]
     InvalidGeneratedCode(#[source] syn::Error),
-    #[error("qualified type path `{path}` is not supported")]
-    UnsupportedTypePath {
-        /// The unsupported record or entity path.
-        path: Path,
-    },
     #[error(
         "entity `{entity}` declares {count} once-events, exceeding the maximum of {max}",
         max = crate::runtime::MAX_ONCE_EVENTS
@@ -186,36 +175,253 @@ pub fn generate(schema: &Schema, opts: &Options) -> Result<GenerateInfo, Generat
 ///
 /// # Errors
 ///
-/// Returns [`GenerateError`] if the schema contains a qualified type path, a
-/// generated observer type conflicts with a schema type, a derive entry is not
-/// a parseable Rust path, or the generated code is not a valid Rust file.
+/// Returns [`GenerateError`] if a generated observer type conflicts with a
+/// schema type, a derive entry is not a parseable Rust path, or the generated
+/// code is not a valid Rust file.
 pub fn generate_str(schema: &Schema, opts: &Options) -> Result<String, GenerateError> {
-    ensure_unqualified_type_paths(schema)?;
+    let namespaces = namespace::Namespace::root(schema);
 
-    // record structs, event enums, then the live instrumentation surface
     let reexports = runtime::reexports();
-    let records = generate_record_types(schema, opts)?;
-    let events = generate_event_types(schema, opts)?;
-    let runtime = generate_runtime_types(schema)?;
+    let entity_types = runtime::entity_types(schema);
+    let types = generate_namespace(schema, opts, &namespaces, false)?;
+    let model = runtime::generate_model(schema, &namespaces);
     let any_event = if opts.any_event {
-        any_event::generate_any_event(schema, opts)?
+        any_event::generate_any_event(&namespaces, opts)?
     } else {
         quote! {}
     };
-    let file = syn::parse2::<syn::File>(quote! { #reexports #records #events #runtime #any_event })
-        .map_err(GenerateError::InvalidGeneratedCode)?;
+    let file = syn::parse2::<syn::File>(quote! {
+        #reexports
+        #entity_types
+        #types
+        #model
+        #any_event
+    })
+    .map_err(GenerateError::InvalidGeneratedCode)?;
     Ok(prettyplease::unparse(&file))
 }
 
-fn ensure_unqualified_type_paths(schema: &Schema) -> Result<(), GenerateError> {
-    let qualified = schema
+fn generate_namespace(
+    schema: &Schema,
+    opts: &Options,
+    namespace: &namespace::Namespace<'_>,
+    include_any_event: bool,
+) -> Result<proc_macro2::TokenStream, GenerateError> {
+    let records = namespace
         .records()
-        .map(|record| record.path())
-        .chain(schema.entities().map(|entity| entity.path()))
-        .find(|path| !path.namespace().is_empty());
+        .iter()
+        .map(|record| records::record_struct(record, opts))
+        .collect::<Result<Vec<_>, _>>()?;
+    let events = namespace
+        .entities()
+        .iter()
+        .map(|entity| events::entity_event_enum(entity, opts))
+        .collect::<Result<Vec<_>, _>>()?;
+    let runtime = namespace
+        .entities()
+        .iter()
+        .map(|entity| runtime::entity_runtime_types(schema, entity))
+        .collect::<Result<Vec<_>, _>>()?;
+    let children = namespace
+        .children()
+        .iter()
+        .map(|child| {
+            let segment = child
+                .path()
+                .last()
+                .expect("child namespaces extend their parent");
+            let module = common::module_ident(segment);
+            let contents = generate_namespace(schema, opts, child, true)?;
+            Ok::<_, GenerateError>(quote! {
+                pub mod #module {
+                    #contents
+                }
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let any_event = if include_any_event && opts.any_event && namespace.has_entities() {
+        any_event::generate_any_event(namespace, opts)?
+    } else {
+        quote! {}
+    };
+    let observer_storage = runtime::observer_storage(schema, namespace)?;
+    Ok(quote! {
+        #(#records)*
+        #(#events)*
+        #(#runtime)*
+        #(#children)*
+        #observer_storage
+        #any_event
+    })
+}
 
-    match qualified {
-        Some(path) => Err(GenerateError::UnsupportedTypePath { path: path.clone() }),
-        None => Ok(()),
+#[cfg(test)]
+mod path_tests {
+    use super::*;
+    use quent_constraints::Constraint;
+    use quent_ref_target::RefTargetConstraint;
+    use quent_schema::builder::AnnotationsBuilder;
+    use quent_schema::builder::SchemaBuilder;
+    use quent_schema::test_utils::{entity, event, field, path, record, record_type};
+    use quent_schema::{Annotations, DataType};
+
+    #[test]
+    fn places_entity_types_in_path_modules() {
+        let schema = SchemaBuilder::try_new("Demo")
+            .unwrap()
+            .with_entity(entity("Foo::Query", [event("event", [])]))
+            .build()
+            .unwrap();
+
+        let source = generate_str(&schema, &Options::default()).unwrap();
+        assert!(source.contains("pub mod foo"));
+        assert!(source.contains("pub enum QueryEvent"));
+        assert!(!source.contains("pub type Observer"));
+        assert!(source.contains(
+            "pub struct Handle<E: ::quent_instrumentation::Entity<Context = Context<Demo>>>"
+        ));
+        assert!(source.contains("impl super::Handle<Query>"));
+        assert!(source.contains("impl ::quent_instrumentation::Entity for Query"));
+        assert!(source.contains("type Context = super::Context<super::Demo>"));
+        assert!(source.contains("pub struct DemoObservers"));
+        assert!(source.contains("struct FooObservers"));
+        assert!(source.contains("foo_observers: foo::FooObservers"));
+        assert!(source.contains("query_observer: ::quent_instrumentation::Observer<Query>"));
+        assert!(source.contains(
+            "impl ::quent_instrumentation::ObserverProvider<foo::Query> for DemoObservers"
+        ));
+        assert!(source.contains(r#"const NAME: &'static str = "Foo::Query""#));
+        assert!(!source.contains("foo_query_observer"));
+    }
+
+    #[test]
+    fn separates_types_with_colliding_flattened_paths() {
+        let schema = SchemaBuilder::try_new("Demo")
+            .unwrap()
+            .with_record(record("Foo::BarBaz", []))
+            .with_record(record("FooBar::Baz", []))
+            .build()
+            .unwrap();
+
+        let source = generate_str(&schema, &Options::default()).unwrap();
+        assert!(source.contains("pub mod foo"));
+        assert!(source.contains("pub struct BarBaz"));
+        assert!(source.contains("pub mod foo_bar"));
+        assert!(source.contains("pub struct Baz"));
+    }
+
+    #[test]
+    fn rejects_observer_type_collisions() {
+        let conflicting_path = path("Foo::FooObservers");
+        let schema = SchemaBuilder::try_new("Demo")
+            .unwrap()
+            .with_record(record("Foo::FooObservers", []))
+            .with_entity(entity("Foo::Query", [event("event", [])]))
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            generate_str(&schema, &Options::default()),
+            Err(GenerateError::GeneratedTypeCollision {
+                generated,
+                schema_path,
+            }) if generated == "FooObservers" && schema_path == conflicting_path
+        ));
+    }
+
+    #[test]
+    fn does_not_merge_namespaces_that_share_a_rust_name() {
+        let schema = SchemaBuilder::try_new("Demo")
+            .unwrap()
+            .with_record(record("FooBar::First", []))
+            .with_record(record("foo_bar::Second", []))
+            .build()
+            .unwrap();
+
+        let source = generate_str(&schema, &Options::default()).unwrap();
+        assert_eq!(source.matches("pub mod foo_bar").count(), 2);
+    }
+
+    #[test]
+    fn qualifies_types_across_path_modules() {
+        let target_annotations = AnnotationsBuilder::new()
+            .with_constraint(RefTargetConstraint::NAME, Some("Foo::Worker".to_string()))
+            .build()
+            .unwrap();
+        let schema = SchemaBuilder::try_new("Demo")
+            .unwrap()
+            .with_record(record("Bar::Meta", []))
+            .with_record(record("Foo::Parent", []))
+            .with_record(record("Foo::Nested::Local", []))
+            .with_record(record("Foo::Nested::Child::Value", []))
+            .with_record(record("Foo::Sibling::Value", []))
+            .with_entity(entity("Foo::Worker", [event("created", [])]))
+            .with_entity(entity(
+                "Foo::Nested::Task",
+                [event(
+                    "created",
+                    [
+                        field("meta", record_type("Bar::Meta")),
+                        field("parent", record_type("Foo::Parent")),
+                        field("local", record_type("Foo::Nested::Local")),
+                        field("child", record_type("Foo::Nested::Child::Value")),
+                        field("sibling", record_type("Foo::Sibling::Value")),
+                        field(
+                            "worker",
+                            DataType::EntityRef {
+                                data: None,
+                                annotations: target_annotations,
+                            },
+                        ),
+                        field(
+                            "any",
+                            DataType::EntityRef {
+                                data: None,
+                                annotations: Annotations::default(),
+                            },
+                        ),
+                    ],
+                )],
+            ))
+            .build()
+            .unwrap();
+
+        let source = generate_str(&schema, &Options::default()).unwrap();
+        assert!(source.contains("meta: super::super::bar::Meta"));
+        assert!(source.contains("parent: super::Parent"));
+        assert!(source.contains("local: Local"));
+        assert!(source.contains("child: child::Value"));
+        assert!(source.contains("sibling: super::sibling::Value"));
+        assert!(source.contains("worker: ::quent_instrumentation::EntityRef<super::Worker>"));
+        assert!(
+            source.contains("any: ::quent_instrumentation::EntityRef<super::super::AnyEntity>")
+        );
+    }
+
+    #[test]
+    fn generates_any_event_per_entity_namespace() {
+        let schema = SchemaBuilder::try_new("Demo")
+            .unwrap()
+            .with_entity(entity("Root", [event("created", [])]))
+            .with_entity(entity("Foo::Query", [event("created", [])]))
+            .with_entity(entity("Foo::Nested::Task", [event("created", [])]))
+            .build()
+            .unwrap();
+        let opts = Options {
+            any_event: true,
+            ..Options::default()
+        };
+
+        let source = generate_str(&schema, &opts).unwrap();
+        assert!(source.contains("Root(&'a ::quent_instrumentation::Event<RootEvent>)"));
+        assert!(source.contains("Foo(foo::AnyEvent<'a>)"));
+        assert!(source.contains("Query(&'a ::quent_instrumentation::Event<QueryEvent>)"));
+        assert!(source.contains("Nested(nested::AnyEvent<'a>)"));
+        assert!(source.contains("Task(&'a ::quent_instrumentation::Event<TaskEvent>)"));
+        assert!(source.contains("foo::AnyEvent::from_any(any)"));
+        assert!(source.contains("nested::AnyEvent::from_any(any)"));
+        assert!(
+            source.rfind("pub enum AnyEvent") > source.rfind("impl ::quent_instrumentation::Model")
+        );
     }
 }

--- a/crates/instrumentation-build/src/namespace.rs
+++ b/crates/instrumentation-build/src/namespace.rs
@@ -43,6 +43,11 @@ impl<'schema> Namespace<'schema> {
         &self.children
     }
 
+    /// Returns child namespaces containing entities directly or transitively.
+    pub(crate) fn children_with_entities(&self) -> impl Iterator<Item = &Self> {
+        self.children.iter().filter(|child| child.has_entities())
+    }
+
     pub(crate) fn has_entities(&self) -> bool {
         !self.entities.is_empty() || self.children.iter().any(Self::has_entities)
     }

--- a/crates/instrumentation-build/src/namespace.rs
+++ b/crates/instrumentation-build/src/namespace.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use quent_schema::{Entity, Identifier, Record, Schema};

--- a/crates/instrumentation-build/src/namespace.rs
+++ b/crates/instrumentation-build/src/namespace.rs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use quent_schema::{Entity, Identifier, Record, Schema};
+
+/// A tree of Rust namespaces containing schema records and entities.
+pub(crate) struct Namespace<'schema> {
+    path: Vec<Identifier>,
+    records: Vec<&'schema Record>,
+    entities: Vec<&'schema Entity>,
+    children: Vec<Self>,
+}
+
+impl<'schema> Namespace<'schema> {
+    pub(crate) fn root(schema: &'schema Schema) -> Self {
+        let mut root = Self::new(Vec::new());
+        for record in schema.records() {
+            root.namespace_mut(record.path().namespace())
+                .records
+                .push(record);
+        }
+        for entity in schema.entities() {
+            root.namespace_mut(entity.path().namespace())
+                .entities
+                .push(entity);
+        }
+        root
+    }
+
+    pub(crate) fn path(&self) -> &[Identifier] {
+        &self.path
+    }
+
+    pub(crate) fn records(&self) -> &[&'schema Record] {
+        &self.records
+    }
+
+    pub(crate) fn entities(&self) -> &[&'schema Entity] {
+        &self.entities
+    }
+
+    pub(crate) fn children(&self) -> &[Self] {
+        &self.children
+    }
+
+    pub(crate) fn has_entities(&self) -> bool {
+        !self.entities.is_empty() || self.children.iter().any(Self::has_entities)
+    }
+
+    fn new(path: Vec<Identifier>) -> Self {
+        Self {
+            path,
+            records: Vec::new(),
+            entities: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+
+    fn namespace_mut(&mut self, path: &[Identifier]) -> &mut Self {
+        let mut namespace = self;
+        for segment in path {
+            let index = match namespace
+                .children
+                .iter()
+                .position(|child| child.path.last() == Some(segment))
+            {
+                Some(index) => index,
+                None => {
+                    let mut child_path = namespace.path.clone();
+                    child_path.push(segment.clone());
+                    namespace.children.push(Self::new(child_path));
+                    namespace.children.len() - 1
+                }
+            };
+            namespace = &mut namespace.children[index];
+        }
+        namespace
+    }
+}

--- a/crates/instrumentation-build/src/records.rs
+++ b/crates/instrumentation-build/src/records.rs
@@ -5,42 +5,26 @@
 
 use convert_case::Case;
 use proc_macro2::TokenStream;
-use quent_schema::{Record, Schema};
+use quent_schema::Record;
 use quote::quote;
 
-use crate::common::{derive_attr, doc_attr, doc_attr_or, raw_ident, to_case};
+use crate::common::{derive_attr, doc_attr, doc_attr_or, path_name_pascal, raw_ident, to_case};
 use crate::data_type::map_data_type;
 use crate::{GenerateError, Options};
 
-/// Record structs, as tokens, in declaration order.
-///
-/// # Panics
-///
-/// Panics if a field type nests deeper than [`crate::data_type::MAX_TYPE_DEPTH`].
-pub(crate) fn generate_record_types(
-    schema: &Schema,
-    opts: &Options,
-) -> Result<TokenStream, GenerateError> {
-    let records: Vec<TokenStream> = schema
-        .records()
-        .map(|record| record_struct(record, opts))
-        .collect::<Result<_, _>>()?;
-    Ok(quote! { #(#records)* })
-}
-
-fn record_struct(record: &Record, opts: &Options) -> Result<TokenStream, GenerateError> {
-    let record_pascal = to_case(record.path().name(), Case::Pascal);
+pub(crate) fn record_struct(record: &Record, opts: &Options) -> Result<TokenStream, GenerateError> {
+    let record_pascal = path_name_pascal(record.path());
     let ident = raw_ident(record_pascal.clone());
     let docs = doc_attr_or(
         record.annotations().docs(),
-        &format!("The `{record_pascal}` record."),
+        &format!("The `{}` record.", record.path()),
     );
     let derives = derive_attr(opts.record_derives)?;
     let fields: Vec<TokenStream> = record
         .fields()
         .map(|field| {
             let name = raw_ident(to_case(field.name(), Case::Snake));
-            let ty = map_data_type(field.ty(), 0);
+            let ty = map_data_type(field.ty(), 0, record.path().namespace());
             let field_docs = doc_attr(field.annotations().docs());
             quote! { #field_docs pub #name: #ty }
         })
@@ -63,40 +47,26 @@ mod tests {
     use super::*;
     use crate::common::pretty;
     use quent_schema::DataType;
-    use quent_schema::test_utils::{field, ident, record, schema};
+    use quent_schema::test_utils::{field, record, record_type};
 
     #[test]
-    fn test_generate_record_types() {
-        let s = schema(
-            "M",
-            [],
+    fn generates_record_struct() {
+        let record = record(
+            "Nested",
             [
-                record("OnePrim", [field("a", DataType::U8)]),
-                record(
-                    "Nested",
-                    [
-                        field("inner", DataType::Record(ident("OnePrim").into())),
-                        field("list", DataType::List(Box::new(DataType::String))),
-                    ],
-                ),
-                record("Empty", []),
+                field("inner", record_type("OnePrim")),
+                field("list", DataType::List(Box::new(DataType::String))),
             ],
         );
         let expected = quote! {
-            #[doc = "The `OnePrim` record."]
-            pub struct OnePrim {
-                pub a: u8
-            }
             #[doc = "The `Nested` record."]
             pub struct Nested {
                 pub inner: OnePrim,
                 pub list: Vec<String>
             }
-            #[doc = "The `Empty` record."]
-            pub struct Empty;
         };
         assert_eq!(
-            pretty(generate_record_types(&s, &Options::default()).unwrap()),
+            pretty(record_struct(&record, &Options::default()).unwrap()),
             pretty(expected)
         );
     }

--- a/crates/instrumentation-build/src/runtime/context.rs
+++ b/crates/instrumentation-build/src/runtime/context.rs
@@ -63,22 +63,18 @@ pub(super) fn observer_storage(
             #field_visibility #field: ::quent_instrumentation::Observer<#entity_ty>
         }
     });
-    let namespace_fields = namespace
-        .children()
-        .iter()
-        .filter(|child| child.has_entities())
-        .map(|child| {
-            let segment = child
-                .path()
-                .last()
-                .expect("child namespaces extend their parent");
-            let field = namespace_observers_field(segment);
-            let module = module_ident(segment);
-            let child_storage = observers_ident(schema, child);
-            quote! {
-                #field_visibility #field: #module::#child_storage
-            }
-        });
+    let namespace_fields = namespace.children_with_entities().map(|child| {
+        let segment = child
+            .path()
+            .last()
+            .expect("child namespaces extend their parent");
+        let field = namespace_observers_field(segment);
+        let module = module_ident(segment);
+        let child_storage = observers_ident(schema, child);
+        quote! {
+            #field_visibility #field: #module::#child_storage
+        }
+    });
 
     Ok(quote! {
         #[doc = #description]
@@ -191,19 +187,15 @@ fn observer_storage_initializer(
             )
         }
     });
-    let namespace_fields = namespace
-        .children()
-        .iter()
-        .filter(|child| child.has_entities())
-        .map(|child| {
-            let segment = child
-                .path()
-                .last()
-                .expect("child namespaces extend their parent");
-            let field = namespace_observers_field(segment);
-            let value = observer_storage_initializer(schema, child, active);
-            quote! { #field: #value }
-        });
+    let namespace_fields = namespace.children_with_entities().map(|child| {
+        let segment = child
+            .path()
+            .last()
+            .expect("child namespaces extend their parent");
+        let field = namespace_observers_field(segment);
+        let value = observer_storage_initializer(schema, child, active);
+        quote! { #field: #value }
+    });
     quote! {
         #storage {
             #(#entity_fields,)*

--- a/crates/instrumentation-build/src/runtime/context.rs
+++ b/crates/instrumentation-build/src/runtime/context.rs
@@ -9,19 +9,28 @@ use quent_schema::{Entity, Schema};
 use quote::quote;
 use syn::Ident;
 
-use super::{event_ident, marker_ident, model_ident};
+use super::model_ident;
 use crate::GenerateError;
-use crate::common::{raw_ident, to_case};
+use crate::common::{module_ident, path_name_pascal, raw_ident, relative_type_path, to_case};
+use crate::namespace::Namespace;
 
-/// Generates the model's typed observer storage.
-pub(super) fn observer_storage(schema: &Schema) -> Result<TokenStream, GenerateError> {
-    let storage = observers_ident(schema);
+/// Generate observer storage for one schema namespace.
+pub(super) fn observer_storage(
+    schema: &Schema,
+    namespace: &Namespace<'_>,
+) -> Result<TokenStream, GenerateError> {
+    if !namespace.path().is_empty() && !namespace.has_entities() {
+        return Ok(quote! {});
+    }
+
+    let storage = observers_ident(schema, namespace);
     let storage_name = storage.to_string();
-    if let Some(schema_path) = schema
+    if let Some(schema_path) = namespace
         .records()
+        .iter()
         .map(|record| record.path())
-        .chain(schema.entities().map(|entity| entity.path()))
-        .find(|path| to_case(path.name(), Case::Pascal) == storage_name)
+        .chain(namespace.entities().iter().map(|entity| entity.path()))
+        .find(|path| path_name_pascal(path) == storage_name)
     {
         return Err(GenerateError::GeneratedTypeCollision {
             generated: storage_name,
@@ -29,37 +38,67 @@ pub(super) fn observer_storage(schema: &Schema) -> Result<TokenStream, GenerateE
         });
     }
 
-    let description = format!(
-        "Observers for the `{}` instrumentation model.",
-        schema.name()
-    );
+    let (visibility, field_visibility) = storage_visibility(namespace);
+    let description = if namespace.path().is_empty() {
+        format!(
+            "Observers for the `{}` instrumentation model.",
+            schema.name()
+        )
+    } else {
+        format!(
+            "Observers for the `{}` namespace.",
+            namespace
+                .path()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("::")
+        )
+    };
     let hidden_docs = "Hidden because the model context provides typed observer access.";
-    let entity_fields = schema.entities().map(|entity| {
+    let entity_fields = namespace.entities().iter().map(|entity| {
         let field = entity_observer_field(entity);
-        let entity_ty = marker_ident(entity);
+        let entity_ty = relative_type_path(entity.path(), namespace.path(), "");
         quote! {
-            #field: ::quent_instrumentation::Observer<#entity_ty>
+            #field_visibility #field: ::quent_instrumentation::Observer<#entity_ty>
         }
     });
+    let namespace_fields = namespace
+        .children()
+        .iter()
+        .filter(|child| child.has_entities())
+        .map(|child| {
+            let segment = child
+                .path()
+                .last()
+                .expect("child namespaces extend their parent");
+            let field = namespace_observers_field(segment);
+            let module = module_ident(segment);
+            let child_storage = observers_ident(schema, child);
+            quote! {
+                #field_visibility #field: #module::#child_storage
+            }
+        });
 
     Ok(quote! {
         #[doc = #description]
         #[doc = ""]
         #[doc = #hidden_docs]
         #[doc(hidden)]
-        pub struct #storage {
+        #visibility struct #storage {
             #(#entity_fields,)*
+            #(#namespace_fields,)*
         }
     })
 }
 
-/// Generates the model marker and its runtime integration.
-pub(super) fn schema_model(schema: &Schema) -> TokenStream {
+/// Generate the model marker and its runtime integration.
+pub(super) fn schema_model(schema: &Schema, namespaces: &Namespace<'_>) -> TokenStream {
     let model = model_ident(schema);
     let model_name = schema.name().to_string();
-    let observers = observers_ident(schema);
-    let active_observers = observer_storage_initializer(schema, true);
-    let noop_observers = observer_storage_initializer(schema, false);
+    let observers = observers_ident(schema, namespaces);
+    let active_observers = observer_storage_initializer(schema, namespaces, true);
+    let noop_observers = observer_storage_initializer(schema, namespaces, false);
     let options_binding = if schema.entities().next().is_some() {
         raw_ident("options".to_owned())
     } else {
@@ -125,12 +164,16 @@ pub(super) fn schema_model(schema: &Schema) -> TokenStream {
     }
 }
 
-fn observer_storage_initializer(schema: &Schema, active: bool) -> TokenStream {
-    let storage = observers_ident(schema);
-    let entity_fields = schema.entities().map(|entity| {
+fn observer_storage_initializer(
+    schema: &Schema,
+    namespace: &Namespace<'_>,
+    active: bool,
+) -> TokenStream {
+    let storage = observers_path(schema, namespace);
+    let entity_fields = namespace.entities().iter().map(|entity| {
         let field = entity_observer_field(entity);
-        let entity_ty = marker_ident(entity);
-        let event_ty = event_ident(entity);
+        let entity_ty = relative_type_path(entity.path(), &[], "");
+        let event_ty = relative_type_path(entity.path(), &[], "Event");
         let observer = if active {
             quote! {
                 context
@@ -148,29 +191,62 @@ fn observer_storage_initializer(schema: &Schema, active: bool) -> TokenStream {
             )
         }
     });
+    let namespace_fields = namespace
+        .children()
+        .iter()
+        .filter(|child| child.has_entities())
+        .map(|child| {
+            let segment = child
+                .path()
+                .last()
+                .expect("child namespaces extend their parent");
+            let field = namespace_observers_field(segment);
+            let value = observer_storage_initializer(schema, child, active);
+            quote! { #field: #value }
+        });
     quote! {
         #storage {
             #(#entity_fields,)*
+            #(#namespace_fields,)*
         }
     }
 }
 
 fn observer_storage_impl(schema: &Schema, entity: &Entity) -> TokenStream {
-    let storage = observers_ident(schema);
-    let entity_ty = marker_ident(entity);
+    let storage = root_observers_ident(schema);
+    let entity_ty = relative_type_path(entity.path(), &[], "");
+    let mut observer = quote! { self };
+    for segment in entity.path().namespace() {
+        let field = namespace_observers_field(segment);
+        observer = quote! { #observer.#field };
+    }
     let field = entity_observer_field(entity);
+    observer = quote! { #observer.#field };
 
     quote! {
         impl ::quent_instrumentation::ObserverProvider<#entity_ty> for #storage {
             fn observer(&self) -> ::quent_instrumentation::Observer<#entity_ty> {
-                ::core::clone::Clone::clone(&self.#field)
+                ::core::clone::Clone::clone(&#observer)
             }
         }
     }
 }
 
-fn observers_ident(schema: &Schema) -> Ident {
+fn observers_ident(schema: &Schema, namespace: &Namespace<'_>) -> Ident {
+    match namespace.path().last() {
+        Some(segment) => raw_ident(format!("{}Observers", to_case(segment, Case::Pascal))),
+        None => root_observers_ident(schema),
+    }
+}
+
+fn root_observers_ident(schema: &Schema) -> Ident {
     raw_ident(format!("{}Observers", to_case(schema.name(), Case::Pascal)))
+}
+
+fn observers_path(schema: &Schema, namespace: &Namespace<'_>) -> TokenStream {
+    let modules = namespace.path().iter().map(module_ident);
+    let storage = observers_ident(schema, namespace);
+    quote! { #(#modules::)* #storage }
 }
 
 fn entity_observer_field(entity: &Entity) -> Ident {
@@ -178,4 +254,18 @@ fn entity_observer_field(entity: &Entity) -> Ident {
         "{}_observer",
         to_case(entity.path().name(), Case::Snake)
     ))
+}
+
+fn namespace_observers_field(segment: &quent_schema::Identifier) -> Ident {
+    raw_ident(format!("{}_observers", to_case(segment, Case::Snake)))
+}
+
+fn storage_visibility(namespace: &Namespace<'_>) -> (TokenStream, TokenStream) {
+    if namespace.path().is_empty() {
+        return (quote! { pub }, quote! {});
+    }
+    let parents = namespace.path().iter().map(|_| quote! { super });
+    let root = quote! { #(#parents)::* };
+    let visibility = quote! { pub(in #root) };
+    (visibility.clone(), visibility)
 }

--- a/crates/instrumentation-build/src/runtime/handle.rs
+++ b/crates/instrumentation-build/src/runtime/handle.rs
@@ -10,7 +10,7 @@ use quote::quote;
 
 use super::{event_ident, marker_ident};
 use crate::GenerateError;
-use crate::common::{doc_attr_or, raw_ident, to_case};
+use crate::common::{doc_attr_or, raw_ident, relative_root_type, to_case};
 use crate::data_type::map_data_type;
 
 /// The maximum once-events an entity may declare: one bit per event in the
@@ -26,7 +26,7 @@ pub(crate) const MAX_ONCE_EVENTS: usize = u64::BITS as usize;
 pub(super) fn entity_handle(entity: &Entity) -> Result<TokenStream, GenerateError> {
     let event_ty = event_ident(entity);
     let marker_ty = marker_ident(entity);
-    let handle_ty = raw_ident("Handle".to_owned());
+    let handle_ty = relative_root_type("Handle", entity.path().namespace());
 
     let once_count = entity
         .events()
@@ -62,7 +62,7 @@ pub(super) fn entity_handle(entity: &Entity) -> Result<TokenStream, GenerateErro
                 .fields()
                 .map(|f| {
                     let name = raw_ident(to_case(f.name(), Case::Snake));
-                    let ty = map_data_type(f.ty(), 0);
+                    let ty = map_data_type(f.ty(), 0, entity.path().namespace());
                     quote! { #name: #ty }
                 })
                 .collect();

--- a/crates/instrumentation-build/src/runtime/mod.rs
+++ b/crates/instrumentation-build/src/runtime/mod.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Generation of the live instrumentation surface for a schema.
+//! Generation of the live instrumentation surface: per-entity observers and
+//! handles, plus the schema's context that deals them out.
 
 use convert_case::Case;
 use proc_macro2::TokenStream;
@@ -10,32 +11,17 @@ use quote::quote;
 use syn::Ident;
 
 use crate::GenerateError;
-use crate::common::{raw_ident, to_case};
+use crate::common::{path_name_pascal, raw_ident, relative_root_type, to_case};
 
 mod context;
 mod handle;
 
 pub(crate) use handle::MAX_ONCE_EVENTS;
 
-/// Generates the entity runtime types and model integration.
-pub(crate) fn generate_runtime_types(schema: &Schema) -> Result<TokenStream, GenerateError> {
-    let entity_types = entity_types(schema);
-    let entities = schema
-        .entities()
-        .map(|entity| entity_runtime_types(schema, entity))
-        .collect::<Result<Vec<_>, _>>()?;
-    let observer_storage = context::observer_storage(schema)?;
-    let model = context::schema_model(schema);
-
-    Ok(quote! {
-        #entity_types
-        #(#entities)*
-        #observer_storage
-        #model
-    })
-}
-
-fn entity_runtime_types(schema: &Schema, entity: &Entity) -> Result<TokenStream, GenerateError> {
+pub(crate) fn entity_runtime_types(
+    schema: &Schema,
+    entity: &Entity,
+) -> Result<TokenStream, GenerateError> {
     let marker = entity_marker(entity);
     let event_impl = entity_event_impl(entity);
     let handle = handle::entity_handle(entity)?;
@@ -48,7 +34,21 @@ fn entity_runtime_types(schema: &Schema, entity: &Entity) -> Result<TokenStream,
     })
 }
 
-fn entity_types(schema: &Schema) -> TokenStream {
+pub(crate) fn generate_model(
+    schema: &Schema,
+    namespaces: &crate::namespace::Namespace<'_>,
+) -> TokenStream {
+    context::schema_model(schema, namespaces)
+}
+
+pub(crate) fn observer_storage(
+    schema: &Schema,
+    namespace: &crate::namespace::Namespace<'_>,
+) -> Result<TokenStream, GenerateError> {
+    context::observer_storage(schema, namespace)
+}
+
+pub(crate) fn entity_types(schema: &Schema) -> TokenStream {
     let model = model_ident(schema);
     let model_name = schema.name().to_string();
     let handle_docs =
@@ -79,7 +79,10 @@ fn entity_types(schema: &Schema) -> TokenStream {
     }
 }
 
-/// Re-exports shared runtime types used by the generated API.
+/// Re-export the always-available runtime types that appear in the generated
+/// API, so consumers reference them through the generated module rather than
+/// `quent_instrumentation`. Opt-in types like the callback exporter are
+/// not re-exported.
 pub(crate) fn reexports() -> TokenStream {
     quote! {
         pub use ::quent_instrumentation::{
@@ -88,6 +91,8 @@ pub(crate) fn reexports() -> TokenStream {
     }
 }
 
+/// `{Entity}` — the zero-size marker naming the entity, used as the target
+/// type of [`EntityRef`](quent_instrumentation::EntityRef) fields that point at it.
 fn entity_marker(entity: &Entity) -> TokenStream {
     let marker = marker_ident(entity);
     let doc = format!("Marker type for the `{}` entity.", entity.path());
@@ -98,9 +103,10 @@ fn entity_marker(entity: &Entity) -> TokenStream {
     }
 }
 
+/// Tie an entity's event enum to its canonical schema path.
 fn entity_event_impl(entity: &Entity) -> TokenStream {
     let event_ty = event_ident(entity);
-    let stream_name = to_case(entity.path().name(), Case::Snake);
+    let stream_name = entity.path().to_string();
     quote! {
         impl ::quent_instrumentation::EntityEvent for #event_ty {
             const NAME: &'static str = #stream_name;
@@ -108,30 +114,33 @@ fn entity_event_impl(entity: &Entity) -> TokenStream {
     }
 }
 
+/// `{Entity}Event` — the entity's event enum.
 fn event_ident(entity: &Entity) -> Ident {
-    raw_ident(format!(
-        "{}Event",
-        to_case(entity.path().name(), Case::Pascal)
-    ))
+    raw_ident(format!("{}Event", path_name_pascal(entity.path())))
 }
 
+/// `{Entity}` — the entity's ref-target marker type.
 fn marker_ident(entity: &Entity) -> Ident {
-    raw_ident(to_case(entity.path().name(), Case::Pascal))
+    raw_ident(path_name_pascal(entity.path()))
 }
 
-fn model_ident(schema: &Schema) -> Ident {
+pub(super) fn model_ident(schema: &Schema) -> Ident {
     raw_ident(to_case(schema.name(), Case::Pascal))
 }
 
 fn entity_impl(schema: &Schema, entity: &Entity) -> TokenStream {
+    let namespace = entity.path().namespace();
     let marker = marker_ident(entity);
     let event = event_ident(entity);
-    let model = model_ident(schema);
+    let context = relative_root_type("Context", namespace);
+    let model_name = model_ident(schema).to_string();
+    let model = relative_root_type(&model_name, namespace);
+    let handle = relative_root_type("Handle", namespace);
     quote! {
         impl ::quent_instrumentation::Entity for #marker {
             type Event = #event;
-            type Context = Context<#model>;
-            type Handle = Handle<Self>;
+            type Context = #context<#model>;
+            type Handle = #handle<Self>;
         }
     }
 }
@@ -146,7 +155,7 @@ mod tests {
     use quent_schema::test_utils::{field, ident};
 
     #[test]
-    fn generates_generic_instrumentation_api() {
+    fn generate_assembles_event_impl_observer_handle_and_context() {
         let connection = EntityBuilder::new(ident("Connection"))
             .with_event(
                 EventBuilder::new(ident("data"), Cardinality::Multi)
@@ -156,20 +165,22 @@ mod tests {
             )
             .build()
             .unwrap();
-        let schema = SchemaBuilder::new(ident("Demo"))
+        let s = SchemaBuilder::new(ident("Demo"))
             .with_entity(connection)
             .build()
             .unwrap();
-
-        let source = pretty(generate_runtime_types(&schema).unwrap());
-
-        assert!(source.contains("pub struct Handle<E:"));
-        assert!(source.contains("impl Handle<Connection>"));
-        assert!(source.contains("pub struct DemoObservers"));
-        assert!(source.contains("connection_observer:"));
-        assert!(source.contains("pub struct Demo"));
-        assert!(source.contains("impl ::quent_instrumentation::Entity for Connection"));
-        assert!(source.contains("type Context = Context<Demo>"));
-        assert!(source.contains(r#"const NAME: &'static str = "connection""#));
+        let entity = s.entities().next().unwrap();
+        let entity_types = entity_runtime_types(&s, entity).unwrap();
+        let namespaces = crate::namespace::Namespace::root(&s);
+        let model = generate_model(&s, &namespaces);
+        let src = pretty(quote! {
+            #entity_types
+            #model
+        });
+        assert!(src.contains("impl ::quent_instrumentation::EntityEvent for ConnectionEvent"));
+        assert!(src.contains(r#"const NAME: &'static str = "Connection""#));
+        assert!(src.contains("type Event = ConnectionEvent"));
+        assert!(src.contains("impl Handle<Connection>"));
+        assert!(src.contains("pub struct Demo"));
     }
 }


### PR DESCRIPTION
# Description

Stacked on #466.

Adds qualified schema type path support to `quent-instrumentation-build`. Schema namespaces become Rust modules instead of being flattened:

```rust
Foo::BarBaz → foo::BarBaz
FooBar::Baz → foo_bar::Baz
```

This preserves path boundaries and allows equal leaf names such as Foo::Query and Bar::Query to coexist.

Records, entities, events, references, handles, and observer storage follow the generated module hierarchy. Namespace-local AnyEvent enums compose into their parent namespace, while namespaces without events generate no aggregate.

## Related Issues

Follow-up to #449. Closes #442.

_Written by Codex._