### PR TITLE
feat(nvtx): tolerant NVTX model and analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvtx-analyzer"
+version = "0.1.0"
+dependencies = [
+ "nvtx-bridge",
+ "nvtx-events",
+ "nvtx-example",
+ "quent-events",
+ "quent-instrumentation",
+ "quent-time",
+ "rustc-hash",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "nvtx-bridge"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "integrations/nvtx/injection",
     "integrations/nvtx/bridge",
     "integrations/nvtx/example",
+    "integrations/nvtx/analyzer",
     # Domain-specific crates
     "domains/query_engine/analyzer",
     "domains/query_engine/model",

--- a/integrations/nvtx/analyzer/Cargo.toml
+++ b/integrations/nvtx/analyzer/Cargo.toml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "nvtx-analyzer"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[features]
+default = []
+# Enables `tests/roundtrip.rs`, which reconstructs a real in-process capture.
+#
+# Off by default so `cargo test -p nvtx-analyzer` stays hermetic: the test links
+# `nvtx-example` -> `nvtx-injection`, whose build script runs bindgen against the
+# pixi-pinned `nvtx-c` headers. Run it with
+# `pixi run cargo test -p nvtx-analyzer --features real-capture-tests`.
+real-capture-tests = ["dep:nvtx-example", "dep:quent-instrumentation"]
+
+[dependencies]
+# Framework-free: the NVTX vocabulary, the Quent event envelope, and the shared
+# time primitives. The shared analysis/modelling crates are excluded by design,
+# keeping the panic-prone FSM runtime off this crate's path.
+nvtx-events = { path = "../events" }
+nvtx-bridge = { path = "../bridge" }
+quent-events = { path = "../../../crates/events" }
+quent-time = { path = "../../../crates/time" }
+# Same hasher the shared analyzer uses. These keys are process-local NVTX
+# handles, never attacker-chosen, so HashDoS resistance buys nothing here.
+rustc-hash = { workspace = true }
+tracing = { workspace = true }
+
+# Roundtrip-test-only. Optional *regular* dependencies rather than
+# dev-dependencies because Cargo does not allow `optional` in
+# `[dev-dependencies]`; nothing in `src/` references either.
+nvtx-example = { path = "../example", optional = true }
+# `io-callback` selects the callback exporter the roundtrip collects through.
+quent-instrumentation = { path = "../../../crates/instrumentation", features = [
+    "io-callback",
+], optional = true }
+
+[dev-dependencies]
+uuid = { workspace = true }

--- a/integrations/nvtx/analyzer/src/anomalies.rs
+++ b/integrations/nvtx/analyzer/src/anomalies.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! What the stream did that reconstruction could not represent.
+//!
+//! Two shapes, both invisible in the span list. A close with no matching open
+//! produces no span at all — and the drops are not a random sample, they are the
+//! ranges straddling the moment capture attached, which skews long. A key reused
+//! while still open produces a span, but one whose end can never be known, and
+//! nothing on the span distinguishes that from an ordinary detach.
+
+/// Counts of what the stream did that the span list does not show.
+///
+/// Non-zero does not mean the capture is broken. Attaching to a running process
+/// routinely truncates the head of a trace; reused keys point at a malformed or
+/// wrongly merged stream. Both mean [`spans`](crate::NvtxModel::spans) is not
+/// the whole story, which is the only claim this type makes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReconstructionAnomalies {
+    /// `RangeEnd`s with no open `RangeStart`.
+    pub orphan_range_ends: u64,
+    /// `RangePop`s with no open `RangePush` on their `(thread, domain)` stack.
+    pub orphan_range_pops: u64,
+    /// `ResourceDestroy`s with no open `ResourceCreate`.
+    pub orphan_resource_destroys: u64,
+    /// `RangeStart`s that reused an id already open, displacing it.
+    ///
+    /// NVTX draws range ids from one process-global counter, so a live id
+    /// cannot legitimately be restarted. The displaced range still reconstructs,
+    /// with no end.
+    pub reused_range_ids: u64,
+    /// `ResourceCreate`s that reused a handle already open, displacing it.
+    pub reused_resource_handles: u64,
+}
+
+impl ReconstructionAnomalies {
+    /// Whether the stream reconstructed without anomaly.
+    ///
+    /// `true` says every close matched an open and no key was reused. It says
+    /// nothing about whether the spans were *measured* — a capture can stop
+    /// cleanly with ranges still running, which leaves
+    /// [`NvtxSpan::end`](crate::NvtxSpan::end) `None` and is not an anomaly.
+    pub fn is_faithful(&self) -> bool {
+        self.total() == 0
+    }
+
+    /// How many events reconstruction could not represent faithfully.
+    pub fn total(&self) -> u64 {
+        self.orphan_range_ends
+            .saturating_add(self.orphan_range_pops)
+            .saturating_add(self.orphan_resource_destroys)
+            .saturating_add(self.reused_range_ids)
+            .saturating_add(self.reused_resource_handles)
+    }
+}

--- a/integrations/nvtx/analyzer/src/lib.rs
+++ b/integrations/nvtx/analyzer/src/lib.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hand-written, framework-free reconstruction core for captured NVTX events.
+//!
+//! Turns a stream of verbatim [`NvtxEvent`](nvtx_events::NvtxEvent)s — carried in
+//! Quent's [`Event`](quent_events::Event) envelope — into an in-memory
+//! [`NvtxModel`] of plain [`NvtxSpan`]s.
+//!
+//! A capture is a partial observation: it watches a process that was already
+//! running and keeps running afterwards. Incomplete pairs are therefore ordinary
+//! input, not errors — and this layer resolves what the stream referenced
+//! without substituting anything for what it never said. An open with no close
+//! keeps everything the open stated and has [`end`](NvtxSpan::end) `None`, so
+//! what to bound it at is the consuming analysis's decision rather than one made
+//! here. A close with no open produces no span at all, because the closing
+//! events carry only a correlation key — no name, no attributes — and is counted
+//! in [`ReconstructionAnomalies`] instead.
+//!
+//! Events may arrive out of timestamp order, and a label's registration may
+//! arrive after the range using it or never; replay sorts first and resolves
+//! names in a prior pass. See [`NvtxModelBuilder::build`].
+//!
+//! The crate defines its own span type and depends on neither the shared
+//! analyzer nor the shared model crate, which is what lets the above states be
+//! representable at all.
+
+mod anomalies;
+mod model;
+mod ranges;
+mod resource;
+mod span;
+mod stats;
+mod tables;
+
+pub use anomalies::ReconstructionAnomalies;
+pub use model::{NvtxModel, NvtxModelBuilder};
+pub use span::{NvtxCategory, NvtxDomain, NvtxMark, NvtxSpan, NvtxThread, SpanId, SpanKind};
+pub use stats::{RangeStats, StatsKey};
+
+// Re-exported so consumers can read span attributes without depending on the
+// vocabulary crate directly. Carried verbatim, exactly as captured.
+pub use nvtx_events::{NvtxColor, NvtxPayload};

--- a/integrations/nvtx/analyzer/src/model.rs
+++ b/integrations/nvtx/analyzer/src/model.rs
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The two-pass reconstruction entry point.
+//!
+//! Pass 1 materializes the stream in timestamp order and builds the
+//! handle-resolution tables; pass 2 replays it against them. Splitting the two
+//! is what makes replay tolerant of arrival order in both dimensions — by then
+//! neither an end before its start nor a `RegisterString` after the range using
+//! it is still possible.
+
+use std::collections::BTreeMap;
+
+use nvtx_bridge::NvtxEventEntity;
+use nvtx_events::NvtxEvent;
+use quent_events::Event;
+use quent_time::{TimeOrderedCollector, TimeUnixNanoSec};
+
+use crate::anomalies::ReconstructionAnomalies;
+use crate::ranges::{PushPopRanges, StartEndRanges};
+use crate::resource::Resources;
+use crate::span::{
+    NvtxCategory, NvtxDomain, NvtxMark, NvtxSpan, NvtxThread, SpanId, SpanKind, category_id,
+};
+use crate::stats::{self, RangeStats, StatsKey};
+use crate::tables::ResolutionTables;
+
+/// An in-memory model reconstructed from a captured NVTX event stream.
+#[derive(Debug, Default)]
+pub struct NvtxModel {
+    spans: Vec<NvtxSpan>,
+    marks: Vec<NvtxMark>,
+    domains: Vec<NvtxDomain>,
+    threads: Vec<NvtxThread>,
+    categories: Vec<NvtxCategory>,
+    /// Retained so names not attached to a reconstructed entity — an unnamed
+    /// thread, a category referenced by nothing yet — still resolve on demand.
+    tables: ResolutionTables,
+    anomalies: ReconstructionAnomalies,
+    /// Event timestamp bounds. Not recoverable from the spans — see the
+    /// accessors.
+    trace_start: TimeUnixNanoSec,
+    trace_end: TimeUnixNanoSec,
+}
+
+impl NvtxModel {
+    /// Every reconstructed span.
+    ///
+    /// A span's index here *is* its [`SpanId`], which is what makes
+    /// [`SpanKind::PushPop::parent`](SpanKind::PushPop) resolvable. Ordering is
+    /// by opening: push/pop ranges take their slot when pushed, start/end ranges
+    /// when they close.
+    pub fn spans(&self) -> &[NvtxSpan] {
+        &self.spans
+    }
+
+    /// The span a [`SpanId`] refers to, or `None` if it came from another model.
+    pub fn span(&self, id: SpanId) -> Option<&NvtxSpan> {
+        self.spans.get(id.0)
+    }
+
+    /// What the stream did that the span list does not show — dropped closes,
+    /// and keys reused while still open.
+    ///
+    /// Check [`is_faithful`](ReconstructionAnomalies::is_faithful) before
+    /// treating [`spans`](Self::spans) as the whole population: attaching to a
+    /// process with work already running truncates the head of the trace, and a
+    /// dropped close leaves nothing behind to notice it by.
+    pub fn anomalies(&self) -> ReconstructionAnomalies {
+        self.anomalies
+    }
+
+    /// The earliest event timestamp, or `0` for an empty stream.
+    ///
+    /// Not derivable from [`Self::spans`]: the first event may be a mark, or a
+    /// close whose open was never captured.
+    pub fn trace_start(&self) -> TimeUnixNanoSec {
+        self.trace_start
+    }
+
+    /// The latest event timestamp, or `0` for an empty stream.
+    ///
+    /// Where observation stopped — the bound to reach for when an analysis needs
+    /// to give a span with no [`end`](NvtxSpan::end) a right edge. Reconstruction
+    /// does not apply it for you, because whether that bound belongs in a figure
+    /// depends on the figure. The largest span `end` is not a substitute: the
+    /// last event may carry no span at all.
+    pub fn trace_end(&self) -> TimeUnixNanoSec {
+        self.trace_end
+    }
+
+    /// Every reconstructed mark, in timestamp order.
+    pub fn marks(&self) -> &[NvtxMark] {
+        &self.marks
+    }
+
+    /// Every reconstructed resource lifespan: the interval between a create and
+    /// its destroy.
+    ///
+    /// NVTX says only that the handle existed and what it was called, so nothing
+    /// about its size or occupancy is inferred.
+    pub fn resources(&self) -> impl Iterator<Item = &NvtxSpan> {
+        self.spans
+            .iter()
+            .filter(|span| matches!(span.kind, SpanKind::Resource { .. }))
+    }
+
+    /// Every domain the stream mentioned, ordered by raw handle.
+    pub fn domains(&self) -> &[NvtxDomain] {
+        &self.domains
+    }
+
+    /// Every OS thread the stream mentioned, ordered by id.
+    pub fn threads(&self) -> &[NvtxThread] {
+        &self.threads
+    }
+
+    /// Every non-zero category the stream mentioned, ordered by `(domain, id)`.
+    pub fn categories(&self) -> &[NvtxCategory] {
+        &self.categories
+    }
+
+    /// Aggregated durations per `(name, domain, category)`.
+    ///
+    /// Range spans only. Marks have no duration and resource lifespans measure
+    /// existence rather than work, so neither participates.
+    pub fn range_statistics(&self) -> BTreeMap<StatsKey, RangeStats> {
+        stats::range_statistics(&self.spans)
+    }
+
+    /// Aggregated durations over the range spans `keep` accepts.
+    ///
+    /// For a view showing part of a capture — whole-model statistics would not
+    /// describe the spans on screen.
+    pub fn range_statistics_where(
+        &self,
+        keep: impl Fn(&NvtxSpan) -> bool,
+    ) -> BTreeMap<StatsKey, RangeStats> {
+        stats::range_statistics_where(&self.spans, keep)
+    }
+
+    /// The resolved name of a category *within its domain*.
+    ///
+    /// The domain is required, not optional: NVTX category ids are unique only
+    /// within a domain, so resolving one globally would return another domain's
+    /// name. Returns `None` for category `0`, NVTX's "no category" sentinel.
+    pub fn category_name(&self, domain: u64, category: u32) -> Option<String> {
+        self.tables.resolve_category(domain, category)
+    }
+
+    /// The resolved name of an OS thread.
+    ///
+    /// Threads are usually unnamed, so this answers for *any* id — a thread the
+    /// stream never named renders as `"thread {id}"` rather than nothing.
+    pub fn thread_name(&self, thread_id: u32) -> String {
+        self.tables.resolve_thread(thread_id)
+    }
+}
+
+/// Write a closed span into the slot reserved for it when it was pushed.
+///
+/// Bounds-checked rather than indexed: a stray id is dropped, not a panic.
+fn fill(slots: &mut [Option<NvtxSpan>], id: SpanId, span: NvtxSpan) {
+    if let Some(slot) = slots.get_mut(id.0) {
+        *slot = Some(span);
+    }
+}
+
+/// Builds an [`NvtxModel`] from a captured event stream.
+#[derive(Debug, Default)]
+pub struct NvtxModelBuilder;
+
+impl NvtxModelBuilder {
+    /// Reconstruct a model from a captured NVTX event stream.
+    ///
+    /// Events may arrive in any order and may reference handles registered
+    /// anywhere in the stream. Incomplete pairs are represented rather than
+    /// dropped or guessed — see the crate docs for what each case yields.
+    pub fn build(events: impl IntoIterator<Item = Event<NvtxEventEntity>>) -> NvtxModel {
+        // Pass 1a — materialize in timestamp order. Equal timestamps keep
+        // arrival order, so replay is deterministic.
+        let mut collector = TimeOrderedCollector::default();
+        collector.extend(events);
+        let ordered = collector.into_inner();
+
+        // Pass 1b — learn every name in the stream before resolving any of them.
+        let tables = ResolutionTables::build(&ordered);
+
+        // Pass 2 — replay.
+        let mut ranges = StartEndRanges::default();
+        let mut pushes = PushPopRanges::default();
+        let mut resources = Resources::default();
+        let mut marks = Vec::new();
+        let mut anomalies = ReconstructionAnomalies::default();
+        let mut trace_start: Option<TimeUnixNanoSec> = None;
+        let mut trace_end: TimeUnixNanoSec = 0;
+
+        // Slots, not a plain span list: a `SpanId` is an index here, and a
+        // nested push needs its parent's id at pop time — while the parent is
+        // still open. Reserving the slot at push time makes that id exist
+        // before the span does.
+        let mut slots: Vec<Option<NvtxSpan>> = Vec::new();
+
+        for event in ordered {
+            trace_start = Some(trace_start.map_or(event.timestamp, |at| at.min(event.timestamp)));
+            trace_end = trace_end.max(event.timestamp);
+
+            match event.data.0 {
+                NvtxEvent::RangeStart {
+                    domain,
+                    range_id,
+                    attributes,
+                } => {
+                    let name = tables.resolve_message(domain, &attributes.message);
+                    if let Some(span) =
+                        ranges.start(range_id, domain, name, attributes, event.timestamp)
+                    {
+                        // A span came back only because this start displaced one
+                        // still open under the same id.
+                        anomalies.reused_range_ids += 1;
+                        slots.push(Some(span));
+                    }
+                }
+                // The domain on a `RangeEnd` is redundant: `range_id` is
+                // process-globally unique, so it alone identifies the range.
+                NvtxEvent::RangeEnd { range_id, .. } => {
+                    match ranges.end(range_id, event.timestamp) {
+                        Some(span) => slots.push(Some(span)),
+                        None => anomalies.orphan_range_ends += 1,
+                    }
+                }
+                NvtxEvent::RangePush {
+                    domain,
+                    thread_id,
+                    attributes,
+                } => {
+                    let name = tables.resolve_message(domain, &attributes.message);
+                    let id = SpanId(slots.len());
+                    slots.push(None);
+                    pushes.push(id, thread_id, domain, name, attributes, event.timestamp);
+                }
+                NvtxEvent::RangePop { domain, thread_id } => {
+                    match pushes.pop(thread_id, domain, event.timestamp) {
+                        Some((id, span)) => fill(&mut slots, id, span),
+                        None => anomalies.orphan_range_pops += 1,
+                    }
+                }
+                NvtxEvent::Mark { domain, attributes } => marks.push(NvtxMark {
+                    domain,
+                    // `nvtxDomainMarkEx` carries no thread id.
+                    thread_id: None,
+                    name: tables.resolve_message(domain, &attributes.message),
+                    category: category_id(attributes.category),
+                    color: attributes.color,
+                    payload: attributes.payload,
+                    timestamp: event.timestamp,
+                }),
+                NvtxEvent::ResourceCreate {
+                    domain,
+                    handle,
+                    identifier_type,
+                    // Interpreting the raw identifier bits depends on
+                    // `identifier_type`; decoding extension classes is out of
+                    // scope for this crate.
+                    identifier: _,
+                    message,
+                } => {
+                    let name = tables.resolve_message(domain, &message);
+                    if let Some(span) =
+                        resources.create(handle, domain, name, identifier_type, event.timestamp)
+                    {
+                        // As above: only a displaced lifespan returns a span.
+                        anomalies.reused_resource_handles += 1;
+                        slots.push(Some(span));
+                    }
+                }
+                // Matched on `handle` alone — the event carries no domain, so
+                // there is nothing else to key on.
+                NvtxEvent::ResourceDestroy { handle } => {
+                    match resources.destroy(handle, event.timestamp) {
+                        Some(span) => slots.push(Some(span)),
+                        None => anomalies.orphan_resource_destroys += 1,
+                    }
+                }
+                // Consumed by pass 1; they only advance the trace end here.
+                // Listed explicitly rather than caught by `_`, so a new
+                // `NvtxEvent` variant fails to compile instead of being
+                // silently discarded.
+                NvtxEvent::DomainCreate { .. }
+                | NvtxEvent::DomainDestroy { .. }
+                | NvtxEvent::RegisterString { .. }
+                | NvtxEvent::NameCategory { .. }
+                | NvtxEvent::NameThread { .. } => {}
+            }
+        }
+
+        // Anything still open never had its close observed, so it ends `None`.
+        slots.extend(ranges.drain_unclosed().into_iter().map(Some));
+        slots.extend(resources.drain_unclosed().into_iter().map(Some));
+        for (id, span) in pushes.drain_unclosed() {
+            fill(&mut slots, id, span);
+        }
+
+        // Flattening preserves the indices the `SpanId`s were handed out
+        // against only while every slot is filled; a hole would shift every
+        // later index, so the invariant is asserted rather than assumed.
+        debug_assert!(
+            slots.iter().all(Option::is_some),
+            "an unfilled slot would invalidate every SpanId after it"
+        );
+        // `Flatten` reports a lower size hint of `0`, so collecting alone would
+        // grow the span list by repeated doubling.
+        let mut spans: Vec<NvtxSpan> = Vec::with_capacity(slots.len());
+        spans.extend(slots.into_iter().flatten());
+
+        let domains = tables.domain_records();
+        let threads = tables.thread_records();
+        let categories = tables.category_records();
+
+        NvtxModel {
+            spans,
+            marks,
+            domains,
+            threads,
+            categories,
+            tables,
+            anomalies,
+            trace_start: trace_start.unwrap_or(0),
+            trace_end,
+        }
+    }
+}

