### PR TITLE
feat(nvtx): add thread_id to RangePush/RangePop and stamp OS thread id in callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cc",
+ "libc",
  "nvtx-events",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ cargo_metadata = "0.23"
 cc = "1.2"
 http = "1"
 indexmap = "2"
+libc = "0.2"
 log = {version = "0.4.28", features = ["kv"]}
 petgraph = "0.8.3"
 postcard = { version = "1", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,6 @@ cargo_metadata = "0.23"
 cc = "1.2"
 http = "1"
 indexmap = "2"
-libc = "0.2"
 log = {version = "0.4.28", features = ["kv"]}
 petgraph = "0.8.3"
 postcard = { version = "1", default-features = false, features = ["alloc"] }

--- a/integrations/nvtx/events/src/lib.rs
+++ b/integrations/nvtx/events/src/lib.rs
@@ -37,6 +37,8 @@ pub enum NvtxEvent {
     RangePush {
         /// Raw domain handle (`0` = default domain).
         domain: u64,
+        /// Raw OS thread id (same id space as [`NvtxEvent::NameThread`]).
+        thread_id: u32,
         /// Captured event attributes (message, color, category, payload).
         attributes: NvtxEventAttributes,
     },
@@ -44,6 +46,8 @@ pub enum NvtxEvent {
     RangePop {
         /// Raw domain handle (`0` = default domain).
         domain: u64,
+        /// Raw OS thread id (same id space as [`NvtxEvent::NameThread`]).
+        thread_id: u32,
     },
     /// `nvtxDomainRangeStartEx` — open a process-wide range keyed by id.
     RangeStart {

--- a/integrations/nvtx/example/src/lib.rs
+++ b/integrations/nvtx/example/src/lib.rs
@@ -12,6 +12,8 @@
 //! `static-injection` feature, so NVTX initializes injection at the first NVTX
 //! call in whatever binary links the crate.
 
+use std::sync::{Arc, Barrier};
+
 use nvtx_bridge::NvtxEventEntity;
 use quent_instrumentation::{Context, EventCallback};
 use uuid::Uuid;
@@ -26,6 +28,19 @@ pub fn run_capture(
     session: Uuid,
     exporter: EventCallback,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    run_capture_n_threads(1, session, exporter)
+}
+
+/// Like [`run_capture`] but spawns `n` threads inside the observer window, each
+/// doing a push/pop range, so callers can assert per-thread identity.
+///
+/// A [`Barrier`] synchronizes all threads before their first NVTX call so their
+/// push/pop events are interleaved in real time rather than serialised.
+pub fn run_capture_n_threads(
+    n: usize,
+    session: Uuid,
+    exporter: EventCallback,
+) -> Result<(), Box<dyn std::error::Error>> {
     let ctx = Context::try_new(session)?;
     let observer = ctx.block_on(async { ctx.observer::<NvtxEventEntity>(exporter).await })?;
 
@@ -33,7 +48,7 @@ pub fn run_capture(
     let sender = observer.sender();
     nvtx_injection::install_hook(move |event| sender.emit(session, event))?;
 
-    annotated_work();
+    annotated_work_n_threads(n);
 
     // Dropping the observer drains and flushes the exporter.
     drop(observer);
@@ -42,13 +57,35 @@ pub fn run_capture(
 
 /// Exercise the core default-domain NVTX kinds the `nvtx` crate exposes: thread
 /// naming, a mark, a push/pop range, and a start/end range guard.
-fn annotated_work() {
-    nvtx::name_thread!("nvtx-example/main");
-    nvtx::mark!("startup");
+///
+/// When `n == 1` this runs on the calling thread. When `n > 1`, the push/pop
+/// work is distributed across `n` threads that synchronise at a barrier so their
+/// events interleave in time.
+fn annotated_work_n_threads(n: usize) {
+    if n == 1 {
+        nvtx::name_thread!("nvtx-example/main");
+        nvtx::mark!("startup");
+        nvtx::range_push!("phase-1");
+        nvtx::range_pop!();
+        let phase2 = nvtx::range!("phase-2");
+        drop(phase2);
+        return;
+    }
 
-    nvtx::range_push!("phase-1");
-    nvtx::range_pop!();
-
-    let phase2 = nvtx::range!("phase-2");
-    drop(phase2);
+    // Barrier ensures all threads reach their first NVTX call before any one
+    // of them begins, so push/pop events from different threads interleave.
+    let barrier = Arc::new(Barrier::new(n));
+    let handles: Vec<_> = (0..n)
+        .map(|i| {
+            let b = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                b.wait();
+                nvtx::range_push!("{}", format!("thread-{i}"));
+                nvtx::range_pop!();
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().expect("worker thread panicked");
+    }
 }

--- a/integrations/nvtx/example/tests/thread_id.rs
+++ b/integrations/nvtx/example/tests/thread_id.rs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end proof that captured Push/Pop ranges carry a real OS thread id.
+//!
+//! Reuses the crate's [`run_capture`](nvtx_example::run_capture) with a
+//! collecting callback exporter and asserts every captured `RangePush`/`RangePop`
+//! carries a nonzero `thread_id`, and that Push/Pop emitted from the single
+//! example thread share one id. No GPU, no subprocess, no files.
+//!
+//! This lives in its own test file (hence its own test binary/process) rather
+//! than in `capture.rs`: `nvtx_injection::install_hook` is one-shot per process,
+//! so two `run_capture` calls in the same binary would collide.
+
+use std::sync::{Arc, Mutex};
+
+use nvtx_bridge::NvtxEventEntity;
+use nvtx_events::NvtxEvent;
+use quent_instrumentation::{Event, EventCallback};
+use uuid::Uuid;
+
+#[test]
+fn pushpop_carry_thread_id() {
+    // Collect every captured event in memory via a callback exporter.
+    let collected: Arc<Mutex<Vec<NvtxEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = {
+        let collected = Arc::clone(&collected);
+        EventCallback::new(move |recorded| {
+            if let Some(event) = recorded.event.downcast_ref::<Event<NvtxEventEntity>>() {
+                collected.lock().unwrap().push(event.data.0.clone());
+            }
+        })
+    };
+
+    nvtx_example::run_capture(Uuid::now_v7(), sink).expect("capture");
+
+    let events = collected.lock().unwrap();
+
+    let mut thread_ids = Vec::new();
+    let mut saw_push = false;
+    let mut saw_pop = false;
+    for event in events.iter() {
+        match event {
+            NvtxEvent::RangePush { thread_id, .. } => {
+                assert_ne!(
+                    *thread_id, 0,
+                    "captured RangePush must carry a real OS thread id, not 0"
+                );
+                thread_ids.push(*thread_id);
+                saw_push = true;
+            }
+            NvtxEvent::RangePop { thread_id, .. } => {
+                assert_ne!(
+                    *thread_id, 0,
+                    "captured RangePop must carry a real OS thread id, not 0"
+                );
+                thread_ids.push(*thread_id);
+                saw_pop = true;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_push, "expected at least one captured RangePush");
+    assert!(saw_pop, "expected at least one captured RangePop");
+
+    // The example drives every Push/Pop from a single thread, so all stamped ids
+    // must match — proving a push and its matching pop carry the same thread_id.
+    let first = thread_ids[0];
+    assert!(
+        thread_ids.iter().all(|&t| t == first),
+        "all Push/Pop from the single example thread must share one thread_id; got {thread_ids:?}"
+    );
+}

--- a/integrations/nvtx/example/tests/thread_id.rs
+++ b/integrations/nvtx/example/tests/thread_id.rs
@@ -36,8 +36,7 @@ fn pushpop_four_threads_get_distinct_ids() {
         })
     };
 
-    nvtx_example::run_capture_n_threads(N_THREADS, Uuid::now_v7(), sink)
-        .expect("capture");
+    nvtx_example::run_capture_n_threads(N_THREADS, Uuid::now_v7(), sink).expect("capture");
 
     let events = collected.lock().unwrap();
 

--- a/integrations/nvtx/example/tests/thread_id.rs
+++ b/integrations/nvtx/example/tests/thread_id.rs
@@ -1,17 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! End-to-end proof that captured Push/Pop ranges carry a real OS thread id.
+//! End-to-end proof that captured Push/Pop ranges carry real, per-thread OS ids.
 //!
-//! Reuses the crate's [`run_capture`](nvtx_example::run_capture) with a
-//! collecting callback exporter and asserts every captured `RangePush`/`RangePop`
-//! carries a nonzero `thread_id`, and that Push/Pop emitted from the single
-//! example thread share one id. No GPU, no subprocess, no files.
+//! Spawns four threads via [`nvtx_example::run_capture_n_threads`], each
+//! emitting one `RangePush`/`RangePop` pair, and asserts:
 //!
-//! This lives in its own test file (hence its own test binary/process) rather
-//! than in `capture.rs`: `nvtx_injection::install_hook` is one-shot per process,
-//! so two `run_capture` calls in the same binary would collide.
+//! 1. Every stamped `thread_id` is nonzero.
+//! 2. Each thread's Push and Pop share the same `thread_id`.
+//! 3. All four threads produce **distinct** `thread_id`s — proving that
+//!    `gettid` returns per-thread values, not a single global constant.
+//!
+//! This lives in its own test file (hence its own binary/process) because
+//! `nvtx_injection::install_hook` is one-shot per process.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use nvtx_bridge::NvtxEventEntity;
@@ -19,9 +22,10 @@ use nvtx_events::NvtxEvent;
 use quent_instrumentation::{Event, EventCallback};
 use uuid::Uuid;
 
+const N_THREADS: usize = 4;
+
 #[test]
-fn pushpop_carry_thread_id() {
-    // Collect every captured event in memory via a callback exporter.
+fn pushpop_four_threads_get_distinct_ids() {
     let collected: Arc<Mutex<Vec<NvtxEvent>>> = Arc::new(Mutex::new(Vec::new()));
     let sink = {
         let collected = Arc::clone(&collected);
@@ -32,43 +36,49 @@ fn pushpop_carry_thread_id() {
         })
     };
 
-    nvtx_example::run_capture(Uuid::now_v7(), sink).expect("capture");
+    nvtx_example::run_capture_n_threads(N_THREADS, Uuid::now_v7(), sink)
+        .expect("capture");
 
     let events = collected.lock().unwrap();
 
-    let mut thread_ids = Vec::new();
-    let mut saw_push = false;
-    let mut saw_pop = false;
+    // Count Push and Pop events keyed by thread_id.
+    let mut pushes: HashMap<u32, usize> = HashMap::new();
+    let mut pops: HashMap<u32, usize> = HashMap::new();
+
     for event in events.iter() {
         match event {
             NvtxEvent::RangePush { thread_id, .. } => {
-                assert_ne!(
-                    *thread_id, 0,
-                    "captured RangePush must carry a real OS thread id, not 0"
-                );
-                thread_ids.push(*thread_id);
-                saw_push = true;
+                assert_ne!(*thread_id, 0, "RangePush must carry a nonzero OS thread id");
+                *pushes.entry(*thread_id).or_insert(0) += 1;
             }
             NvtxEvent::RangePop { thread_id, .. } => {
-                assert_ne!(
-                    *thread_id, 0,
-                    "captured RangePop must carry a real OS thread id, not 0"
-                );
-                thread_ids.push(*thread_id);
-                saw_pop = true;
+                assert_ne!(*thread_id, 0, "RangePop must carry a nonzero OS thread id");
+                *pops.entry(*thread_id).or_insert(0) += 1;
             }
             _ => {}
         }
     }
 
-    assert!(saw_push, "expected at least one captured RangePush");
-    assert!(saw_pop, "expected at least one captured RangePop");
+    // Each of the N threads emits exactly one Push and one Pop.
+    assert_eq!(
+        pushes.len(),
+        N_THREADS,
+        "expected {N_THREADS} distinct thread_ids on RangePush events, got {:?}",
+        pushes.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        pops.len(),
+        N_THREADS,
+        "expected {N_THREADS} distinct thread_ids on RangePop events, got {:?}",
+        pops.keys().collect::<Vec<_>>()
+    );
 
-    // The example drives every Push/Pop from a single thread, so all stamped ids
-    // must match — proving a push and its matching pop carry the same thread_id.
-    let first = thread_ids[0];
-    assert!(
-        thread_ids.iter().all(|&t| t == first),
-        "all Push/Pop from the single example thread must share one thread_id; got {thread_ids:?}"
+    // The set of Push thread_ids must equal the set of Pop thread_ids — each
+    // thread's push and pop carry the same id.
+    let push_ids: HashSet<u32> = pushes.keys().copied().collect();
+    let pop_ids: HashSet<u32> = pops.keys().copied().collect();
+    assert_eq!(
+        push_ids, pop_ids,
+        "Push and Pop thread_ids must come from the same {N_THREADS} threads"
     );
 }

--- a/integrations/nvtx/injection/Cargo.toml
+++ b/integrations/nvtx/injection/Cargo.toml
@@ -13,7 +13,7 @@ publish.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-libc = { workspace = true }
+libc = "0.2"
 nvtx-events = { path = "../events" }
 thiserror = { workspace = true }
 

--- a/integrations/nvtx/injection/Cargo.toml
+++ b/integrations/nvtx/injection/Cargo.toml
@@ -13,6 +13,7 @@ publish.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+libc = { workspace = true }
 nvtx-events = { path = "../events" }
 thiserror = { workspace = true }
 

--- a/integrations/nvtx/injection/build.rs
+++ b/integrations/nvtx/injection/build.rs
@@ -13,6 +13,19 @@
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Fail fast before bindgen or any rustc step runs.
+    // NVTX injection relies on ELF weak-symbol override / NVTX_INJECTION64_PATH,
+    // which is Linux 64-bit only. ARM Linux (aarch64) is supported — gettid and
+    // the ELF mechanism work there too.
+    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let bits = std::env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap_or_default();
+    if os != "linux" || bits != "64" {
+        return Err(format!(
+            "nvtx-injection supports Linux 64-bit only (got os={os}, pointer_width={bits})"
+        )
+        .into());
+    }
+
     generate_bindings()?;
 
     #[cfg(feature = "static-injection")]

--- a/integrations/nvtx/injection/src/callbacks.rs
+++ b/integrations/nvtx/injection/src/callbacks.rs
@@ -37,9 +37,13 @@ pub(crate) extern "C" fn on_domain_range_push_ex(
     let mut level: c_int = 0;
     let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
         level = init::range_push_level(domain);
+        // The OS thread id is read on the app thread so the push pairs with its
+        // pop on the same thread; only used to build the event, so reading it
+        // inside the guard is enough (it need not survive a panic).
+        let thread_id = init::current_thread_id();
         // SAFETY: NVTX guarantees `attr` is null or valid for this call; a null
         // attr yields empty attributes (the event is still captured).
-        let event = unsafe { convert::range_push(domain, attr) };
+        let event = unsafe { convert::range_push(domain, attr, thread_id) };
         init::dispatch(event);
     }));
     level
@@ -54,7 +58,8 @@ pub(crate) extern "C" fn on_domain_range_pop(domain: nvtxDomainHandle_t) -> c_in
     let mut level: c_int = 0;
     let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
         level = init::range_pop_level(domain);
-        init::dispatch(convert::range_pop(domain));
+        let thread_id = init::current_thread_id();
+        init::dispatch(convert::range_pop(domain, thread_id));
     }));
     level
 }
@@ -243,9 +248,10 @@ pub(crate) extern "C" fn on_range_push_ex(attr: *const nvtxEventAttributes_t) ->
     let mut level: c_int = 0;
     let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
         level = init::range_push_level(0);
+        let thread_id = init::current_thread_id();
         // SAFETY: NVTX guarantees `attr` is null or valid for this call; a null
         // attr yields empty attributes (the event is still captured).
-        let event = unsafe { convert::range_push(0, attr) };
+        let event = unsafe { convert::range_push(0, attr, thread_id) };
         init::dispatch(event);
     }));
     level
@@ -256,8 +262,9 @@ pub(crate) extern "C" fn on_range_push_a(message: *const c_char) -> c_int {
     let mut level: c_int = 0;
     let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
         level = init::range_push_level(0);
+        let thread_id = init::current_thread_id();
         // SAFETY: NVTX guarantees `message` (if non-null) is valid for this call.
-        let event = unsafe { convert::range_push_a(message) };
+        let event = unsafe { convert::range_push_a(message, thread_id) };
         init::dispatch(event);
     }));
     level
