### PR TITLE
fix(ui): dont overflow resource timelines x

### DIFF
--- a/ui/packages/@quent/components/src/ui/tree-table.tsx
+++ b/ui/packages/@quent/components/src/ui/tree-table.tsx
@@ -791,7 +791,6 @@ export function TreeTable<I extends TreeTableDataItem>({
     setTreeData(data);
   }, [data]);
 
-  const containerRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [isLayoutReady, setIsLayoutReady] = useState(false);
@@ -803,13 +802,14 @@ export function TreeTable<I extends TreeTableDataItem>({
   );
 
   useIsomorphicLayoutEffect(() => {
-    const node = containerRef.current;
+    const node = scrollContainerRef.current;
     if (!node) {
       return;
     }
 
     const updateWidth = () => {
-      const next = node.getBoundingClientRect().width;
+      // clientWidth excludes classic scrollbar gutters from the content budget.
+      const next = node.clientWidth;
       setContainerWidth(next);
       if (!isLayoutReady) {
         setIsLayoutReady(true);
@@ -824,9 +824,8 @@ export function TreeTable<I extends TreeTableDataItem>({
     }
 
     const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (entry) {
-        setContainerWidth(entry.contentRect.width);
+      if (entries[0]) {
+        setContainerWidth(node.clientWidth);
         if (!isLayoutReady) {
           setIsLayoutReady(true);
         }
@@ -913,7 +912,7 @@ export function TreeTable<I extends TreeTableDataItem>({
             return (
               <div
                 key={column.key}
-                className="flex items-center pr-1"
+                className="flex min-w-0 items-center overflow-hidden pr-1"
                 style={{
                   paddingLeft: `${firstCellPaddingLeft}px`,
                   paddingRight: '6px',
@@ -929,7 +928,7 @@ export function TreeTable<I extends TreeTableDataItem>({
           return (
             <div
               key={column.key}
-              className="text-left text-xs text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap"
+              className="min-w-0 text-left text-xs text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap"
             >
               {column.render({ item: extended, level, isSelected })}
             </div>
@@ -967,20 +966,16 @@ export function TreeTable<I extends TreeTableDataItem>({
   };
 
   return (
-    <div className="h-full w-full select-none">
+    <div className="h-full w-full min-w-0 select-none">
       <div
-        ref={containerRef}
         className={cn(
-          'bg-transparent transition-opacity duration-100 ease-out h-full',
+          'h-full min-w-0 bg-transparent transition-opacity duration-100 ease-out',
           isLayoutReady ? 'opacity-100' : 'opacity-0'
         )}
       >
         <div
           ref={scrollContainerRef}
-          className={cn(
-            'w-full overflow-y-auto max-h-full overscroll-none',
-            isLayoutReady ? 'overflow-x-auto' : 'overflow-x-hidden'
-          )}
+          className="w-full min-w-0 max-h-full overflow-x-hidden overflow-y-auto overscroll-none"
         >
           <div style={{ minWidth: `${effectiveWidth}px` }}>
             {/* Sticky header container */}

--- a/ui/packages/@quent/components/src/ui/tree-table.tsx
+++ b/ui/packages/@quent/components/src/ui/tree-table.tsx
@@ -975,7 +975,7 @@ export function TreeTable<I extends TreeTableDataItem>({
       >
         <div
           ref={scrollContainerRef}
-          className="w-full min-w-0 max-h-full overflow-x-hidden overflow-y-auto overscroll-none"
+          className="w-full min-w-0 max-h-full overflow-x-auto overflow-y-auto overscroll-none"
         >
           <div style={{ minWidth: `${effectiveWidth}px` }}>
             {/* Sticky header container */}

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -312,9 +312,9 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
   ]);
 
   return (
-    <div className="flex flex-col h-full w-full">
+    <div className="flex min-w-0 flex-col h-full w-full">
       <TimelineToolbar durationSeconds={durationSeconds} />
-      <div className="flex-1 min-h-0">
+      <div className="min-w-0 flex-1 min-h-0">
         <TreeTable<TreeTableItem>
           data={treeData}
           columns={columns}

--- a/ui/src/routes/profile.engine.$engineId.query.$queryId.timeline.tsx
+++ b/ui/src/routes/profile.engine.$engineId.query.$queryId.timeline.tsx
@@ -13,7 +13,7 @@ function TimelineTab() {
   const { engineId } = Route.useParams();
   const queryBundle = QueryRoute.useLoaderData();
   return (
-    <div className="flex items-center justify-center w-full h-full min-h-[200px]">
+    <div className="flex min-w-0 w-full h-full min-h-[200px]">
       <QueryResourceTree engineId={engineId} queryBundle={queryBundle} />
     </div>
   );

--- a/ui/src/routes/profile.engine.$engineId.query.$queryId.tsx
+++ b/ui/src/routes/profile.engine.$engineId.query.$queryId.tsx
@@ -28,7 +28,7 @@ const activeTabClass = cn(tabClass, 'text-foreground font-semibold bg-muted shad
 function QueryLayout() {
   const { engineId, queryId } = Route.useParams();
   return (
-    <div className="flex flex-col h-full w-full">
+    <div className="flex min-w-0 flex-col h-full w-full">
       <div className="shrink-0 border-b">
         <div className="inline-flex h-9 w-full items-center justify-center p-1 text-muted-foreground gap-0">
           <Link
@@ -49,7 +49,7 @@ function QueryLayout() {
           </Link>
         </div>
       </div>
-      <div className="flex-1 min-h-0">
+      <div className="min-w-0 flex-1 min-h-0">
         <Outlet />
       </div>
     </div>

--- a/ui/src/routes/profile.engine.$engineId.tsx
+++ b/ui/src/routes/profile.engine.$engineId.tsx
@@ -22,7 +22,7 @@ function ProfileLayout() {
 
   return (
     <Provider key={queryId ?? ''}>
-      <ResizablePanelGroup orientation="horizontal" className="h-full">
+      <ResizablePanelGroup orientation="horizontal" className="h-full min-w-0">
         <ResizablePanel defaultSize="33%" minSize="15%" collapsible collapsedSize="0%">
           {queryId && queryId !== '' ? (
             <QueryPlan queryId={queryId} engineId={engineId} />
@@ -38,7 +38,7 @@ function ProfileLayout() {
           minSize="20%"
           collapsible
           collapsedSize="0%"
-          className="overflow-y-auto h-[calc(100vh-4rem)]"
+          className="min-w-0 overflow-x-hidden overflow-y-auto h-[calc(100vh-4rem)]"
         >
           <Outlet />
         </ResizablePanel>


### PR DESCRIPTION
# Description
Fix horizontal scroll in resource timelines pane on certain OS + browser combinations. Allows the tree table to shrink (min-w-0) and some defensive hiding of overflow-x. 

## Related Issues
N/A

## Testing

## Screenshots