--- a/integrations/nvtx/analyzer/src/model.rs
+++ b/integrations/nvtx/analyzer/src/model.rs
@@ -247,8 +247,6 @@ impl NvtxModelBuilder {
                 }
                 NvtxEvent::Mark { domain, attributes } => marks.push(NvtxMark {
                     domain,
-                    // `nvtxDomainMarkEx` carries no thread id.
-                    thread_id: None,
                     name: tables.resolve_message(domain, &attributes.message),
                     category: category_id(attributes.category),
                     color: attributes.color,

--- a/integrations/nvtx/analyzer/src/ranges.rs
+++ b/integrations/nvtx/analyzer/src/ranges.rs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reconstruction of NVTX ranges — two kinds, two match keys.
+//!
+//! `RangeStart`/`RangeEnd` correlate by `range_id` alone: NVTX assigns ids from
+//! one process-global counter, so they match across threads and domains and the
+//! domain on a `RangeEnd` is redundant.
+//!
+//! `RangePush`/`RangePop` carry no id and correlate by position on a stack, one
+//! stack per `(thread_id, domain)`. That grain mirrors the injection layer's own
+//! `RANGE_DEPTH`, a thread-local keyed by domain. Keying coarser does not fail
+//! loudly on a multi-threaded stream — it silently closes another thread's push
+//! and reconstructs plausible-but-wrong nesting.
+
+use rustc_hash::FxHashMap as HashMap;
+
+use nvtx_events::{NvtxColor, NvtxEventAttributes, NvtxPayload};
+use quent_time::TimeUnixNanoSec;
+use tracing::{debug, warn};
+
+use crate::span::{NvtxSpan, SpanId, SpanKind, category_id};
+
+/// An open range of either kind, awaiting whatever closes it.
+///
+/// Both kinds reconstruct the same span, so the rules that must not drift
+/// between them — the category sentinel above all — live here once. Which
+/// [`SpanKind`] results is not stored: it follows from which tracker holds the
+/// range, and the push/pop variant needs a parent that is unknown until close.
+struct OpenRange {
+    domain: u64,
+    name: String,
+    /// Only the attributes a span keeps. Retaining the whole
+    /// `NvtxEventAttributes` would hold its `message` alive for as long as the
+    /// range stays open, and the message is dead once `name` is resolved.
+    category: Option<u32>,
+    color: Option<NvtxColor>,
+    payload: Option<NvtxPayload>,
+    start: TimeUnixNanoSec,
+}
+
+impl OpenRange {
+    fn new(
+        domain: u64,
+        name: String,
+        attributes: NvtxEventAttributes,
+        start: TimeUnixNanoSec,
+    ) -> Self {
+        Self {
+            domain,
+            name,
+            category: category_id(attributes.category),
+            color: attributes.color,
+            payload: attributes.payload,
+            start,
+        }
+    }
+
+    /// Close this range, with `end` left `None` when no close was observed.
+    ///
+    /// `end >= start` is a precondition, not something clamped here: replay runs
+    /// in total timestamp order, so whatever closes a range was observed no
+    /// earlier than the open.
+    fn close(self, end: Option<TimeUnixNanoSec>, kind: SpanKind) -> NvtxSpan {
+        debug_assert!(
+            end.is_none_or(|end| end >= self.start),
+            "replay is timestamp-ordered, so a close cannot precede its open"
+        );
+        NvtxSpan {
+            domain: self.domain,
+            name: self.name,
+            category: self.category,
+            color: self.color,
+            payload: self.payload,
+            start: self.start,
+            end,
+            kind,
+        }
+    }
+}
+
+/// The set of currently-open process-wide ranges.
+#[derive(Default)]
+pub(crate) struct StartEndRanges {
+    open: HashMap<u64, OpenRange>,
+}
+
+impl StartEndRanges {
+    /// Record a `RangeStart` under its already-resolved `name`.
+    ///
+    /// Returns a span when this start *displaces* one still open under the same
+    /// id. That reuse is malformed, but the displaced start was observed, so it
+    /// reconstructs with no end rather than being erased. The caller tallies the
+    /// reuse.
+    pub(crate) fn start(
+        &mut self,
+        range_id: u64,
+        domain: u64,
+        name: String,
+        attributes: NvtxEventAttributes,
+        start: TimeUnixNanoSec,
+    ) -> Option<NvtxSpan> {
+        let open = OpenRange::new(domain, name, attributes, start);
+        let displaced = self.open.insert(range_id, open)?;
+        warn!(
+            "nvtx range id 0x{range_id:X} was restarted at {start} before it ended; the earlier \
+             range has no end"
+        );
+        Some(displaced.close(None, SpanKind::StartEnd))
+    }
+
+    /// Close the range matching `range_id`, if one is open.
+    ///
+    /// Returns `None` for an orphan end. The caller counts those — a `RangeEnd`
+    /// carries only a correlation key, with no name or attributes to build a
+    /// span from, so it is only visible as a tally on the model.
+    pub(crate) fn end(&mut self, range_id: u64, end: TimeUnixNanoSec) -> Option<NvtxSpan> {
+        let Some(open) = self.open.remove(&range_id) else {
+            // Routine, not anomalous: a range that started before capture
+            // attached always ends without a recorded start.
+            debug!("orphan nvtx range end for id 0x{range_id:X} with no open start; skipping");
+            return None;
+        };
+        Some(open.close(Some(end), SpanKind::StartEnd))
+    }
+
+    /// Emit every range still open when the stream ran out, ending `None`.
+    ///
+    /// Ordered by `(start, range_id)` so several leaked ranges still
+    /// reconstruct deterministically out of an unordered `HashMap`.
+    pub(crate) fn drain_unclosed(&mut self) -> Vec<NvtxSpan> {
+        let mut leaked: Vec<(u64, OpenRange)> = self.open.drain().collect();
+        leaked.sort_by_key(|(range_id, open)| (open.start, *range_id));
+
+        // One `warn!` for the count, per-range detail at `debug!`: a stream that
+        // leaks thousands of ranges would otherwise emit thousands of warnings.
+        if !leaked.is_empty() {
+            warn!(
+                "{} nvtx range(s) were never ended; their spans have no end",
+                leaked.len()
+            );
+        }
+
+        leaked
+            .into_iter()
+            .map(|(range_id, open)| {
+                debug!("nvtx range id 0x{range_id:X} was never ended");
+                open.close(None, SpanKind::StartEnd)
+            })
+            .collect()
+    }
+}
+
+/// The stack a push/pop range nests on: one OS thread within one domain.
+///
+/// The thread is explicit because the analyzer replays every captured thread's
+/// events on one thread of its own.
+type StackKey = (u32, u64);
+
+/// A `RangePush` awaiting its matching `RangePop`.
+struct OpenPushSpan {
+    /// The slot reserved for this span at *push* time, because a child pops
+    /// before its parent and needs the parent's id to record `parent`.
+    id: SpanId,
+    range: OpenRange,
+}
+
+impl OpenPushSpan {
+    /// `thread_id` comes from the stack this was popped off, which is the only
+    /// place it is recorded — it is half the key, not a field on the range.
+    fn close(
+        self,
+        end: Option<TimeUnixNanoSec>,
+        thread_id: u32,
+        parent: Option<SpanId>,
+    ) -> (SpanId, NvtxSpan) {
+        (
+            self.id,
+            self.range
+                .close(end, SpanKind::PushPop { thread_id, parent }),
+        )
+    }
+}
+
+/// The currently-open push/pop ranges, one stack per `(thread_id, domain)`.
+#[derive(Default)]
+pub(crate) struct PushPopRanges {
+    stacks: HashMap<StackKey, Vec<OpenPushSpan>>,
+}
+
+impl PushPopRanges {
+    /// Record a `RangePush` under its already-resolved `name`, in the slot `id`.
+    pub(crate) fn push(
+        &mut self,
+        id: SpanId,
+        thread_id: u32,
+        domain: u64,
+        name: String,
+        attributes: NvtxEventAttributes,
+        start: TimeUnixNanoSec,
+    ) {
+        self.stacks
+            .entry((thread_id, domain))
+            .or_default()
+            .push(OpenPushSpan {
+                id,
+                range: OpenRange::new(domain, name, attributes, start),
+            });
+    }
+
+    /// Close the innermost open push on `(thread_id, domain)`, if there is one.
+    ///
+    /// `parent` is read *after* the pop, so it is whatever encloses the range
+    /// just closed — `None` when that range was outermost on its thread.
+    /// Returns `None` for an orphan pop, logged and skipped.
+    pub(crate) fn pop(
+        &mut self,
+        thread_id: u32,
+        domain: u64,
+        end: TimeUnixNanoSec,
+    ) -> Option<(SpanId, NvtxSpan)> {
+        let key = (thread_id, domain);
+        // One lookup on the hot path: `pop` runs once per `RangePop`, roughly
+        // half a push/pop-heavy stream. Borrowing the stack once answers what
+        // closed, what encloses it, and whether the key is now empty.
+        let popped = self.stacks.get_mut(&key).and_then(|stack| {
+            let open = stack.pop()?;
+            let parent = stack.last().map(|enclosing| enclosing.id);
+            Some((open, parent, stack.is_empty()))
+        });
+
+        let Some((open, parent, now_empty)) = popped else {
+            // Routine, like an orphan `RangeEnd`: a push from before capture
+            // attached pops with no recorded open.
+            debug!(
+                "orphan nvtx range pop on thread {thread_id} in domain 0x{domain:X} \
+                 with no open push; skipping"
+            );
+            return None;
+        };
+
+        // Retain only keys with open ranges, so the map does not grow with
+        // every thread the process ever ran.
+        if now_empty {
+            self.stacks.remove(&key);
+        }
+        Some(open.close(Some(end), thread_id, parent))
+    }
+
+    /// Emit every push still open when the stream ran out, ending `None`.
+    ///
+    /// Nesting is the stack's own shape, so a leaked inner push keeps its
+    /// parent rather than being flattened. Stacks are visited in key order for
+    /// determinism.
+    pub(crate) fn drain_unclosed(&mut self) -> Vec<(SpanId, NvtxSpan)> {
+        let mut leaked: Vec<(StackKey, Vec<OpenPushSpan>)> = self.stacks.drain().collect();
+        leaked.sort_by_key(|(key, _)| *key);
+
+        let unpopped: usize = leaked.iter().map(|(_, stack)| stack.len()).sum();
+        if unpopped > 0 {
+            warn!("{unpopped} nvtx range(s) were never popped; their spans have no end");
+        }
+
+        let mut closed = Vec::new();
+        for ((thread_id, domain), mut stack) in leaked {
+            // Drained innermost-first so the parent is whatever the pop
+            // uncovers — the same rule `pop` applies, not a second statement of
+            // it that has to be kept in step.
+            while let Some(open) = stack.pop() {
+                let parent = stack.last().map(|enclosing| enclosing.id);
+                debug!(
+                    "nvtx range \"{}\" on thread {thread_id} in domain 0x{domain:X} \
+                     was never popped",
+                    open.range.name
+                );
+                closed.push(open.close(None, thread_id, parent));
+            }
+        }
+        closed
+    }
+}

--- a/integrations/nvtx/analyzer/src/resource.rs
+++ b/integrations/nvtx/analyzer/src/resource.rs
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resource lifespan reconstruction — the third match key.
+//!
+//! The interval between `nvtxDomainResourceCreate` and its destroy, modelled as
+//! an [`NvtxSpan`] with [`SpanKind::Resource`].
+//!
+//! **The match key is the handle alone**, not `(domain, handle)` — forced by the
+//! vocabulary, since
+//! [`NvtxEvent::ResourceDestroy`](nvtx_events::NvtxEvent::ResourceDestroy)
+//! carries only a handle because the underlying NVTX call does. Keying on the
+//! pair would not fail loudly: every destroy would miss its create and every
+//! resource would silently reconstruct as a leak with no end. The domain is
+//! recovered from the create instead.
+//!
+//! A create says a handle exists and what it is called — nothing about its size
+//! or occupancy — so nothing further is inferred.
+
+use rustc_hash::FxHashMap as HashMap;
+
+use quent_time::TimeUnixNanoSec;
+use tracing::{debug, warn};
+
+use crate::span::{NvtxSpan, SpanKind};
+
+/// A `ResourceCreate` awaiting its matching `ResourceDestroy`.
+struct OpenResource {
+    /// Recovered from the create, because the destroy carries no domain.
+    domain: u64,
+    name: String,
+    identifier_type: i32,
+    start: TimeUnixNanoSec,
+}
+
+impl OpenResource {
+    /// Close this resource, with `end` left `None` when no destroy was observed.
+    ///
+    /// `end >= start` is a precondition established by timestamp-ordered
+    /// replay, matching the range reconstructions.
+    fn close(self, end: Option<TimeUnixNanoSec>) -> NvtxSpan {
+        debug_assert!(
+            end.is_none_or(|end| end >= self.start),
+            "replay is timestamp-ordered, so a destroy cannot precede its create"
+        );
+        NvtxSpan {
+            domain: self.domain,
+            name: self.name,
+            // `nvtxResourceAttributes_t` is not an event-attribute struct; it
+            // has no category, color, or payload to carry.
+            category: None,
+            color: None,
+            payload: None,
+            start: self.start,
+            end,
+            kind: SpanKind::Resource {
+                identifier_type: self.identifier_type,
+            },
+        }
+    }
+}
+
+/// The set of currently-open resource lifespans, keyed by handle alone.
+#[derive(Default)]
+pub(crate) struct Resources {
+    open: HashMap<u64, OpenResource>,
+}
+
+impl Resources {
+    /// Record a `ResourceCreate` under its already-resolved `name`.
+    ///
+    /// Returns a span when this create *displaces* a lifespan still open under
+    /// the same handle. The displaced lifespan keeps everything the create
+    /// stated and ends `None`, rather than being discarded — the create was
+    /// observed, only its destroy never arrived. The caller tallies the reuse.
+    pub(crate) fn create(
+        &mut self,
+        handle: u64,
+        domain: u64,
+        name: String,
+        identifier_type: i32,
+        start: TimeUnixNanoSec,
+    ) -> Option<NvtxSpan> {
+        let open = OpenResource {
+            domain,
+            name,
+            identifier_type,
+            start,
+        };
+        let displaced = self.open.insert(handle, open)?;
+        warn!(
+            "nvtx resource handle 0x{handle:X} was recreated at {start} before it was destroyed; \
+             the earlier lifespan has no end"
+        );
+        Some(displaced.close(None))
+    }
+
+    /// Close the resource matching `handle`, if one is open.
+    ///
+    /// Returns `None` for an orphan destroy — the *normal* case for a resource
+    /// created before capture attached. The caller counts those.
+    pub(crate) fn destroy(&mut self, handle: u64, end: TimeUnixNanoSec) -> Option<NvtxSpan> {
+        let Some(open) = self.open.remove(&handle) else {
+            // `debug!`, not `warn!`, because this is routine: logging it as an
+            // anomaly would bury the genuine ones.
+            debug!(
+                "orphan nvtx resource destroy for handle 0x{handle:X} with no open create; skipping"
+            );
+            return None;
+        };
+        Some(open.close(Some(end)))
+    }
+
+    /// Emit every resource still open when the stream ran out, ending `None`.
+    ///
+    /// Ordered by `(start, handle)` so several leaked resources still
+    /// reconstruct deterministically out of an unordered `HashMap`.
+    pub(crate) fn drain_unclosed(&mut self) -> Vec<NvtxSpan> {
+        let mut leaked: Vec<(u64, OpenResource)> = self.open.drain().collect();
+        leaked.sort_by_key(|(handle, open)| (open.start, *handle));
+
+        // One `warn!` for the count, per-handle detail at `debug!`, so a stream
+        // leaking many resources does not emit one warning each.
+        if !leaked.is_empty() {
+            warn!(
+                "{} nvtx resource(s) were never destroyed; their lifespans have no end",
+                leaked.len()
+            );
+        }
+
+        leaked
+            .into_iter()
+            .map(|(handle, open)| {
+                debug!("nvtx resource handle 0x{handle:X} was never destroyed");
+                open.close(None)
+            })
+            .collect()
+    }
+}

--- a/integrations/nvtx/analyzer/src/span.rs
+++ b/integrations/nvtx/analyzer/src/span.rs
@@ -165,12 +165,13 @@ impl NvtxSpan {
 }
 
 /// A reconstructed `nvtxDomainMarkEx` instant: a timestamp with no duration.
+///
+/// No thread: `nvtxDomainMarkEx` does not report one, so a mark says when
+/// something happened but never where.
 #[derive(Debug, Clone, PartialEq)]
 pub struct NvtxMark {
     /// Raw domain handle (`0` = default domain).
     pub domain: u64,
-    /// Raw OS thread id, when the originating event carried one.
-    pub thread_id: Option<u32>,
     /// Resolved message, or a placeholder when the handle was never registered.
     pub name: String,
     /// Raw category id (`None` when the event carried category `0` = none).

--- a/integrations/nvtx/analyzer/src/span.rs
+++ b/integrations/nvtx/analyzer/src/span.rs
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The reconstruction core's own plain span types.
+//!
+//! Hand-written structs, not framework types. Keeping our own is what lets a
+//! zero-duration span, or one whose close was never captured, be representable
+//! here — the shared framework would reject or panic on both.
+
+use nvtx_events::{NvtxColor, NvtxPayload};
+use quent_time::TimeUnixNanoSec;
+
+/// A stable handle to an [`NvtxSpan`] within one reconstructed model.
+///
+/// The index into the owning model's span list. Only meaningful against the
+/// model it was produced from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SpanId(pub usize);
+
+/// Which NVTX construct a span was reconstructed from, together with the fields
+/// only that construct has.
+///
+/// The kind-conditional attributes live in the variants rather than beside them:
+/// a process-wide range has no thread, a resource lifespan has no parent, and
+/// neither range kind has an identifier type. Flat `Option` fields would leave
+/// those rules stated only in prose, and admit the combinations that contradict
+/// them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpanKind {
+    /// A per-thread nested range: `nvtxDomainRangePushEx` / `nvtxDomainRangePop`.
+    PushPop {
+        /// Raw OS thread id — half of the `(thread, domain)` nesting key, so
+        /// always known for this kind.
+        thread_id: u32,
+        /// The enclosing push on the same stack, or `None` when this one was
+        /// outermost on its thread.
+        parent: Option<SpanId>,
+    },
+    /// A process-wide range keyed by id: `nvtxDomainRangeStartEx` / `nvtxDomainRangeEnd`.
+    ///
+    /// Carries no thread: the id comes from a process-global counter and the end
+    /// may be emitted from any thread.
+    StartEnd,
+    /// A resource lifespan: `nvtxDomainResourceCreate` / `nvtxDomainResourceDestroy`.
+    Resource {
+        /// Raw `nvtxResourceAttributes_t::identifierType`, undecoded — see
+        /// [`identifier_type_label`](Self::identifier_type_label).
+        identifier_type: i32,
+    },
+}
+
+impl SpanKind {
+    /// The OS thread this span ran on, for the one kind that records it.
+    pub fn thread_id(self) -> Option<u32> {
+        match self {
+            Self::PushPop { thread_id, .. } => Some(thread_id),
+            Self::StartEnd | Self::Resource { .. } => None,
+        }
+    }
+
+    /// The enclosing span, for the one kind that nests.
+    pub fn parent(self) -> Option<SpanId> {
+        match self {
+            Self::PushPop { parent, .. } => parent,
+            Self::StartEnd | Self::Resource { .. } => None,
+        }
+    }
+
+    /// What kind of thing a [`Resource`](Self::Resource) span identifies.
+    ///
+    /// A core/generic NVTX resource type gets a static label; an unrecognized or
+    /// CUDA-extension type passes through as `"<identifier_type {n}>"` rather
+    /// than being guessed at.
+    pub fn identifier_type_label(self) -> Option<String> {
+        match self {
+            Self::Resource { identifier_type } => Some(label_identifier_type(identifier_type)),
+            Self::PushPop { .. } | Self::StartEnd => None,
+        }
+    }
+}
+
+/// Label an `nvtxResourceAttributes_t::identifierType` tag.
+///
+/// `nvToolsExt.h` composes an identifier type as
+/// `NVTX_RESOURCE_MAKE_TYPE(CLASS, INDEX) = (CLASS << 16) | INDEX`, and
+/// `NVTX_RESOURCE_CLASS_GENERIC` is `1` — so the core `nvtxResourceGenericType_t`
+/// set is `0x0001_0001`..=`0x0001_0004`. Other classes (CUDA, CUDA runtime,
+/// OpenCL, D3D, sync) are extension surfaces this crate deliberately does not
+/// interpret.
+///
+/// Total by construction: everything outside the core set passes through as
+/// `"<identifier_type {n}>"`, interpolating only the raw integer, so an
+/// unrecognized type can never render as a recognized one.
+fn label_identifier_type(identifier_type: i32) -> String {
+    // Confirmed against the pixi-pinned nvtx-c headers, the same ones
+    // `nvtx-injection`'s bindgen build reads.
+    let label = match identifier_type {
+        // `NVTX_RESOURCE_TYPE_UNKNOWN`, also what the capture layer records for
+        // an attribute struct too short to contain the field — a legitimate
+        // "not stated" rather than an anomaly.
+        0x0000_0000 => "unknown",
+        0x0001_0001 => "generic pointer",
+        0x0001_0002 => "generic handle",
+        0x0001_0003 => "native thread",
+        0x0001_0004 => "posix thread",
+        _ => return format!("<identifier_type {identifier_type}>"),
+    };
+    label.to_owned()
+}
+
+/// Map a raw category id onto the presence it encodes.
+///
+/// Category `0` is NVTX's "no category" sentinel — an absence, not an id. Every
+/// consumer goes through here so the rule is stated once. `nvtx-events` would
+/// be the better home, since it already models `color`, `message`, and
+/// `payload` as `Option` and `category` is the one attribute left as a magic
+/// number.
+pub(crate) const fn category_id(raw: u32) -> Option<u32> {
+    if raw == 0 { None } else { Some(raw) }
+}
+
+/// A reconstructed NVTX interval.
+///
+/// The open is always known — it is what carried the name and attributes. The
+/// close may not be, and then [`end`](Self::end) is `None`: this layer resolves
+/// what the stream referenced and substitutes nothing for what it never said.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NvtxSpan {
+    /// Raw domain handle (`0` = default domain).
+    pub domain: u64,
+    /// Resolved message, or a placeholder when the handle was never registered.
+    pub name: String,
+    /// Raw category id (`None` when the event carried category `0` = none).
+    pub category: Option<u32>,
+    /// Verbatim color attribute, undecoded.
+    pub color: Option<NvtxColor>,
+    /// Verbatim payload value, undecoded.
+    pub payload: Option<NvtxPayload>,
+    pub start: TimeUnixNanoSec,
+    /// When the close was observed, or `None` when it never was.
+    ///
+    /// Not "unknown yet" — reconstruction is complete before a model exists, so
+    /// `None` states that the stream carried no close for this open. It happens
+    /// routinely: a capture detaches while work is still running, or a later
+    /// open reuses this one's key. Whether to bound such a span, and at what,
+    /// is the consuming analysis's decision — [`NvtxModel::trace_end`] is where
+    /// observation stopped.
+    ///
+    /// When present, always `>= start`. That is not enforced by clamping; it
+    /// follows from replay running in total timestamp order.
+    ///
+    /// [`NvtxModel::trace_end`]: crate::NvtxModel::trace_end
+    pub end: Option<TimeUnixNanoSec>,
+    /// Which NVTX construct this span was reconstructed from, and its
+    /// kind-specific fields.
+    pub kind: SpanKind,
+}
+
+impl NvtxSpan {
+    /// The measured duration in nanoseconds, or `None` when the close was never
+    /// captured.
+    pub fn duration(&self) -> Option<u64> {
+        Some(self.end?.saturating_sub(self.start))
+    }
+}
+
+/// A reconstructed `nvtxDomainMarkEx` instant: a timestamp with no duration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NvtxMark {
+    /// Raw domain handle (`0` = default domain).
+    pub domain: u64,
+    /// Raw OS thread id, when the originating event carried one.
+    pub thread_id: Option<u32>,
+    /// Resolved message, or a placeholder when the handle was never registered.
+    pub name: String,
+    /// Raw category id (`None` when the event carried category `0` = none).
+    pub category: Option<u32>,
+    /// Verbatim color attribute, undecoded.
+    pub color: Option<NvtxColor>,
+    /// Verbatim payload value, undecoded.
+    pub payload: Option<NvtxPayload>,
+    /// When the mark was emitted.
+    pub timestamp: TimeUnixNanoSec,
+}
+
+/// A domain the stream referenced, with its resolved name and lifespan.
+///
+/// Present for every domain *mentioned* by the stream, not only those with a
+/// captured `nvtxDomainCreate` — a domain created before capture began still
+/// groups the events that name it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NvtxDomain {
+    /// Raw domain handle (`0` = default domain).
+    pub domain: u64,
+    /// Resolved name, or the placeholder for an uncreated handle.
+    pub name: String,
+    /// The `nvtxDomainCreate` timestamp, or `None` when no creation was
+    /// captured — the domain already existed when capture attached.
+    ///
+    /// Kept separate from [`first_seen`](Self::first_seen) rather than
+    /// substituted into it: the two answer different questions, and a domain
+    /// created before the capture would otherwise report a creation time that is
+    /// really just the first event mentioning it.
+    pub created: Option<TimeUnixNanoSec>,
+    /// The earliest timestamp at which anything referenced this domain.
+    ///
+    /// Always known, and an upper bound on the real creation time.
+    pub first_seen: TimeUnixNanoSec,
+    /// The `nvtxDomainDestroy` timestamp, if one was captured.
+    pub destroyed: Option<TimeUnixNanoSec>,
+}
+
+/// An OS thread the stream referenced, with its resolved name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NvtxThread {
+    /// Raw OS thread id (the `nvtxNameOsThread` id space).
+    pub thread_id: u32,
+    /// Resolved name, or `"thread {id}"` when the thread was never named.
+    pub name: String,
+}
+
+/// A category the stream referenced, namespaced by its owning domain.
+///
+/// The `(domain, category)` pair *is* the identity: NVTX category ids are only
+/// unique within a domain, so a globally-keyed view would silently merge
+/// unrelated categories.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NvtxCategory {
+    /// Raw domain handle the category belongs to.
+    pub domain: u64,
+    /// Raw category id (never `0` — that is the "no category" sentinel).
+    pub category: u32,
+    /// Resolved name, or the placeholder for an unnamed category.
+    pub name: String,
+}