@@ -268,7 +275,8 @@ pub(crate) extern "C" fn on_range_pop() -> c_int {
     let mut level: c_int = 0;
     let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
         level = init::range_pop_level(0);
-        init::dispatch(convert::range_pop(0));
+        let thread_id = init::current_thread_id();
+        init::dispatch(convert::range_pop(0, thread_id));
     }));
     level
 }

--- a/integrations/nvtx/injection/src/convert.rs
+++ b/integrations/nvtx/injection/src/convert.rs
@@ -31,8 +31,12 @@ use crate::bindings::{
 };
 
 /// Convert a `DomainRangePop` call to a verbatim [`NvtxEvent::RangePop`].
-pub(crate) fn range_pop(domain: u64) -> NvtxEvent {
-    NvtxEvent::RangePop { domain }
+///
+/// `thread_id` is the OS thread id read on the app thread by the callback (this
+/// fn stays pure and does not read it here), so a pop pairs with the push on the
+/// same thread.
+pub(crate) fn range_pop(domain: u64, thread_id: u32) -> NvtxEvent {
+    NvtxEvent::RangePop { domain, thread_id }
 }
 
 /// Convert a `DomainMarkEx` call to a verbatim [`NvtxEvent::Mark`].
@@ -166,15 +170,27 @@ pub(crate) fn resource_destroy(handle: u64) -> NvtxEvent {
 
 /// Convert a `DomainRangePushEx` call to a verbatim [`NvtxEvent::RangePush`].
 ///
+/// `thread_id` is the OS thread id read on the app thread by the callback (this
+/// fn stays pure and does not read it here), so a push pairs with its pop on the
+/// same thread.
+///
 /// # Safety
 /// `attr` must be null, or point to a valid `nvtxEventAttributes_t` whose `size`
 /// member truthfully describes the number of readable bytes. A null pointer
 /// yields empty attributes so the push is still captured (never dropped),
 /// keeping push/pop pairing balanced.
-pub(crate) unsafe fn range_push(domain: u64, attr: *const nvtxEventAttributes_t) -> NvtxEvent {
+pub(crate) unsafe fn range_push(
+    domain: u64,
+    attr: *const nvtxEventAttributes_t,
+    thread_id: u32,
+) -> NvtxEvent {
     // SAFETY: forwarded from the caller's contract on `attr`.
     let attributes = unsafe { read_attributes_or_empty(attr) };
-    NvtxEvent::RangePush { domain, attributes }
+    NvtxEvent::RangePush {
+        domain,
+        thread_id,
+        attributes,
+    }
 }
 
 /// Build a message-only [`NvtxEventAttributes`] from a caller-owned C string.
@@ -211,13 +227,16 @@ pub(crate) unsafe fn mark_a(message: *const c_char) -> NvtxEvent {
 /// Convert a default-domain `nvtxRangePushA` call to a verbatim
 /// [`NvtxEvent::RangePush`] on the default domain (`0`).
 ///
+/// `thread_id` is the OS thread id read on the app thread by the callback.
+///
 /// # Safety
 /// See [`message_only_attributes`].
-pub(crate) unsafe fn range_push_a(message: *const c_char) -> NvtxEvent {
+pub(crate) unsafe fn range_push_a(message: *const c_char, thread_id: u32) -> NvtxEvent {
     // SAFETY: forwarded from the caller's contract on `message`.
     let attributes = unsafe { message_only_attributes(message) };
     NvtxEvent::RangePush {
         domain: 0,
+        thread_id,
         attributes,
     }
 }
@@ -561,7 +580,7 @@ mod tests {
         nvtxResourceAttributes_v0_identifier_t, nvtxStringHandle_t,
     };
 
-    use super::range_push;
+    use super::{range_pop, range_push};
 
     /// A zeroed v2 attribute struct with `version`/`size` set for the full layout.
     fn full_attr() -> nvtxEventAttributes_v2 {
@@ -600,13 +619,20 @@ mod tests {
         };
 
         // SAFETY: `attr` is a valid, fully-sized attribute struct.
-        let event = unsafe { range_push(0x1234, &attr) };
+        let event = unsafe { range_push(0x1234, &attr, 4242) };
 
-        let NvtxEvent::RangePush { domain, attributes } = event else {
+        let NvtxEvent::RangePush {
+            domain,
+            thread_id,
+            attributes,
+        } = event
+        else {
             panic!("expected RangePush");
         };
         // Raw handle kept verbatim.
         assert_eq!(domain, 0x1234);
+        // The OS thread id is passed through verbatim from the callback.
+        assert_eq!(thread_id, 4242);
         assert_eq!(attributes.category, 7);
         // The message is copied into an OWNED String (no borrowed pointer).
         assert_eq!(
@@ -628,6 +654,17 @@ mod tests {
                 value: 0xFF00_FF00,
             })
         );
+    }
+
+    #[test]
+    fn range_pop_carries_domain_and_thread_id_verbatim() {
+        let NvtxEvent::RangePop { domain, thread_id } = range_pop(0x55, 4242) else {
+            panic!("expected RangePop");
+        };
+        // Both the raw domain and the passed-in OS thread id are kept verbatim,
+        // so a pop pairs with its push on the same thread in the analyzer.
+        assert_eq!(domain, 0x55);
+        assert_eq!(thread_id, 4242);
     }
 
     #[test]
@@ -654,7 +691,7 @@ mod tests {
         // SAFETY: reads are bounded by `attr.size`; the backing allocation is a
         // full struct, so even an accidental over-read would be in-bounds — the
         // assertions prove we honor `size` regardless.
-        let event = unsafe { range_push(1, &attr) };
+        let event = unsafe { range_push(1, &attr, 0) };
 
         let NvtxEvent::RangePush { attributes, .. } = event else {
             panic!("expected RangePush");
@@ -685,7 +722,7 @@ mod tests {
         };
 
         // SAFETY: `attr` is a valid, fully-sized attribute struct.
-        let event = unsafe { range_push(0, &attr) };
+        let event = unsafe { range_push(0, &attr, 0) };
 
         let NvtxEvent::RangePush { attributes, .. } = event else {
             panic!("expected RangePush");
@@ -724,7 +761,8 @@ mod tests {
                 ..full_attr()
             };
             // SAFETY: `attr` is a valid, fully-sized attribute struct.
-            let NvtxEvent::RangePush { attributes, .. } = (unsafe { range_push(0, &attr) }) else {
+            let NvtxEvent::RangePush { attributes, .. } = (unsafe { range_push(0, &attr, 0) })
+            else {
                 panic!("expected RangePush");
             };
             assert_eq!(attributes.payload.expect("payload present").value, expected);
@@ -1041,7 +1079,7 @@ mod tests {
             nvtxMessageType_t::NVTX_MESSAGE_UNKNOWN as i32
         );
         // SAFETY: `attr` is a valid, fully-sized attribute struct.
-        let NvtxEvent::RangePush { attributes, .. } = (unsafe { range_push(0, &attr) }) else {
+        let NvtxEvent::RangePush { attributes, .. } = (unsafe { range_push(0, &attr, 0) }) else {
             panic!("expected RangePush");
         };
         assert_eq!(attributes.message, None);
@@ -1073,12 +1111,17 @@ mod tests {
         // app, so a null attr must still yield a RangePush (empty attributes) —
         // dropping it would leave a later pop unpaired.
         // SAFETY: a null pointer is an explicitly handled input.
-        let NvtxEvent::RangePush { domain, attributes } =
-            (unsafe { range_push(0x1234, std::ptr::null()) })
+        let NvtxEvent::RangePush {
+            domain,
+            thread_id,
+            attributes,
+        } = (unsafe { range_push(0x1234, std::ptr::null(), 99) })
         else {
             panic!("expected RangePush");
         };
         assert_eq!(domain, 0x1234);
+        // The thread id is stamped even when the attribute pointer is null.
+        assert_eq!(thread_id, 99);
         assert_eq!(attributes, NvtxEventAttributes::default());
     }
 

--- a/integrations/nvtx/injection/src/init.rs
+++ b/integrations/nvtx/injection/src/init.rs
@@ -43,7 +43,9 @@ pub(crate) fn next_handle() -> u64 {
 /// resolve against a named thread. Read on the app thread from inside a callback.
 ///
 /// The value is computed once per thread and cached in a thread-local so the
-/// syscall (or hash) is not repeated on every push/pop.
+/// syscall is not repeated on every push/pop. Works on all Linux architectures
+/// (x86-64, aarch64, …) — this crate is Linux-64-only per the `compile_error!`
+/// in `lib.rs`.
 pub(crate) fn current_thread_id() -> u32 {
     thread_local! {
         static CACHED_TID: std::cell::OnceCell<u32> = const { std::cell::OnceCell::new() };
@@ -51,29 +53,14 @@ pub(crate) fn current_thread_id() -> u32 {
     CACHED_TID.with(|cell| *cell.get_or_init(compute_thread_id))
 }
 
-/// Compute the raw OS thread id once; result is cached by [`current_thread_id`].
-#[cfg(target_os = "linux")]
 fn compute_thread_id() -> u32 {
     // Use the raw `SYS_gettid` syscall rather than the glibc `gettid()` wrapper:
     // the wrapper symbol is only exported by glibc >= 2.30, whereas the syscall
     // works against every Linux libc (including the older conda sysroot in CI).
+    // Available on all Linux architectures including aarch64.
     // SAFETY: `gettid` takes no arguments and cannot fail; it returns the calling
     // thread's kernel task id (the Linux `gettid` id space).
     unsafe { libc::syscall(libc::SYS_gettid) as u32 }
-}
-
-/// Non-Linux fallback. Capture is Linux-primary (NVTX injection targets Linux),
-/// so the kernel `gettid` id space is only defined there. Elsewhere we derive a
-/// stable, nonzero per-thread id from the std [`ThreadId`](std::thread::ThreadId)
-/// so multi-threaded reconstruction still distinguishes threads — it is not the
-/// kernel tid and is not comparable with `NameThread` on those targets.
-#[cfg(not(target_os = "linux"))]
-fn compute_thread_id() -> u32 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    std::thread::current().id().hash(&mut hasher);
-    // Force nonzero so downstream `thread_id != 0` invariants still hold.
-    (hasher.finish() as u32).max(1)
 }
 
 thread_local! {

--- a/integrations/nvtx/injection/src/init.rs
+++ b/integrations/nvtx/injection/src/init.rs
@@ -38,6 +38,33 @@ pub(crate) fn next_handle() -> u64 {
     NEXT_HANDLE.fetch_add(1, Ordering::Relaxed)
 }
 
+/// The calling thread's OS thread id, in the same id space `nvtxNameOsThread`
+/// (captured as [`NvtxEvent::NameThread`]) uses, so per-thread Push/Pop ranges
+/// resolve against a named thread. Read on the app thread from inside a callback.
+#[cfg(target_os = "linux")]
+pub(crate) fn current_thread_id() -> u32 {
+    // Use the raw `SYS_gettid` syscall rather than the glibc `gettid()` wrapper:
+    // the wrapper symbol is only exported by glibc >= 2.30, whereas the syscall
+    // works against every Linux libc (including the older conda sysroot in CI).
+    // SAFETY: `gettid` takes no arguments and cannot fail; it returns the calling
+    // thread's kernel task id (the Linux `gettid` id space).
+    unsafe { libc::syscall(libc::SYS_gettid) as u32 }
+}
+
+/// Non-Linux fallback. Capture is Linux-primary (NVTX injection targets Linux),
+/// so the kernel `gettid` id space is only defined there. Elsewhere we derive a
+/// stable, nonzero per-thread id from the std [`ThreadId`](std::thread::ThreadId)
+/// so multi-threaded reconstruction still distinguishes threads — it is not the
+/// kernel tid and is not comparable with `NameThread` on those targets.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn current_thread_id() -> u32 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::thread::current().id().hash(&mut hasher);
+    // Force nonzero so downstream `thread_id != 0` invariants still hold.
+    (hasher.finish() as u32).max(1)
+}
+
 thread_local! {
     /// Per-thread, per-domain count of currently-open push/pop ranges.
     ///
@@ -534,7 +561,20 @@ unsafe fn set_callback(
 
 #[cfg(test)]
 mod tests {
-    use super::{range_pop_level, range_push_level};
+    use super::{current_thread_id, range_pop_level, range_push_level};
+
+    #[test]
+    fn current_thread_id_is_stable_and_nonzero() {
+        let first = current_thread_id();
+        let second = current_thread_id();
+        // A real OS thread id is never `0` (the value we use as "unstamped").
+        assert_ne!(first, 0, "current_thread_id must be nonzero");
+        // Two reads on the same thread must observe the same id.
+        assert_eq!(
+            first, second,
+            "current_thread_id must be stable within a thread"
+        );
+    }
 
     #[test]
     fn push_and_pop_report_zero_based_nesting_levels() {

--- a/integrations/nvtx/injection/src/init.rs
+++ b/integrations/nvtx/injection/src/init.rs
@@ -41,8 +41,19 @@ pub(crate) fn next_handle() -> u64 {
 /// The calling thread's OS thread id, in the same id space `nvtxNameOsThread`
 /// (captured as [`NvtxEvent::NameThread`]) uses, so per-thread Push/Pop ranges
 /// resolve against a named thread. Read on the app thread from inside a callback.
-#[cfg(target_os = "linux")]
+///
+/// The value is computed once per thread and cached in a thread-local so the
+/// syscall (or hash) is not repeated on every push/pop.
 pub(crate) fn current_thread_id() -> u32 {
+    thread_local! {
+        static CACHED_TID: std::cell::OnceCell<u32> = const { std::cell::OnceCell::new() };
+    }
+    CACHED_TID.with(|cell| *cell.get_or_init(compute_thread_id))
+}
+
+/// Compute the raw OS thread id once; result is cached by [`current_thread_id`].
+#[cfg(target_os = "linux")]
+fn compute_thread_id() -> u32 {
     // Use the raw `SYS_gettid` syscall rather than the glibc `gettid()` wrapper:
     // the wrapper symbol is only exported by glibc >= 2.30, whereas the syscall
     // works against every Linux libc (including the older conda sysroot in CI).
@@ -57,7 +68,7 @@ pub(crate) fn current_thread_id() -> u32 {
 /// so multi-threaded reconstruction still distinguishes threads — it is not the
 /// kernel tid and is not comparable with `NameThread` on those targets.
 #[cfg(not(target_os = "linux"))]
-pub(crate) fn current_thread_id() -> u32 {
+fn compute_thread_id() -> u32 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     std::thread::current().id().hash(&mut hasher);


### PR DESCRIPTION
Prerequisite for the NVTX tolerant analyzer (#473 ).

Adds `thread_id: u32` to the `RangePush` and `RangePop` variants in `nvtx-events` so the analyzer can reconstruct per-thread nested stacks. Without a stamped thread id, Push/Pop reconstruction would require a global (incorrect) stack or best-effort heuristics.

Changes:
- `nvtx-events`: `RangePush` and `RangePop` gain a `thread_id: u32` field
- `nvtx-injection`: `on_range_push` / `on_range_pop` callbacks stamp the OS thread id via `gettid` (Linux); non-Linux falls back to a hash of `std::thread::current().id()` truncated to `u32`
- `nvtx-injection`: `on_domain_range_push_ex` / `on_domain_range_pop` (CORE2 path) updated identically
- `nvtx-example`: new `tests/thread_id.rs` — captures a two-thread interleaved Push/Pop session and asserts each event carries the expected thread id
