### PR TITLE
fix(time): keep arrival order for equal timestamps in TimeOrderedCollector

### DIFF
--- a/crates/time/src/lib.rs
+++ b/crates/time/src/lib.rs
@@ -124,10 +124,7 @@ pub trait Timestamp {
 /// in which case [`Self::push`] is O(1). Out-of-order items are inserted via
 /// binary search (O(log n) search + O(n) insertion).
 ///
-/// The ordering is **stable**: items sharing a timestamp keep their arrival
-/// order regardless of which insertion path they took. This matters when equal
-/// timestamps mean the clock lost the ordering, leaving arrival order as the
-/// only remaining signal for which item came first.
+/// Stable: items with equal timestamps keep their arrival order.
 pub struct TimeOrderedCollector<T>(Vec<T>);
 
 impl<T> Default for TimeOrderedCollector<T> {
@@ -146,10 +143,8 @@ where
         {
             self.0.push(state);
         } else {
-            // `<=`, not `<`: this must be the *upper* bound so a late arrival
-            // lands after items it ties with, matching the fast path above.
-            // A `<` here is the lower bound, which would insert it *before*
-            // them and silently reverse the arrival order of equal timestamps.
+            // `<=` (upper bound): late arrivals land after ties, matching the fast path.
+            // `<` (lower bound) would insert before ties, reversing arrival order.
             let pos = self
                 .0
                 .partition_point(|s| s.timestamp() <= state.timestamp());
@@ -213,8 +208,6 @@ mod collector_tests {
         );
     }
 
-    /// A tie reached via the fast path (monotonically non-decreasing arrivals)
-    /// keeps arrival order.
     #[test]
     fn equal_timestamps_keep_arrival_order_on_the_fast_path() {
         assert_eq!(
@@ -223,16 +216,10 @@ mod collector_tests {
         );
     }
 
-    /// The same tie reached via the *slow* path must also keep arrival order.
-    ///
-    /// Regression: the binary search used a `<` predicate (lower bound), which
-    /// inserted a late arrival *before* every item it tied with — reversing the
-    /// two. Only the slow path was affected, so a stream that never went
-    /// backwards in time hid the bug entirely.
+    /// Regression: `<` predicate (lower bound) reversed arrival order on the slow path.
     #[test]
     fn equal_timestamps_keep_arrival_order_on_the_slow_path() {
-        // "later" forces the next push off the fast path; "second" then ties
-        // with "first", which is no longer the last element.
+        // t=20 "later" triggers the slow path for the subsequent t=10 "second".
         assert_eq!(
             collect([
                 Tagged(10, "first"),
@@ -243,7 +230,6 @@ mod collector_tests {
         );
     }
 
-    /// Stability holds across a run of equals inserted out of order.
     #[test]
     fn equal_timestamps_keep_arrival_order_across_a_run() {
         assert_eq!(

--- a/crates/time/src/lib.rs
+++ b/crates/time/src/lib.rs
@@ -123,6 +123,11 @@ pub trait Timestamp {
 /// Optimized for when the common case is that items arrive in timestamp order,
 /// in which case [`Self::push`] is O(1). Out-of-order items are inserted via
 /// binary search (O(log n) search + O(n) insertion).
+///
+/// The ordering is **stable**: items sharing a timestamp keep their arrival
+/// order regardless of which insertion path they took. This matters when equal
+/// timestamps mean the clock lost the ordering, leaving arrival order as the
+/// only remaining signal for which item came first.
 pub struct TimeOrderedCollector<T>(Vec<T>);
 
 impl<T> Default for TimeOrderedCollector<T> {
@@ -141,9 +146,13 @@ where
         {
             self.0.push(state);
         } else {
+            // `<=`, not `<`: this must be the *upper* bound so a late arrival
+            // lands after items it ties with, matching the fast path above.
+            // A `<` here is the lower bound, which would insert it *before*
+            // them and silently reverse the arrival order of equal timestamps.
             let pos = self
                 .0
-                .partition_point(|s| s.timestamp() < state.timestamp());
+                .partition_point(|s| s.timestamp() <= state.timestamp());
             self.0.insert(pos, state);
         }
     }
@@ -161,6 +170,92 @@ where
         for transition in iter {
             self.push(transition)
         }
+    }
+}
+
+#[cfg(test)]
+mod collector_tests {
+    use super::*;
+
+    /// Carries its timestamp plus a tag, so equal-timestamp ordering is visible.
+    #[derive(Debug, PartialEq, Eq)]
+    struct Tagged(TimeUnixNanoSec, &'static str);
+
+    impl Timestamp for Tagged {
+        fn timestamp(&self) -> TimeUnixNanoSec {
+            self.0
+        }
+    }
+
+    fn collect(items: impl IntoIterator<Item = Tagged>) -> Vec<(TimeUnixNanoSec, &'static str)> {
+        let mut collector = TimeOrderedCollector::default();
+        collector.extend(items);
+        collector
+            .into_inner()
+            .into_iter()
+            .map(|Tagged(ts, tag)| (ts, tag))
+            .collect()
+    }
+
+    #[test]
+    fn in_order_arrivals_are_sorted() {
+        assert_eq!(
+            collect([Tagged(10, "a"), Tagged(20, "b"), Tagged(30, "c")]),
+            [(10, "a"), (20, "b"), (30, "c")]
+        );
+    }
+
+    #[test]
+    fn late_arrivals_are_sorted_into_place() {
+        assert_eq!(
+            collect([Tagged(30, "c"), Tagged(10, "a"), Tagged(20, "b")]),
+            [(10, "a"), (20, "b"), (30, "c")]
+        );
+    }
+
+    /// A tie reached via the fast path (monotonically non-decreasing arrivals)
+    /// keeps arrival order.
+    #[test]
+    fn equal_timestamps_keep_arrival_order_on_the_fast_path() {
+        assert_eq!(
+            collect([Tagged(10, "first"), Tagged(10, "second")]),
+            [(10, "first"), (10, "second")]
+        );
+    }
+
+    /// The same tie reached via the *slow* path must also keep arrival order.
+    ///
+    /// Regression: the binary search used a `<` predicate (lower bound), which
+    /// inserted a late arrival *before* every item it tied with — reversing the
+    /// two. Only the slow path was affected, so a stream that never went
+    /// backwards in time hid the bug entirely.
+    #[test]
+    fn equal_timestamps_keep_arrival_order_on_the_slow_path() {
+        // "later" forces the next push off the fast path; "second" then ties
+        // with "first", which is no longer the last element.
+        assert_eq!(
+            collect([
+                Tagged(10, "first"),
+                Tagged(20, "later"),
+                Tagged(10, "second"),
+            ]),
+            [(10, "first"), (10, "second"), (20, "later")]
+        );
+    }
+
+    /// Stability holds across a run of equals inserted out of order.
+    #[test]
+    fn equal_timestamps_keep_arrival_order_across_a_run() {
+        assert_eq!(
+            collect([
+                Tagged(10, "a"),
+                Tagged(10, "b"),
+                Tagged(20, "later"),
+                Tagged(10, "c"),
+                Tagged(10, "d"),
+            ]),
+            [(10, "a"), (10, "b"), (10, "c"), (10, "d"), (20, "later")]
+        );
     }
 }
 


### PR DESCRIPTION
`TimeOrderedCollector::push` has two insertion paths that disagree about where a tie goes:

- **Fast path** (`last.timestamp() <= new`) — appends *after* existing equals.
- **Slow path** — used `partition_point(|s| s.timestamp() < new)`, a *lower* bound, which inserts *before* every item it ties with, reversing their arrival order.

The slow path only runs when the newcomer is older than the last element, so a stream that never goes backwards in time never reaches it. That is why existing coverage missed this — a monotonically non-decreasing stream takes the fast path every time.

Concretely, pushing `[(t=10,a), (t=20,b), (t=10,c)]` yielded `[c, a, b]` — `c` jumped ahead of `a` despite arriving after it.

**Why it matters:** equal timestamps mean the clock lost the ordering, leaving arrival order as the only remaining signal for which item came first. Reversing it silently corrupts reconstruction downstream. For an NVTX push/pop pair sharing a clock tick, it turns a valid zero-duration range into a fabricated duration plus a spurious synthetic close — plausible-looking output, no error raised.

Changes the predicate to `<=` (upper bound) so both paths agree, and adds regression tests that drive the slow path with real ties. The new tests live in their own module because the existing one is gated behind `__test-clock-override`, which is excluded from `default-members`.

Shared by `crates/analyzer` (`fsm/runtime.rs`, `fsm/events.rs`, `resource/runtime.rs`); its suite and the full workspace suite pass unchanged.