--- a/integrations/nvtx/analyzer/src/stats.rs
+++ b/integrations/nvtx/analyzer/src/stats.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Range statistics — a fold over the reconstructed span set.
+//!
+//! Groups range spans by `(name, domain, category)` — all three, since a name
+//! means different work in different domains and the application distinguishes
+//! categories deliberately.
+//!
+//! Only ranges participate. A mark has no duration and a resource lifespan
+//! measures existence rather than work, so folding either in yields a number
+//! that reads like a duration but answers a different question.
+//!
+//! Duration figures cover **observed** closes only. A span whose close was never
+//! captured has no duration to fold in — inventing one would report inference as
+//! measurement — so it raises `count` without raising `observed_count`.
+
+use std::collections::BTreeMap;
+
+use rustc_hash::FxHashMap as HashMap;
+
+use crate::span::{NvtxSpan, SpanKind};
+
+/// What one [`RangeStats`] group is keyed by.
+///
+/// `Ord` rather than `Hash`: the statistics come back in a [`BTreeMap`], so
+/// repeated builds of the same stream iterate in the same order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StatsKey {
+    /// The resolved span name (or its placeholder).
+    pub name: String,
+    /// Raw domain handle (`0` = default domain).
+    pub domain: u64,
+    /// Raw category id, or `None` for NVTX's "no category" sentinel.
+    pub category: Option<u32>,
+}
+
+/// Aggregated durations for one `(name, domain, category)` group, in nanoseconds.
+///
+/// Duration fields cover observed closes only — compare
+/// [`observed_count`](Self::observed_count) against [`count`](Self::count) to
+/// see how much of the group they speak for. The difference is the number of
+/// spans whose close was never captured; [`NvtxModel::anomalies`] says whether
+/// any of that was a key reused mid-flight rather than a capture that stopped.
+///
+/// [`NvtxModel::anomalies`]: crate::NvtxModel::anomalies
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RangeStats {
+    /// How many spans fell into this group, measured or not.
+    pub count: u64,
+    /// How many contributed to the duration figures below.
+    pub observed_count: u64,
+    /// Sum of the observed durations.
+    pub total_duration: u64,
+    /// `total_duration / observed_count`, or `0` when nothing was observed.
+    pub avg_duration: u64,
+    /// The shortest observed duration.
+    pub min_duration: u64,
+    /// The longest observed duration.
+    pub max_duration: u64,
+    /// Whether [`Self::total_duration`] hit the `u64` ceiling and stopped being
+    /// a sum. Only an adversarial or corrupt stream reaches this.
+    pub saturated: bool,
+}
+
+impl RangeStats {
+    /// Fold one span into this group.
+    fn accumulate(&mut self, span: &NvtxSpan) {
+        self.count += 1;
+
+        // A span with no observed close has no duration to fold in. It stays in
+        // `count`, so the gap between the two counts is what says the figures
+        // below do not speak for the whole group.
+        let Some(duration) = span.duration() else {
+            return;
+        };
+
+        if self.observed_count == 0 {
+            // A zeroed `min` would win every comparison, so the first span seeds
+            // both bounds rather than being compared against them.
+            self.min_duration = duration;
+            self.max_duration = duration;
+        } else {
+            self.min_duration = self.min_duration.min(duration);
+            self.max_duration = self.max_duration.max(duration);
+        }
+        self.observed_count += 1;
+
+        match self.total_duration.checked_add(duration) {
+            Some(total) => self.total_duration = total,
+            // Saturate, but say so: a silently wrapped total would be a
+            // plausible-looking wrong number.
+            None => {
+                self.total_duration = u64::MAX;
+                self.saturated = true;
+            }
+        }
+    }
+
+    /// Compute the derived average, once the group is complete.
+    ///
+    /// `checked_div` because a group can be entirely unobserved closes, and this
+    /// would otherwise be the one arithmetic panic in a total path.
+    fn finish(&mut self) {
+        self.avg_duration = self
+            .total_duration
+            .checked_div(self.observed_count)
+            .unwrap_or(0);
+    }
+}
+
+/// Aggregate every range span in `spans` by `(name, domain, category)`.
+pub(crate) fn range_statistics(spans: &[NvtxSpan]) -> BTreeMap<StatsKey, RangeStats> {
+    range_statistics_where(spans, |_| true)
+}
+
+/// Aggregate the range spans in `spans` that `keep` accepts.
+///
+/// Whole-capture figures beside a windowed chart invite the reader to relate
+/// two numbers drawn from different populations.
+pub(crate) fn range_statistics_where(
+    spans: &[NvtxSpan],
+    keep: impl Fn(&NvtxSpan) -> bool,
+) -> BTreeMap<StatsKey, RangeStats> {
+    // Folded against borrowed names, then keyed by owned ones once per group.
+    // Grouping straight into the `BTreeMap` would clone every span's name only
+    // to drop it again on the already-present path.
+    let mut grouped: HashMap<(&str, u64, Option<u32>), RangeStats> = HashMap::default();
+
+    for span in spans
+        .iter()
+        .filter(|span| matches!(span.kind, SpanKind::PushPop { .. } | SpanKind::StartEnd))
+        .filter(|span| keep(span))
+    {
+        grouped
+            .entry((span.name.as_str(), span.domain, span.category))
+            .or_default()
+            .accumulate(span);
+    }
+
+    grouped
+        .into_iter()
+        .map(|((name, domain, category), mut stats)| {
+            // `avg` is derived, so it is computed once per group rather than
+            // recomputed on every span.
+            stats.finish();
+            let key = StatsKey {
+                name: name.to_owned(),
+                domain,
+                category,
+            };
+            (key, stats)
+        })
+        .collect()
+}

--- a/integrations/nvtx/analyzer/src/tables.rs
+++ b/integrations/nvtx/analyzer/src/tables.rs
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pass-1 handle-resolution tables and the placeholder policy.
+//!
+//! NVTX captures every name as a raw integer handle, and the registration giving
+//! a handle meaning may appear anywhere in the stream — including after the
+//! events using it. Resolution therefore needs a prior scan over the whole
+//! stream, and that scan is order-independent so a forward reference resolves
+//! exactly as a backward one does.
+//!
+//! Two keying rules matter most, because getting either wrong produces
+//! plausible-but-wrong labels rather than an error:
+//!
+//! - registered strings key on `(domain, handle)`, never the bare handle — NVTX
+//!   registers strings per domain, so one handle value names different strings
+//!   in different domains;
+//! - category names key on `(domain, category)`, never globally — small ids like
+//!   `1` collide across domains constantly.
+//!
+//! Anything unresolved gets a placeholder that is a pure function of the raw id,
+//! so the same stream always renders the same labels and an unresolved name is
+//! visibly bracketed rather than passing as a real one.
+
+use std::collections::BTreeSet;
+
+use rustc_hash::FxHashMap as HashMap;
+
+use nvtx_bridge::NvtxEventEntity;
+use nvtx_events::{NvtxEvent, NvtxEventAttributes, NvtxMessage};
+use quent_events::Event;
+use quent_time::TimeUnixNanoSec;
+
+use crate::span::{NvtxCategory, NvtxDomain, NvtxThread, category_id};
+
+/// Label for the NVTX default (NULL) domain when nothing names it.
+///
+/// Domain `0` is legitimately unnamed — every uninstrumented `nvtxMark` lands
+/// there — so it gets a clean label rather than a bracketed placeholder.
+const DEFAULT_DOMAIN_NAME: &str = "default domain";
+
+/// Label for an event that carried no message at all.
+const UNNAMED_MESSAGE: &str = "<unnamed>";
+
+/// Placeholder for a non-zero domain handle that was never created.
+fn unresolved_domain_name(domain: u64) -> String {
+    format!("<domain 0x{domain:X}>")
+}
+
+/// Placeholder for a registered-string handle that was never registered.
+fn unregistered_string_name(handle: u64) -> String {
+    format!("<unregistered string 0x{handle:X}>")
+}
+
+/// Placeholder for a non-zero category that was never named.
+///
+/// The domain is in the label because a category id alone is ambiguous.
+fn unnamed_category_name(domain: u64, category: u32) -> String {
+    format!("<category {category} @ domain 0x{domain:X}>")
+}
+
+/// Label for a thread that emitted events but was never named.
+///
+/// Unnamed threads are the norm, so this is a clean label rather than a
+/// bracketed placeholder.
+fn unnamed_thread_name(thread_id: u32) -> String {
+    format!("thread {thread_id}")
+}
+
+/// When a domain existed, as far as the stream shows.
+#[derive(Debug, Clone, Copy)]
+struct DomainLifespan {
+    /// The earliest timestamp at which anything referenced this domain.
+    ///
+    /// Surfaced in its own right rather than substituted for [`Self::created`]:
+    /// a domain created before capture started is still observable, but when it
+    /// was *first seen* is a different fact from when it was created.
+    first_seen: TimeUnixNanoSec,
+    /// The `DomainCreate` timestamp, when one was captured.
+    created: Option<TimeUnixNanoSec>,
+    /// The `DomainDestroy` timestamp, when one was captured.
+    destroyed: Option<TimeUnixNanoSec>,
+}
+
+/// Everything pass 1 learns from the stream, ready for pass 2 to resolve against.
+///
+/// Built by a single scan. The lifespan bounds fold with `min`/`max`, so they
+/// are order-independent outright; the four name tables are last-write-wins, so
+/// a handle registered twice under different names resolves to the later one.
+/// That is still deterministic because [`Self::build`] is handed the
+/// timestamp-ordered stream, not the arrival-ordered one — the ordering is what
+/// makes "later" well defined.
+#[derive(Debug, Default)]
+pub(crate) struct ResolutionTables {
+    /// `DomainCreate` names, keyed by raw domain handle.
+    domain_names: HashMap<u64, String>,
+    /// Lifespan per domain, including domains only ever referenced.
+    domain_lifespans: HashMap<u64, DomainLifespan>,
+    /// `RegisterString` values, keyed **per domain**.
+    registered_strings: HashMap<(u64, u64), String>,
+    /// `NameCategory` names, keyed **per domain** — never globally.
+    category_names: HashMap<(u64, u32), String>,
+    /// `NameThread` names, keyed by raw OS thread id.
+    thread_names: HashMap<u32, String>,
+    /// Every non-zero `(domain, category)` the stream referenced or named.
+    categories_seen: BTreeSet<(u64, u32)>,
+    /// Every OS thread id the stream referenced or named.
+    threads_seen: BTreeSet<u32>,
+}
+
+impl ResolutionTables {
+    /// Scan the whole stream and build every lookup table (pass 1).
+    ///
+    /// Order-independent by construction, which is what makes a `RegisterString`
+    /// that arrives *after* the range using its handle resolve correctly.
+    pub(crate) fn build(events: &[Event<NvtxEventEntity>]) -> Self {
+        let mut tables = Self::default();
+        for event in events {
+            tables.observe(event.timestamp, &event.data.0);
+        }
+        tables
+    }
+
+    /// Fold one event into the tables.
+    fn observe(&mut self, timestamp: TimeUnixNanoSec, event: &NvtxEvent) {
+        match event {
+            NvtxEvent::RangePush {
+                domain,
+                thread_id,
+                attributes,
+            } => {
+                self.see_domain(*domain, timestamp);
+                self.threads_seen.insert(*thread_id);
+                self.see_attributes(*domain, attributes);
+            }
+            NvtxEvent::RangePop { domain, thread_id } => {
+                self.see_domain(*domain, timestamp);
+                self.threads_seen.insert(*thread_id);
+            }
+            NvtxEvent::RangeStart {
+                domain, attributes, ..
+            }
+            | NvtxEvent::Mark { domain, attributes } => {
+                self.see_domain(*domain, timestamp);
+                self.see_attributes(*domain, attributes);
+            }
+            NvtxEvent::RangeEnd { domain, .. } => self.see_domain(*domain, timestamp),
+            NvtxEvent::DomainCreate { domain, name } => {
+                let lifespan = self.lifespan(*domain, timestamp);
+                // `min` rather than assignment: a stream that somehow repeats a
+                // creation still folds to one deterministic answer.
+                lifespan.created = Some(lifespan.created.unwrap_or(timestamp).min(timestamp));
+                self.domain_names.insert(*domain, name.clone());
+            }
+            NvtxEvent::DomainDestroy { domain } => {
+                let lifespan = self.lifespan(*domain, timestamp);
+                lifespan.destroyed = Some(lifespan.destroyed.unwrap_or(timestamp).max(timestamp));
+            }
+            NvtxEvent::RegisterString {
+                domain,
+                handle,
+                string,
+            } => {
+                self.see_domain(*domain, timestamp);
+                // Keyed by `(domain, handle)`: the same handle value in another
+                // domain is a different string.
+                self.registered_strings
+                    .insert((*domain, *handle), string.clone());
+            }
+            NvtxEvent::NameCategory {
+                domain,
+                category,
+                name,
+            } => {
+                self.see_domain(*domain, timestamp);
+                // Naming the "no category" sentinel is meaningless, so it never
+                // enters the tables or the model view.
+                if let Some(category) = category_id(*category) {
+                    self.categories_seen.insert((*domain, category));
+                    self.category_names
+                        .insert((*domain, category), name.clone());
+                }
+            }
+            NvtxEvent::NameThread { thread_id, name } => {
+                self.threads_seen.insert(*thread_id);
+                self.thread_names.insert(*thread_id, name.clone());
+            }
+            NvtxEvent::ResourceCreate { domain, .. } => self.see_domain(*domain, timestamp),
+            // `ResourceDestroy` carries neither a domain nor a message, so it
+            // contributes nothing to resolution.
+            NvtxEvent::ResourceDestroy { .. } => {}
+        }
+    }
+
+    /// The lifespan entry for `domain`, widening its first-seen bound.
+    fn lifespan(&mut self, domain: u64, timestamp: TimeUnixNanoSec) -> &mut DomainLifespan {
+        let lifespan = self
+            .domain_lifespans
+            .entry(domain)
+            .or_insert(DomainLifespan {
+                first_seen: timestamp,
+                created: None,
+                destroyed: None,
+            });
+        lifespan.first_seen = lifespan.first_seen.min(timestamp);
+        lifespan
+    }
+
+    /// Record that `domain` exists, without learning anything else about it.
+    fn see_domain(&mut self, domain: u64, timestamp: TimeUnixNanoSec) {
+        let _ = self.lifespan(domain, timestamp);
+    }
+
+    /// Record the category an event referenced, if it referenced one.
+    fn see_attributes(&mut self, domain: u64, attributes: &NvtxEventAttributes) {
+        if let Some(category) = category_id(attributes.category) {
+            self.categories_seen.insert((domain, category));
+        }
+    }
+
+    /// Render a captured message as a display name.
+    ///
+    /// Registered handles resolve against `domain`; an unregistered handle falls
+    /// back to a placeholder that surfaces the raw handle rather than failing.
+    pub(crate) fn resolve_message(&self, domain: u64, message: &Option<NvtxMessage>) -> String {
+        match message {
+            Some(NvtxMessage::String(text)) => text.clone(),
+            Some(NvtxMessage::RegisteredHandle(handle)) => self
+                .registered_strings
+                .get(&(domain, *handle))
+                .cloned()
+                .unwrap_or_else(|| unregistered_string_name(*handle)),
+            None => UNNAMED_MESSAGE.to_owned(),
+        }
+    }
+
+    /// Render a domain handle as a display name.
+    pub(crate) fn resolve_domain(&self, domain: u64) -> String {
+        if let Some(name) = self.domain_names.get(&domain) {
+            return name.clone();
+        }
+        // Domain 0 is legitimately unnamed; any other unresolved handle is a
+        // genuine gap and says so.
+        if domain == 0 {
+            DEFAULT_DOMAIN_NAME.to_owned()
+        } else {
+            unresolved_domain_name(domain)
+        }
+    }
+
+    /// Render a non-zero category as a display name, namespaced by its domain.
+    fn category_name(&self, domain: u64, category: u32) -> String {
+        self.category_names
+            .get(&(domain, category))
+            .cloned()
+            .unwrap_or_else(|| unnamed_category_name(domain, category))
+    }
+
+    /// Render a category as a display name, namespaced by its domain.
+    ///
+    /// `None` for category `0`: an absence rather than an unresolved reference,
+    /// so it gets no placeholder.
+    pub(crate) fn resolve_category(&self, domain: u64, category: u32) -> Option<String> {
+        category_id(category).map(|category| self.category_name(domain, category))
+    }
+
+    /// Render an OS thread id as a display name.
+    pub(crate) fn resolve_thread(&self, thread_id: u32) -> String {
+        self.thread_names
+            .get(&thread_id)
+            .cloned()
+            .unwrap_or_else(|| unnamed_thread_name(thread_id))
+    }
+
+    /// Every domain the stream mentioned, resolved and ordered by handle.
+    pub(crate) fn domain_records(&self) -> Vec<NvtxDomain> {
+        let mut records: Vec<NvtxDomain> = self
+            .domain_lifespans
+            .iter()
+            .map(|(&domain, lifespan)| NvtxDomain {
+                domain,
+                name: self.resolve_domain(domain),
+                created: lifespan.created,
+                first_seen: lifespan.first_seen,
+                destroyed: lifespan.destroyed,
+            })
+            .collect();
+        // A `HashMap` iteration order is unspecified; sort so repeated builds of
+        // the same stream produce identical models.
+        records.sort_by_key(|record| record.domain);
+        records
+    }
+
+    /// Every OS thread the stream mentioned, resolved and ordered by id.
+    pub(crate) fn thread_records(&self) -> Vec<NvtxThread> {
+        self.threads_seen
+            .iter()
+            .map(|&thread_id| NvtxThread {
+                thread_id,
+                name: self.resolve_thread(thread_id),
+            })
+            .collect()
+    }
+
+    /// Every non-zero category the stream mentioned, ordered by `(domain, id)`.
+    pub(crate) fn category_records(&self) -> Vec<NvtxCategory> {
+        self.categories_seen
+            .iter()
+            .map(|&(domain, category)| NvtxCategory {
+                domain,
+                category,
+                // `categories_seen` never holds category `0`, so this needs no
+                // sentinel round-trip through `resolve_category`.
+                name: self.category_name(domain, category),
+            })
+            .collect()
+    }
+}

--- a/integrations/nvtx/analyzer/tests/fixtures/mod.rs
+++ b/integrations/nvtx/analyzer/tests/fixtures/mod.rs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Synthetic event-stream fixtures for the reconstruction tests.
+//!
+//! Hand-built rather than captured: the malformed cases the core must tolerate
+//! are only reachable when the test controls every timestamp exactly.
+//!
+//! A directory module rather than `tests/fixtures.rs` because Cargo registers
+//! every `.rs` directly under `tests/` as its own integration-test binary, and
+//! this file has no `#[test]`s. Each consumer compiles it in full but uses only
+//! part of it, hence the allow.
+#![allow(dead_code)]
+
+use nvtx_analyzer::{NvtxModel, NvtxSpan, SpanId};
+use nvtx_bridge::NvtxEventEntity;
+use nvtx_events::{NvtxEvent, NvtxEventAttributes, NvtxMessage};
+use quent_events::Event;
+use quent_time::TimeUnixNanoSec;
+use uuid::Uuid;
+
+/// `NVTX_RESOURCE_TYPE_GENERIC_POINTER`, composed by `NVTX_RESOURCE_MAKE_TYPE`.
+pub const GENERIC_POINTER: i32 = 0x0001_0001;
+
+/// The single span whose resolved name is `name`.
+///
+/// Asserts uniqueness, so a test meaning to pin one span cannot pass when
+/// reconstruction produced two.
+pub fn span<'a>(model: &'a NvtxModel, name: &str) -> &'a NvtxSpan {
+    unique(model.spans().iter(), name)
+}
+
+/// The single *resource* span whose resolved name is `name`.
+pub fn resource<'a>(model: &'a NvtxModel, name: &str) -> &'a NvtxSpan {
+    unique(model.resources(), name)
+}
+
+/// The [`SpanId`] of the single span named `name` — the identity a `parent`
+/// reference must equal.
+pub fn span_id(model: &NvtxModel, name: &str) -> SpanId {
+    let index = model
+        .spans()
+        .iter()
+        .position(|span| span.name == name)
+        .unwrap_or_else(|| panic!("no span named {name:?}"));
+    SpanId(index)
+}
+
+/// The one span in `spans` named `name`, panicking if there is not exactly one.
+fn unique<'a>(spans: impl Iterator<Item = &'a NvtxSpan>, name: &str) -> &'a NvtxSpan {
+    let mut matches = spans.filter(|span| span.name == name);
+    let found = matches
+        .next()
+        .unwrap_or_else(|| panic!("no span named {name:?}"));
+    assert!(
+        matches.next().is_none(),
+        "more than one span named {name:?}"
+    );
+    found
+}
+
+/// The single entity id every fixture event is stamped with — one capture
+/// session is one entity stream.
+pub fn stream_id() -> Uuid {
+    Uuid::nil()
+}
+
+/// Wrap a raw [`NvtxEvent`] in the entity envelope at an exact timestamp.
+pub fn at(timestamp: TimeUnixNanoSec, event: NvtxEvent) -> Event<NvtxEventEntity> {
+    Event::new(stream_id(), timestamp, NvtxEventEntity(event))
+}
+
+/// Attributes carrying only an immediate string message.
+pub fn message(text: &str) -> NvtxEventAttributes {
+    NvtxEventAttributes {
+        message: Some(NvtxMessage::String(text.to_owned())),
+        ..Default::default()
+    }
+}
+
+/// A `nvtxDomainRangeStartEx` opening the process-wide range `range_id`.
+pub fn range_start(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    range_id: u64,
+    text: &str,
+) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::RangeStart {
+            domain,
+            range_id,
+            attributes: message(text),
+        },
+    )
+}
+
+/// A `nvtxDomainRangeEnd` closing the process-wide range `range_id`.
+pub fn range_end(timestamp: TimeUnixNanoSec, domain: u64, range_id: u64) -> Event<NvtxEventEntity> {
+    at(timestamp, NvtxEvent::RangeEnd { domain, range_id })
+}
+
+/// A `nvtxDomainRangePushEx` opening a nested range on `thread_id`.
+///
+/// `(thread_id, domain)` is the nesting key, so both are explicit.
+pub fn range_push(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    thread_id: u32,
+    text: &str,
+) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::RangePush {
+            domain,
+            thread_id,
+            attributes: message(text),
+        },
+    )
+}
+
+/// A `nvtxDomainRangePop` closing the innermost push on `thread_id`.
+pub fn range_pop(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    thread_id: u32,
+) -> Event<NvtxEventEntity> {
+    at(timestamp, NvtxEvent::RangePop { domain, thread_id })
+}
+
+/// A `nvtxDomainRangePushEx` carrying a non-zero category, which the statistics
+/// grouping key needs varied independently of name and domain.
+pub fn range_push_in_category(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    thread_id: u32,
+    category: u32,
+    text: &str,
+) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::RangePush {
+            domain,
+            thread_id,
+            attributes: NvtxEventAttributes {
+                category,
+                ..message(text)
+            },
+        },
+    )
+}
+
+/// A `nvtxDomainResourceCreate` opening the lifespan of resource `handle`.
+///
+/// `identifier_type` is explicit so a fixture can exercise both a core value
+/// and an unrecognized one.
+pub fn resource_create(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    handle: u64,
+    identifier_type: i32,
+    identifier: u64,
+    text: &str,
+) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::ResourceCreate {
+            domain,
+            handle,
+            identifier_type,
+            identifier,
+            message: Some(NvtxMessage::String(text.to_owned())),
+        },
+    )
+}
+
+/// A `nvtxDomainResourceDestroy` closing the lifespan of resource `handle`.
+///
+/// Takes no domain because the NVTX event carries none — which is why the
+/// analyzer must match on the handle alone.
+pub fn resource_destroy(timestamp: TimeUnixNanoSec, handle: u64) -> Event<NvtxEventEntity> {
+    at(timestamp, NvtxEvent::ResourceDestroy { handle })
+}
+
+/// A `nvtxDomainMarkEx` instant, which also lets a fixture set the trace end
+/// without opening a range.
+pub fn mark(timestamp: TimeUnixNanoSec, domain: u64, text: &str) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::Mark {
+            domain,
+            attributes: message(text),
+        },
+    )
+}

--- a/integrations/nvtx/analyzer/tests/pushpop.rs
+++ b/integrations/nvtx/analyzer/tests/pushpop.rs
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-`(thread_id, domain)` nested Push/Pop reconstruction.
+//!
+//! A global stack would reconstruct these streams into plausible-but-wrong
+//! nesting rather than failing visibly, so `pushpop_nested_per_thread` is the
+//! load-bearing test here.
+
+mod fixtures;
+
+use fixtures::{mark, range_end, range_pop, range_push, range_start, span, span_id};
+use nvtx_analyzer::{NvtxModelBuilder, SpanKind};
+
+#[test]
+fn pushpop_nested_per_thread() {
+    // Two threads interleaved in one timestamp-ordered stream. Thread 1 nests
+    // `c` inside `a`; thread 2's `b` spans across both of thread 1's pops.
+    // A global stack would pop `b` when thread 1 popped `c`.
+    let events = vec![
+        range_push(100, 1, 1, "a"),
+        range_push(110, 1, 2, "b"),
+        range_push(120, 1, 1, "c"),
+        range_pop(130, 1, 1),
+        range_pop(140, 1, 1),
+        range_pop(150, 1, 2),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 3, "one span per matched push/pop pair");
+
+    let a = span(&model, "a");
+    assert_eq!(
+        a.kind,
+        SpanKind::PushPop {
+            thread_id: 1,
+            parent: None
+        },
+        "outermost on its thread"
+    );
+    assert_eq!(a.start, 100);
+    assert_eq!(
+        a.end,
+        Some(140),
+        "thread 1's outer push closed on its second pop"
+    );
+
+    let c = span(&model, "c");
+    assert_eq!(
+        c.kind,
+        SpanKind::PushPop {
+            thread_id: 1,
+            parent: Some(span_id(&model, "a"))
+        },
+        "nested inside the enclosing push on the same thread"
+    );
+    assert_eq!(c.start, 120);
+    assert_eq!(c.end, Some(130), "the first pop closed the innermost push");
+
+    let b = span(&model, "b");
+    assert_eq!(
+        b.kind,
+        SpanKind::PushPop {
+            thread_id: 2,
+            parent: None
+        },
+        "a push on another thread is never a parent — the stacks are independent"
+    );
+    assert_eq!(b.start, 110);
+    assert_eq!(
+        b.end,
+        Some(150),
+        "thread 2's push is closed only by thread 2's pop"
+    );
+}
+
+#[test]
+fn pushpop_single_thread() {
+    // The plain nesting case: one thread, one domain, balanced.
+    let events = vec![
+        range_push(100, 7, 42, "outer"),
+        range_push(110, 7, 42, "middle"),
+        range_push(120, 7, 42, "inner"),
+        range_pop(130, 7, 42),
+        range_pop(140, 7, 42),
+        range_pop(150, 7, 42),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 3);
+
+    let outer = span(&model, "outer");
+    let middle = span(&model, "middle");
+    let inner = span(&model, "inner");
+
+    assert_eq!((outer.start, outer.end), (100, Some(150)));
+    assert_eq!((middle.start, middle.end), (110, Some(140)));
+    assert_eq!((inner.start, inner.end), (120, Some(130)));
+
+    assert_eq!(outer.kind.parent(), None);
+    assert_eq!(middle.kind.parent(), Some(span_id(&model, "outer")));
+    assert_eq!(inner.kind.parent(), Some(span_id(&model, "middle")));
+
+    for span in model.spans() {
+        assert_eq!(span.kind.thread_id(), Some(42));
+        assert_eq!(span.domain, 7);
+        assert!(span.end.is_some(), "every pop was captured");
+    }
+}
+
+#[test]
+fn unclosed_pushes_have_no_end() {
+    // Both pushes are left open; the mark carries the trace to 500. That is
+    // where observation stopped, not where the ranges did, so neither gets an
+    // end written into it.
+    let events = vec![
+        range_push(100, 1, 5, "leaked"),
+        range_push(150, 1, 5, "also leaked"),
+        mark(500, 1, "tick"),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(
+        model.spans().len(),
+        2,
+        "both leaked pushes still become spans"
+    );
+
+    let leaked = span(&model, "leaked");
+    assert_eq!(leaked.start, 100);
+    assert_eq!(leaked.end, None, "the pop was never observed");
+    assert_eq!(leaked.kind.parent(), None);
+
+    let inner = span(&model, "also leaked");
+    assert_eq!(inner.end, None);
+    assert_eq!(
+        inner.kind.parent(),
+        Some(span_id(&model, "leaked")),
+        "nesting is still known without a pop — the stack records it"
+    );
+}
+
+#[test]
+fn orphan_pop_skipped() {
+    // The first pop has no open push on `(thread 5, domain 1)`; the second pop
+    // belongs to another thread entirely. Neither is fatal, and neither steals
+    // the real pair's push.
+    let events = vec![
+        range_pop(100, 1, 5),
+        range_push(200, 1, 5, "real"),
+        range_pop(300, 1, 9),
+        range_pop(400, 1, 5),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 1, "orphan pops produced no spans");
+    assert_eq!(
+        model.anomalies().orphan_range_pops,
+        2,
+        "both orphan pops are reported, not silently lost"
+    );
+    let real = span(&model, "real");
+    assert_eq!(real.start, 200);
+    assert_eq!(
+        real.end,
+        Some(400),
+        "the cross-thread pop at 300 did not close it"
+    );
+}
+
+#[test]
+fn malformed_stream_completes() {
+    // Everything the core promises to tolerate, in one stream: out-of-order
+    // arrival, duplicate timestamps, an unmatched `RangeStart`, an orphan
+    // `RangeEnd`, unclosed pushes, orphan pops, and a cross-thread pop.
+    let stream = || {
+        vec![
+            // Out of order: this end precedes its start in arrival order.
+            range_end(320, 1, 77),
+            range_start(300, 1, 77, "reordered"),
+            // Orphan end — no start was ever seen for this id.
+            range_end(310, 1, 4242),
+            // Unmatched start — never ended.
+            range_start(305, 1, 78, "never ended"),
+            // Duplicate timestamps across two threads.
+            range_push(400, 2, 1, "dup a"),
+            range_push(400, 2, 2, "dup b"),
+            range_pop(400, 2, 1),
+            range_pop(400, 2, 2),
+            // Orphan pop on a thread that never pushed.
+            range_pop(500, 2, 3),
+            // Unclosed push, left open at trace end.
+            range_push(600, 2, 1, "left open"),
+            // A pop from a *different* thread must not close it.
+            range_pop(650, 2, 99),
+            // A mark, and a push in a domain that is never popped.
+            mark(700, 0, "tick"),
+            range_push(800, 3, 1, "other domain"),
+        ]
+    };
+
+    // A malformed stream still builds — `build` is infallible by signature.
+    let model = NvtxModelBuilder::build(stream());
+
+    // 2 start/end + 4 push/pop = 6 spans; the two orphan ends/pops contribute none.
+    assert_eq!(model.spans().len(), 6, "every open range became a span");
+
+    let reordered = span(&model, "reordered");
+    assert_eq!((reordered.start, reordered.end), (300, Some(320)));
+
+    assert_eq!(span(&model, "never ended").end, None);
+    assert_eq!(span(&model, "left open").end, None);
+    assert_eq!(span(&model, "other domain").end, None);
+
+    let dup_a = span(&model, "dup a");
+    assert_eq!(dup_a.duration(), Some(0), "zero-duration spans are legal");
+    assert_eq!(dup_a.kind.thread_id(), Some(1));
+
+    for span in model.spans() {
+        assert!(
+            span.end.is_none_or(|end| end >= span.start),
+            "duration can never underflow"
+        );
+    }
+
+    assert_eq!(model.marks().len(), 1, "the mark survived the malformation");
+
+    // Determinism: the same malformed stream reconstructs identically.
+    let again = NvtxModelBuilder::build(stream());
+    assert_eq!(model.spans(), again.spans());
+}

--- a/integrations/nvtx/analyzer/tests/reconstruction.rs
+++ b/integrations/nvtx/analyzer/tests/reconstruction.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reconstruction of `RangeStart`/`RangeEnd` pairs, and what an incomplete
+//! pair yields.
+
+mod fixtures;
+
+use fixtures::{mark, range_end, range_start, span};
+use nvtx_analyzer::{NvtxModelBuilder, SpanKind};
+
+#[test]
+fn startend_match_by_handle() {
+    // The final `RangeEnd` carries a *different* domain than its start: the
+    // match key is `range_id` alone, which NVTX makes process-globally unique.
+    let events = vec![
+        range_start(100, 1, 7, "alpha"),
+        range_start(150, 2, 9, "beta"),
+        range_end(200, 1, 7),
+        range_end(250, 999, 9),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 2, "one span per matched range");
+
+    let alpha = span(&model, "alpha");
+    assert_eq!(alpha.kind, SpanKind::StartEnd);
+    assert_eq!(alpha.domain, 1);
+    assert_eq!(alpha.start, 100);
+    assert_eq!(alpha.end, Some(200), "the end was observed");
+    assert_eq!(alpha.duration(), Some(100));
+
+    let beta = span(&model, "beta");
+    assert_eq!(beta.kind, SpanKind::StartEnd);
+    assert_eq!(beta.domain, 2, "domain comes from the start, not the end");
+    assert_eq!(beta.start, 150);
+    assert_eq!(beta.end, Some(250));
+}
+
+#[test]
+fn out_of_order_sorted() {
+    // The end arrives before its start.
+    let events = vec![range_end(200, 1, 7), range_start(100, 1, 7, "late")];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 1);
+    let late = span(&model, "late");
+    assert_eq!(late.start, 100);
+    assert_eq!(late.end, Some(200), "the end was observed, just early");
+    assert_eq!(late.duration(), Some(100), "replay is timestamp-ordered");
+}
+
+#[test]
+fn duplicate_timestamps_no_panic() {
+    let stream = || {
+        vec![
+            range_start(100, 1, 7, "a"),
+            range_start(100, 1, 8, "b"),
+            range_end(100, 1, 7),
+            range_end(100, 1, 8),
+        ]
+    };
+
+    let model = NvtxModelBuilder::build(stream());
+    assert_eq!(model.spans().len(), 2);
+
+    for span in model.spans() {
+        assert_eq!(span.start, 100);
+        assert_eq!(span.end, Some(100), "zero-duration spans are legal");
+        assert_eq!(span.duration(), Some(0));
+    }
+
+    // Equal timestamps preserve arrival order, so a rebuild is identical.
+    let again = NvtxModelBuilder::build(stream());
+    assert_eq!(
+        model.spans(),
+        again.spans(),
+        "duplicate timestamps reconstruct deterministically"
+    );
+}
+
+#[test]
+fn unclosed_start_has_no_end() {
+    // `leaked` is never ended. The trace runs to 500, but that is where
+    // *observation* stopped, not where the range did — so nothing is written
+    // into its end. A consumer that wants a right edge takes `trace_end`
+    // deliberately.
+    let events = vec![range_start(100, 1, 7, "leaked"), mark(500, 1, "tick")];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 1, "a mark is an instant, not a span");
+    let leaked = span(&model, "leaked");
+    assert_eq!(leaked.start, 100);
+    assert_eq!(leaked.end, None, "no close was ever captured");
+    assert_eq!(leaked.duration(), None, "so there is nothing to measure");
+
+    assert_eq!(model.trace_end(), 500, "the bound is on the model instead");
+    assert!(
+        model.anomalies().is_faithful(),
+        "a capture that stopped mid-flight is not malformed; the span says so itself"
+    );
+}
+
+#[test]
+fn restarted_id_keeps_the_displaced_range() {
+    // `first` is restarted under the same id before it ever ended. NVTX ids are
+    // process-globally unique, so this is malformed — but the first start was
+    // observed, and dropping it would erase a range the stream really reported.
+    let events = vec![
+        range_start(100, 1, 7, "first"),
+        range_start(300, 1, 7, "second"),
+        range_end(500, 1, 7),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 2, "both starts produce a span");
+
+    let first = span(&model, "first");
+    assert_eq!(first.start, 100);
+    assert_eq!(
+        first.end, None,
+        "the displaced range is kept, but nothing ever closed it"
+    );
+    assert_eq!(first.duration(), None);
+
+    // The restart is not visible on the span — it looks like any other
+    // never-closed range — so the model carries the fact instead.
+    assert_eq!(model.anomalies().reused_range_ids, 1);
+    assert!(!model.anomalies().is_faithful());
+
+    // The `RangeEnd` belongs to whichever start was open when it arrived.
+    let second = span(&model, "second");
+    assert_eq!(second.start, 300);
+    assert_eq!(second.end, Some(500), "the end was observed");
+}
+
+#[test]
+fn orphan_end_skipped_but_counted() {
+    // A `RangeEnd` with no open start cannot become a span — it carries only a
+    // correlation key, no name or attributes. It is dropped, but the drop is
+    // reported, because otherwise this model is indistinguishable from one that
+    // saw the whole stream.
+    let events = vec![
+        range_end(100, 1, 7),
+        range_start(200, 1, 8, "real"),
+        range_end(300, 1, 8),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.spans().len(), 1, "the orphan end produced no span");
+    let real = span(&model, "real");
+    assert_eq!(real.start, 200);
+    assert_eq!(real.end, Some(300));
+
+    let anomalies = model.anomalies();
+    assert_eq!(anomalies.orphan_range_ends, 1);
+    assert_eq!(anomalies.total(), 1);
+    assert!(
+        !anomalies.is_faithful(),
+        "the span list is not the whole population"
+    );
+}
+
+#[test]
+fn clean_stream_is_faithful() {
+    // Every close matched an open, so nothing was lost and the span list
+    // accounts for the entire stream.
+    let events = vec![range_start(100, 1, 7, "alpha"), range_end(200, 1, 7)];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert!(model.anomalies().is_faithful());
+    assert_eq!(model.anomalies().total(), 0);
+}

--- a/integrations/nvtx/analyzer/tests/resolution.rs
+++ b/integrations/nvtx/analyzer/tests/resolution.rs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Handle resolution: registered strings, per-domain category namespacing,
+//! placeholder stability, and the model surface those names hang off.
+
+mod fixtures;
+
+use fixtures::{at, range_end, range_start};
+use nvtx_analyzer::{NvtxDomain, NvtxModel, NvtxModelBuilder};
+use nvtx_bridge::NvtxEventEntity;
+use nvtx_events::{NvtxEvent, NvtxEventAttributes, NvtxMessage};
+use quent_events::Event;
+use quent_time::TimeUnixNanoSec;
+
+/// Attributes naming a previously (or subsequently) registered string.
+fn registered(handle: u64) -> NvtxEventAttributes {
+    NvtxEventAttributes {
+        message: Some(NvtxMessage::RegisteredHandle(handle)),
+        ..Default::default()
+    }
+}
+
+/// A `RangeStart` whose message is a registered-string handle.
+fn registered_start(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    range_id: u64,
+    handle: u64,
+) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::RangeStart {
+            domain,
+            range_id,
+            attributes: registered(handle),
+        },
+    )
+}
+
+/// A `RegisterString` binding `handle` to `string` within `domain`.
+fn register(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    handle: u64,
+    string: &str,
+) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::RegisterString {
+            domain,
+            handle,
+            string: string.to_owned(),
+        },
+    )
+}
+
+/// A `NameCategory` naming `category` within `domain`.
+fn name_category(
+    timestamp: TimeUnixNanoSec,
+    domain: u64,
+    category: u32,
+    name: &str,
+) -> Event<NvtxEventEntity> {
+    at(
+        timestamp,
+        NvtxEvent::NameCategory {
+            domain,
+            category,
+            name: name.to_owned(),
+        },
+    )
+}
+
+/// The domain record for `domain`.
+fn domain_record(model: &NvtxModel, domain: u64) -> &NvtxDomain {
+    model
+        .domains()
+        .iter()
+        .find(|record| record.domain == domain)
+        .unwrap_or_else(|| panic!("no domain record for 0x{domain:X}"))
+}
+
+#[test]
+fn uncreated_domain_reports_no_creation_time() {
+    // Domain 7 is referenced but its `DomainCreate` was never captured — it
+    // already existed when capture attached. `first_seen` is an upper bound on
+    // when it was really created, and must not be reported as the creation.
+    let events = vec![range_start(400, 7, 1, "work"), range_end(500, 7, 1)];
+
+    let model = NvtxModelBuilder::build(events);
+
+    let domain = domain_record(&model, 7);
+    assert_eq!(
+        domain.created, None,
+        "no creation was observed, so none is claimed"
+    );
+    assert_eq!(domain.first_seen, 400);
+    assert_eq!(domain.destroyed, None);
+}
+
+#[test]
+fn resolve_registered_string() {
+    // The registration arrives *after* the range that uses it: pass 1 scans the
+    // whole stream, so a forward reference resolves like any other.
+    let events = vec![
+        registered_start(100, 1, 7, 0xAB),
+        range_end(200, 1, 7),
+        register(300, 1, 0xAB, "gather_kernel"),
+        // The same handle value in a different domain is a *different* string.
+        registered_start(400, 2, 8, 0xAB),
+        range_end(500, 2, 8),
+        register(600, 2, 0xAB, "scatter_kernel"),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    let names: Vec<&str> = model
+        .spans()
+        .iter()
+        .map(|span| span.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["gather_kernel", "scatter_kernel"],
+        "registered strings resolve per (domain, handle), never by bare handle"
+    );
+}
+
+#[test]
+fn category_namespaced_by_domain() {
+    // Category 7 is named in two domains. A globally-keyed table would collapse
+    // these into one name; the (domain, category) key keeps them distinct.
+    let events = vec![
+        name_category(10, 1, 7, "io"),
+        name_category(20, 2, 7, "compute"),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.category_name(1, 7).as_deref(), Some("io"));
+    assert_eq!(model.category_name(2, 7).as_deref(), Some("compute"));
+    assert_eq!(
+        model.category_name(0, 0),
+        None,
+        "category 0 is the 'no category' sentinel, not an unresolved reference"
+    );
+
+    let categories: Vec<(u64, u32, &str)> = model
+        .categories()
+        .iter()
+        .map(|record| (record.domain, record.category, record.name.as_str()))
+        .collect();
+    assert_eq!(categories, vec![(1, 7, "io"), (2, 7, "compute")]);
+}
+
+#[test]
+fn placeholder_stable() {
+    // Nothing in this stream is ever registered, created, named, or destroyed:
+    // every label below is a placeholder.
+    let stream = || {
+        vec![
+            registered_start(100, 0x2A, 7, 0xBEEF),
+            at(
+                150,
+                NvtxEvent::RangeEnd {
+                    domain: 0x2A,
+                    range_id: 7,
+                },
+            ),
+            // Domain 0 is legitimately unnamed, and category 9 in domain 0x2A is
+            // referenced but never named.
+            at(
+                200,
+                NvtxEvent::Mark {
+                    domain: 0,
+                    attributes: NvtxEventAttributes {
+                        category: 9,
+                        ..Default::default()
+                    },
+                },
+            ),
+            // A thread that emits but is never named.
+            at(
+                250,
+                NvtxEvent::RangePop {
+                    domain: 0x2A,
+                    thread_id: 42,
+                },
+            ),
+        ]
+    };
+
+    let model = NvtxModelBuilder::build(stream());
+
+    assert_eq!(
+        model.spans()[0].name,
+        "<unregistered string 0xBEEF>",
+        "an unregistered handle surfaces its raw value"
+    );
+    assert_eq!(
+        domain_record(&model, 0x2A).name,
+        "<domain 0x2A>",
+        "a referenced-but-uncreated domain surfaces its raw handle"
+    );
+    assert_eq!(
+        domain_record(&model, 0).name,
+        "default domain",
+        "domain 0 is legitimately unnamed, not unresolved"
+    );
+    assert_eq!(
+        model.category_name(0x2A, 9).as_deref(),
+        Some("<category 9 @ domain 0x2A>"),
+        "an unnamed category is qualified by its domain"
+    );
+    assert_eq!(
+        model.thread_name(42),
+        "thread 42",
+        "an unnamed thread is legitimately unnamed, not unresolved"
+    );
+
+    // Placeholders are pure functions of the raw id — no counters, no
+    // timestamps — so a rebuild is byte-identical.
+    let again = NvtxModelBuilder::build(stream());
+    assert_eq!(model.spans(), again.spans());
+    assert_eq!(model.domains(), again.domains());
+    assert_eq!(model.threads(), again.threads());
+    assert_eq!(model.categories(), again.categories());
+}
+
+#[test]
+fn model_surface_present() {
+    let events = vec![
+        at(
+            10,
+            NvtxEvent::DomainCreate {
+                domain: 1,
+                name: "cudf".to_owned(),
+            },
+        ),
+        register(20, 1, 0x55, "checkpoint"),
+        name_category(30, 1, 3, "io"),
+        at(
+            40,
+            NvtxEvent::NameThread {
+                thread_id: 42,
+                name: "worker".to_owned(),
+            },
+        ),
+        at(
+            50,
+            NvtxEvent::Mark {
+                domain: 1,
+                attributes: NvtxEventAttributes {
+                    category: 3,
+                    message: Some(NvtxMessage::RegisteredHandle(0x55)),
+                    ..Default::default()
+                },
+            },
+        ),
+        at(90, NvtxEvent::DomainDestroy { domain: 1 }),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.marks().len(), 1, "the Mark became an instant");
+    let mark = &model.marks()[0];
+    assert_eq!(mark.name, "checkpoint", "the mark's handle resolved");
+    assert_eq!(mark.domain, 1);
+    assert_eq!(mark.category, Some(3));
+    assert_eq!(mark.timestamp, 50);
+    assert!(
+        model.spans().is_empty(),
+        "a mark is an instant, never a zero-length span"
+    );
+
+    let domain = domain_record(&model, 1);
+    assert_eq!(domain.name, "cudf");
+    assert_eq!(
+        domain.created,
+        Some(10),
+        "a captured DomainCreate is a real creation time"
+    );
+    assert_eq!(domain.first_seen, 10);
+    assert_eq!(domain.destroyed, Some(90));
+
+    assert_eq!(model.threads().len(), 1);
+    assert_eq!(model.threads()[0].thread_id, 42);
+    assert_eq!(model.threads()[0].name, "worker");
+    assert_eq!(model.thread_name(42), "worker");
+
+    assert_eq!(model.category_name(1, 3).as_deref(), Some("io"));
+    assert_eq!(model.categories().len(), 1);
+}

--- a/integrations/nvtx/analyzer/tests/resource.rs
+++ b/integrations/nvtx/analyzer/tests/resource.rs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resource lifespan reconstruction, and the keying rule that makes it work.
+//!
+//! Matching is on the handle alone, since the destroy carries no domain. Keying
+//! on `(domain, handle)` would not fail loudly — every resource would silently
+//! become a leak with no end — so `resource_lifespan` pins the real end
+//! timestamp to catch exactly that.
+
+mod fixtures;
+
+use fixtures::{GENERIC_POINTER, range_push, resource, resource_create, resource_destroy};
+use nvtx_analyzer::{NvtxModelBuilder, NvtxSpan, SpanKind};
+
+/// A CUDA-extension resource class (`nvtxResourceCUDAType_t` lives at class 4),
+/// which the analyzer deliberately does not label.
+const CUDA_EXTENSION_TYPE: i32 = 0x0004_0001;
+
+#[test]
+fn resource_lifespan() {
+    // The destroy carries no domain at all — only the handle. The reconstructed
+    // span must still land in domain 7, recovered from the create.
+    let events = vec![
+        resource_create(100, 7, 0xABCD, GENERIC_POINTER, 0xDEAD_BEEF, "buf"),
+        resource_destroy(400, 0xABCD),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    let resources: Vec<&NvtxSpan> = model.resources().collect();
+    assert_eq!(
+        resources.len(),
+        1,
+        "one span per matched create/destroy pair"
+    );
+
+    let buf = resource(&model, "buf");
+    assert_eq!(
+        buf.kind,
+        SpanKind::Resource {
+            identifier_type: GENERIC_POINTER
+        }
+    );
+    assert_eq!(buf.domain, 7, "domain recovered from the create");
+    assert_eq!(buf.start, 100);
+    assert_eq!(
+        buf.end,
+        Some(400),
+        "matched by handle alone; a (domain, handle) key would leave this with no end"
+    );
+    assert_eq!(buf.duration(), Some(300));
+    assert_eq!(
+        buf.kind.parent(),
+        None,
+        "resource lifespans do not nest, whatever the kind"
+    );
+}
+
+#[test]
+fn resource_identifier_type_labels() {
+    // One core/generic type and one the analyzer does not recognize.
+    let events = vec![
+        resource_create(100, 1, 0x01, GENERIC_POINTER, 0, "known"),
+        resource_destroy(200, 0x01),
+        resource_create(110, 1, 0x02, CUDA_EXTENSION_TYPE, 0, "extension"),
+        resource_destroy(210, 0x02),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(
+        resource(&model, "known").kind.identifier_type_label(),
+        Some("generic pointer".to_owned()),
+        "a core nvtxResourceGenericType_t value gets a static label"
+    );
+    assert_eq!(
+        resource(&model, "extension").kind.identifier_type_label(),
+        Some(format!("<identifier_type {CUDA_EXTENSION_TYPE}>")),
+        "an unrecognized type passes through raw rather than being guessed at"
+    );
+}
+
+#[test]
+fn resource_unclosed_has_no_end() {
+    // No destroy for the resource; a later push carries the trace to 500. The
+    // handle may well still be live, so nothing is written into its end.
+    let events = vec![
+        resource_create(100, 1, 0xFEED, GENERIC_POINTER, 0, "leaked"),
+        range_push(500, 1, 1, "later"),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    let leaked = resource(&model, "leaked");
+    assert_eq!(leaked.end, None, "the destroy was never captured");
+    assert_eq!(leaked.duration(), None);
+    assert_eq!(model.trace_end(), 500, "the bound is on the model instead");
+}
+
+#[test]
+fn recreated_handle_keeps_the_displaced_lifespan() {
+    // The same handle is created twice with no destroy in between — a reuse
+    // before the first lifespan ended. The first create was observed, so its
+    // lifespan must reconstruct rather than vanish.
+    let events = vec![
+        resource_create(100, 1, 0xAB, GENERIC_POINTER, 0, "first"),
+        resource_create(300, 1, 0xAB, GENERIC_POINTER, 0, "second"),
+        resource_destroy(500, 0xAB),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.resources().count(), 2, "both creates produce a span");
+
+    let first = resource(&model, "first");
+    assert_eq!(first.start, 100);
+    assert_eq!(
+        first.end, None,
+        "the displaced lifespan is kept, but nothing ever destroyed it"
+    );
+
+    // The recreate leaves no mark on the span itself, so the model carries it.
+    assert_eq!(model.anomalies().reused_resource_handles, 1);
+    assert!(!model.anomalies().is_faithful());
+
+    let second = resource(&model, "second");
+    assert_eq!(second.start, 300);
+    assert_eq!(second.end, Some(500), "the destroy was observed");
+}
+
+#[test]
+fn resource_orphan_destroy_skipped() {
+    // A destroy with no create ahead of it — the normal case for a resource
+    // created before capture attached. It must be skipped, not fatal.
+    let events = vec![
+        resource_destroy(100, 0x99),
+        resource_create(200, 1, 0x11, GENERIC_POINTER, 0, "real"),
+        resource_destroy(300, 0x11),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(
+        model.resources().count(),
+        1,
+        "the orphan destroy contributes no span; the matched pair still does"
+    );
+    assert_eq!(resource(&model, "real").end, Some(300));
+    assert_eq!(model.anomalies().orphan_resource_destroys, 1);
+}

--- a/integrations/nvtx/analyzer/tests/roundtrip.rs
+++ b/integrations/nvtx/analyzer/tests/roundtrip.rs
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end proof against a **real** NVTX capture.
+//!
+//! Every other test feeds the builder a hand-built stream, so they all agree
+//! with each other about what a capture looks like. This one closes that loop by
+//! running the actual injection layer and reconstructing whatever comes out.
+//!
+//! Gated behind `real-capture-tests` because it links the injection cdylib,
+//! whose build script runs bindgen against the pixi-pinned NVTX headers.
+#![cfg(feature = "real-capture-tests")]
+
+use std::sync::{Arc, Mutex};
+
+use nvtx_analyzer::{NvtxModelBuilder, SpanKind, StatsKey};
+use nvtx_bridge::NvtxEventEntity;
+use quent_instrumentation::{Event, EventCallback};
+use uuid::Uuid;
+
+/// The default (NULL) NVTX domain, which is where `nvtx_example` annotates.
+const DEFAULT_DOMAIN: u64 = 0;
+
+#[test]
+fn example_capture_roundtrip() {
+    // Collect the full envelope, not just the inner event: the builder orders by
+    // `timestamp`, so dropping it would make this test prove nothing about the
+    // real capture's ordering.
+    let collected: Arc<Mutex<Vec<Event<NvtxEventEntity>>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = {
+        let collected = Arc::clone(&collected);
+        EventCallback::<NvtxEventEntity>::new(move |event| {
+            collected.lock().expect("collector poisoned").push(event);
+        })
+    };
+
+    // Injection is process-global and one-shot, so this is deliberately a single
+    // test doing a single capture — no parallel capture is possible here.
+    nvtx_example::run_capture(Uuid::now_v7(), sink).expect("capture");
+
+    // Read through the `Arc` rather than `try_unwrap`ing it: the sink's closure
+    // holds a second clone, and injection is process-global and one-shot, so
+    // nothing guarantees the registry drops the callback before `run_capture`
+    // returns. Unwrapping would make a retained callback fail this test for a
+    // reason unrelated to reconstruction.
+    let events = std::mem::take(&mut *collected.lock().expect("collector poisoned"));
+    assert!(!events.is_empty(), "no NVTX events captured");
+
+    let model = NvtxModelBuilder::build(events);
+
+    // `nvtx::name_thread!` — the name must reach the thread view.
+    assert!(
+        model
+            .threads()
+            .iter()
+            .any(|thread| thread.name == "nvtx-example/main"),
+        "named thread missing; threads: {:?}",
+        model.threads()
+    );
+
+    // `nvtx::mark!` — an instant, not a zero-length span.
+    assert!(
+        model.marks().iter().any(|mark| mark.name == "startup"),
+        "mark \"startup\" missing; marks: {:?}",
+        model.marks()
+    );
+    assert!(
+        !model.spans().iter().any(|span| span.name == "startup"),
+        "the mark must not have been reconstructed as a span"
+    );
+
+    // `nvtx::range_push!` / `range_pop!` — a per-thread nested range.
+    let phase1 = model
+        .spans()
+        .iter()
+        .find(|span| span.name == "phase-1")
+        .expect("span \"phase-1\" missing");
+    assert!(
+        matches!(phase1.kind, SpanKind::PushPop { .. }),
+        "a push/pop range carries the OS thread it ran on; got {:?}",
+        phase1.kind
+    );
+    assert!(phase1.end.is_some(), "the pop was observed");
+    assert!(phase1.duration().is_some());
+
+    // `nvtx::range!` — a process-wide start/end range.
+    let phase2 = model
+        .spans()
+        .iter()
+        .find(|span| span.name == "phase-2")
+        .expect("span \"phase-2\" missing");
+    assert_eq!(phase2.kind, SpanKind::StartEnd);
+    assert!(phase2.end.is_some(), "the end was observed");
+    assert!(phase2.duration().is_some());
+
+    // Both ranges reach the statistics, one group each.
+    let stats = model.range_statistics();
+    for name in ["phase-1", "phase-2"] {
+        let group = stats
+            .get(&StatsKey {
+                name: name.to_owned(),
+                domain: DEFAULT_DOMAIN,
+                category: None,
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "no statistics for {name:?}; groups: {:?}",
+                    stats.keys().collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(group.count, 1, "one occurrence of {name:?}");
+        assert_eq!(group.observed_count, 1, "{name:?} closed for real");
+        assert_eq!(
+            group.min_duration, group.max_duration,
+            "a single occurrence bounds itself"
+        );
+        assert_eq!(group.avg_duration, group.total_duration);
+    }
+}

--- a/integrations/nvtx/analyzer/tests/stats.rs
+++ b/integrations/nvtx/analyzer/tests/stats.rs
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Range statistics — the aggregation, and what it refuses to aggregate.
+//!
+//! Each component of the `(name, domain, category)` key is pinned by a test
+//! that would still pass if the key were only partly right, and marks and
+//! resource lifespans are pinned as excluded.
+
+mod fixtures;
+
+use fixtures::{
+    GENERIC_POINTER, mark, range_end, range_pop, range_push, range_push_in_category, range_start,
+    resource_create, resource_destroy,
+};
+use nvtx_analyzer::{NvtxModelBuilder, RangeStats, StatsKey};
+
+/// The key for an uncategorized range named `name` in `domain`.
+fn key(name: &str, domain: u64) -> StatsKey {
+    StatsKey {
+        name: name.to_owned(),
+        domain,
+        category: None,
+    }
+}
+
+#[test]
+fn range_statistics() {
+    // Three "work" ranges of 100 / 50 / 300 ns, plus one differently-named
+    // range and one same-named range in another domain — neither may merge in.
+    let events = vec![
+        range_push(100, 1, 1, "work"),
+        range_pop(200, 1, 1),
+        range_push(300, 1, 1, "work"),
+        range_pop(350, 1, 1),
+        range_push(400, 1, 1, "work"),
+        range_pop(700, 1, 1),
+        range_push(800, 1, 1, "other"),
+        range_pop(900, 1, 1),
+        // Same name, different domain: the domain is part of the key.
+        range_push(1000, 2, 1, "work"),
+        range_pop(1100, 2, 1),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    let work = stats.get(&key("work", 1)).expect("no stats for work@1");
+    assert_eq!(
+        *work,
+        RangeStats {
+            count: 3,
+            observed_count: 3,
+            total_duration: 450,
+            avg_duration: 150,
+            min_duration: 50,
+            max_duration: 300,
+            saturated: false,
+        }
+    );
+
+    assert_eq!(
+        stats
+            .get(&key("work", 2))
+            .expect("no stats for work@2")
+            .count,
+        1,
+        "a same-named range in another domain is its own group"
+    );
+    assert_eq!(
+        stats
+            .get(&key("other", 1))
+            .expect("no stats for other@1")
+            .count,
+        1
+    );
+    assert_eq!(stats.len(), 3, "exactly three groups");
+}
+
+#[test]
+fn range_statistics_namespaced_by_category() {
+    // One name, one domain, two categories. A key that dropped the category
+    // would report a single group of two.
+    let events = vec![
+        range_push_in_category(100, 1, 1, 7, "work"),
+        range_pop(200, 1, 1),
+        range_push_in_category(300, 1, 1, 9, "work"),
+        range_pop(500, 1, 1),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    assert_eq!(stats.len(), 2, "category is part of the grouping key");
+    for (category, expected) in [(7, 100), (9, 200)] {
+        let stats = stats
+            .get(&StatsKey {
+                name: "work".to_owned(),
+                domain: 1,
+                category: Some(category),
+            })
+            .unwrap_or_else(|| panic!("no stats for category {category}"));
+        assert_eq!(stats.count, 1);
+        assert_eq!(stats.total_duration, expected);
+    }
+}
+
+#[test]
+fn range_statistics_excludes_marks_and_resources() {
+    // A mark is an instant and a resource lifespan is not work; only the range
+    // may be aggregated.
+    let events = vec![
+        range_push(100, 1, 1, "work"),
+        range_pop(200, 1, 1),
+        mark(150, 1, "checkpoint"),
+        resource_create(120, 1, 0xAB, GENERIC_POINTER, 0, "buf"),
+        resource_destroy(900, 0xAB),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    assert_eq!(
+        stats.len(),
+        1,
+        "only the range is aggregated; got {:?}",
+        stats.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        stats.get(&key("work", 1)).expect("work").total_duration,
+        100
+    );
+}
+
+#[test]
+fn range_statistics_excludes_unobserved_from_durations() {
+    // One observed close and one push left open when the trace ended at 900.
+    let events = vec![
+        range_push(100, 1, 1, "work"),
+        range_pop(200, 1, 1),
+        range_push(300, 1, 2, "work"),
+        mark(900, 1, "trace end"),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    let work = stats.get(&key("work", 1)).expect("work");
+    assert_eq!(work.count, 2, "both ranges are in the group");
+    assert_eq!(work.observed_count, 1, "but only one close was captured");
+    assert_eq!(
+        work.count - work.observed_count,
+        1,
+        "the gap between the counts is what says so"
+    );
+
+    // The open range had run 600ns by the clock when capture stopped, but that
+    // is a lower bound on work still in flight. Folding it in used to report
+    // max=600 and avg=350 for a group whose only measurement is 100.
+    assert_eq!(work.total_duration, 100, "observed durations only");
+    assert_eq!(work.avg_duration, 100);
+    assert_eq!(work.max_duration, 100);
+    assert_eq!(work.min_duration, 100);
+}
+
+#[test]
+fn range_statistics_all_unobserved_reports_no_durations() {
+    // Every range in the group was left open. There is no measurement to
+    // report, and `avg` must not divide by zero.
+    let events = vec![
+        range_push(100, 1, 1, "work"),
+        range_push(300, 1, 2, "work"),
+        mark(900, 1, "trace end"),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    let work = stats.get(&key("work", 1)).expect("work");
+    assert_eq!(work.count, 2);
+    assert_eq!(work.observed_count, 0);
+    assert_eq!(work.total_duration, 0, "nothing was measured");
+    assert_eq!(work.avg_duration, 0, "no division by zero");
+    assert!(!work.saturated);
+}
+
+#[test]
+fn displacement_is_reported_on_the_model_not_the_group() {
+    // A restarted range id leaves the displaced range with no end, which reads
+    // in the group exactly like a capture that stopped. The two are different
+    // facts, so the one the group cannot express is on the model.
+    let events = vec![
+        range_start(100, 1, 7, "work"),
+        range_start(300, 1, 7, "work"),
+        range_end(500, 1, 7),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    let work = stats.get(&key("work", 1)).expect("work");
+    assert_eq!(work.count, 2);
+    assert_eq!(work.observed_count, 1, "only the second range closed");
+    assert_eq!(work.total_duration, 200, "500 - 300, the observed pair");
+
+    assert_eq!(
+        model.anomalies().reused_range_ids,
+        1,
+        "the id reuse is a property of the stream, not of this group"
+    );
+}
+
+#[test]
+fn range_statistics_flags_a_saturated_total() {
+    // Two spans whose durations sum past `u64::MAX`. The total stops being a
+    // sum, and `saturated` is what says so — otherwise `u64::MAX` reads as a
+    // real measurement.
+    let events = vec![
+        range_push(0, 1, 1, "huge"),
+        range_pop(u64::MAX, 1, 1),
+        range_push(0, 1, 2, "huge"),
+        range_pop(u64::MAX, 1, 2),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    let huge = stats.get(&key("huge", 1)).expect("huge");
+    assert_eq!(huge.observed_count, 2);
+    assert_eq!(huge.total_duration, u64::MAX);
+    assert!(huge.saturated, "the total is capped, not summed");
+    assert_eq!(huge.max_duration, u64::MAX, "each span on its own is exact");
+}
+
+#[test]
+fn range_statistics_where_covers_only_the_kept_spans() {
+    // A windowed view must report figures for the spans it is showing. The
+    // whole-model fold would describe a different population than the chart.
+    let events = vec![
+        range_push(100, 1, 1, "work"),
+        range_pop(200, 1, 1),
+        range_push(1000, 1, 1, "work"),
+        range_pop(1300, 1, 1),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    let whole = model.range_statistics();
+    assert_eq!(whole.get(&key("work", 1)).expect("work").count, 2);
+
+    // Keep only what overlaps [0, 500).
+    let windowed = model.range_statistics_where(|span| span.start < 500);
+    let work = windowed.get(&key("work", 1)).expect("work");
+    assert_eq!(work.count, 1);
+    assert_eq!(work.total_duration, 100);
+    assert_eq!(work.max_duration, 100, "the 300ns range is out of window");
+}
+
+#[test]
+fn trace_bounds_are_not_the_span_extremes() {
+    // The last event is a mark, and the first range never ends at all because
+    // its id was reused. Neither bound is recoverable from the spans.
+    let events = vec![
+        range_start(100, 1, 7, "first"),
+        range_start(300, 1, 7, "second"),
+        range_end(400, 1, 7),
+        mark(900, 1, "after everything closed"),
+    ];
+
+    let model = NvtxModelBuilder::build(events);
+
+    assert_eq!(model.trace_start(), 100);
+    assert_eq!(
+        model.trace_end(),
+        900,
+        "observation stopped at the mark, past the last span end"
+    );
+
+    let last_span_end = model.spans().iter().filter_map(|span| span.end).max();
+    assert_eq!(last_span_end, Some(400));
+    assert_ne!(
+        Some(model.trace_end()),
+        last_span_end,
+        "the largest span end is not a substitute for the trace end"
+    );
+}
+
+#[test]
+fn trace_bounds_of_an_empty_capture() {
+    let model = NvtxModelBuilder::build(vec![]);
+    assert_eq!(model.trace_start(), 0);
+    assert_eq!(model.trace_end(), 0);
+}
+
+#[test]
+fn range_statistics_zero_duration_and_empty() {
+    // A zero-length range contributes 0 rather than being dropped, and a stream
+    // with no ranges at all yields no groups (never a division by zero).
+    let model = NvtxModelBuilder::build(vec![mark(100, 1, "only a mark")]);
+    assert!(model.range_statistics().is_empty());
+
+    let events = vec![range_push(100, 1, 1, "instant"), range_pop(100, 1, 1)];
+    let model = NvtxModelBuilder::build(events);
+    let stats = model.range_statistics();
+
+    let instant = stats.get(&key("instant", 1)).expect("instant");
+    assert_eq!(
+        *instant,
+        RangeStats {
+            count: 1,
+            observed_count: 1,
+            total_duration: 0,
+            avg_duration: 0,
+            min_duration: 0,
+            max_duration: 0,
+            saturated: false,
+        }
+    );
+}


### PR DESCRIPTION
## Summary

Closes #372. Adds `integrations/nvtx/analyzer` — a framework-free reconstruction core turning a captured `Event<NvtxEventEntity>` stream into a labeled `NvtxModel`. No dependency on any legacy macros.

**Two passes.** The first orders by timestamp and learns every handle registration; the second replays against those tables. By then neither arrival order nor forward references matter.

**Four match keys**, each chosen because the alternatives fail silently rather than loudly:

| Construct | Key | Why not coarser |
|---|---|---|
| `RangeStart`/`RangeEnd` | `range_id` alone | Ids come from one process-global counter, so they match across threads and domains; the domain on an end is redundant |
| `RangePush`/`RangePop` | stack per `(thread_id, domain)` | A global stack closes another thread's push and reconstructs believable-but-wrong nesting |
| Resource create/destroy | bare handle | The destroy carries no domain; keying on the pair makes every resource reconstruct as a leak |
| Registered strings, category names | per domain | Handle values and small category ids collide across domains |

Kind-conditional fields live in `SpanKind` variant data — thread and parent on `PushPop`, identifier type on `Resource` — so a start/end range with a thread is unrepresentable rather than merely undocumented.

**Tolerance.** Nothing is substituted for what the stream never said. An open with no close keeps everything the open stated and ends `None`, as does one whose key was reused while still open. A close with no open yields no span — the closing events carry only a correlation key, with no name or attributes to build one from. Both that and the reuse are counted in `ReconstructionAnomalies`. Drains sort for determinism, arithmetic is saturating or checked throughout, and unresolved handles get placeholders that are pure functions of the raw id, so they cannot pass as real names.

**Statistics.** `RangeStats` per `(name, domain, category)` — count and total/avg/min/max duration. Marks have no duration and resource lifespans measure existence rather than work, so neither participates; a span whose close was never captured raises `count` without raising `observed_count`.

## Test plan

- [x] `cargo test -p nvtx-analyzer` — 33 tests, hermetic
- [x] `pixi run cargo test -p nvtx-analyzer --features real-capture-tests` — adds the roundtrip over a real in-process capture (needs pixi for the nvtx-c headers)
- [x] `pixi run cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `pixi run cargo fmt --all -- --check`

Generated with [Claude Code](https://claude.com/claude-code)