### PR TITLE
chore(deps): bump syn to 3 and prettyplease to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "clang-sys",
  "itertools",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -2396,6 +2396,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,7 +2435,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.2.37",
  "prost",
  "prost-types",
  "pulldown-cmark",
@@ -2583,7 +2593,7 @@ name = "quent-codegen"
 version = "0.1.0"
 dependencies = [
  "convert_case",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quent-model",
  "quent-query-engine-model",
@@ -2591,7 +2601,7 @@ dependencies = [
  "quent-simulator-instrumentation",
  "quote",
  "serde",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2703,13 +2713,13 @@ name = "quent-instrumentation-build"
 version = "0.1.0"
 dependencies = [
  "convert_case",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quent-constraints",
  "quent-ref-target",
  "quent-schema",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
  "thiserror",
 ]
 
@@ -2837,7 +2847,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2852,13 +2862,13 @@ dependencies = [
  "flate2",
  "gix-url",
  "open",
- "prettyplease",
+ "prettyplease 0.3.0",
  "quent-build-info",
  "quote",
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.118",
+ "syn 3.0.3",
  "tar",
  "tempfile",
  "thiserror",
@@ -4396,7 +4406,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4419,7 +4429,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "prost-build",
  "prost-types",
@@ -5136,7 +5146,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -5150,7 +5160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,9 @@ indexmap = "2"
 log = {version = "0.4.28", features = ["kv"]}
 petgraph = "0.8.3"
 postcard = { version = "1", default-features = false, features = ["alloc"] }
+# `prettyplease` and `syn` are a matched pair: prettyplease exposes `syn::File`
+# in its public API, so both must move to a new `syn` major version together.
+prettyplease = "0.3.0"
 prost = "0.14.1"
 pyo3 = "0.29"
 quent-resource = { path = "crates/resource" }
@@ -141,6 +144,7 @@ rustc-hash = "2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 smallvec = {version = "1.15.1", features = ["serde"] }
+syn = { version = "3.0.3", features = ["full", "parsing"] }
 thiserror = "2.0.17"
 tokio = "1.48.0"
 tokio-stream = "0.1.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,8 +133,6 @@ indexmap = "2"
 log = {version = "0.4.28", features = ["kv"]}
 petgraph = "0.8.3"
 postcard = { version = "1", default-features = false, features = ["alloc"] }
-# `prettyplease` and `syn` are a matched pair: prettyplease exposes `syn::File`
-# in its public API, so both must move to a new `syn` major version together.
 prettyplease = "0.3.0"
 prost = "0.14.1"
 pyo3 = "0.29"

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -6,15 +6,15 @@ publish.workspace = true
 
 [dependencies]
 convert_case = "0.11"
-prettyplease = "0.2"
+prettyplease = "0.3"
 proc-macro2 = "1"
 quent-model = { path = "../model" }
 quote = "1"
-syn = { version = "2", features = ["full", "parsing"] }
+syn = { version = "3", features = ["full", "parsing"] }
 
 [dev-dependencies]
 quent-query-engine-model = { path = "../../domains/query_engine/model" }
 quent-readme-example = { path = "../../examples/readme" }
 quent-simulator-instrumentation = { path = "../../examples/simulator/instrumentation" }
 serde = { workspace = true, features = ["derive"] }
-syn = { version = "2", features = ["full", "parsing"] }
+syn = { version = "3", features = ["full", "parsing"] }

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -6,15 +6,15 @@ publish.workspace = true
 
 [dependencies]
 convert_case = "0.11"
-prettyplease = "0.3"
+prettyplease.workspace = true
 proc-macro2 = "1"
 quent-model = { path = "../model" }
 quote = "1"
-syn = { version = "3", features = ["full", "parsing"] }
+syn.workspace = true
 
 [dev-dependencies]
 quent-query-engine-model = { path = "../../domains/query_engine/model" }
 quent-readme-example = { path = "../../examples/readme" }
 quent-simulator-instrumentation = { path = "../../examples/simulator/instrumentation" }
 serde = { workspace = true, features = ["derive"] }
-syn = { version = "3", features = ["full", "parsing"] }
+syn.workspace = true

--- a/crates/instrumentation-build/Cargo.toml
+++ b/crates/instrumentation-build/Cargo.toml
@@ -6,13 +6,13 @@ publish.workspace = true
 
 [dependencies]
 convert_case = "0.11"
-prettyplease = "0.3"
+prettyplease.workspace = true
 proc-macro2 = "1"
 quent-constraints = { path = "../constraints" }
 quent-ref-target = { path = "../ref-target" }
 quent-schema = { path = "../schema" }
 quote = "1"
-syn = { version = "3", features = ["full", "parsing"] }
+syn.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/instrumentation-build/Cargo.toml
+++ b/crates/instrumentation-build/Cargo.toml
@@ -6,13 +6,13 @@ publish.workspace = true
 
 [dependencies]
 convert_case = "0.11"
-prettyplease = "0.2"
+prettyplease = "0.3"
 proc-macro2 = "1"
 quent-constraints = { path = "../constraints" }
 quent-ref-target = { path = "../ref-target" }
 quent-schema = { path = "../schema" }
 quote = "1"
-syn = { version = "2", features = ["full", "parsing"] }
+syn = { version = "3", features = ["full", "parsing"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/instrumentation-build/example/Cargo.lock
+++ b/crates/instrumentation-build/example/Cargo.lock
@@ -307,12 +307,12 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -394,7 +394,7 @@ dependencies = [
  "quent-ref-target",
  "quent-schema",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
  "thiserror",
 ]
 

--- a/crates/model-macros/Cargo.toml
+++ b/crates/model-macros/Cargo.toml
@@ -13,6 +13,6 @@ serde = []
 
 [dependencies]
 convert_case = "0.11"
-syn = { version = "3", features = ["full", "extra-traits"] }
+syn = { workspace = true, features = ["extra-traits"] }
 quote = "1"
 proc-macro2 = "1"

--- a/crates/model-macros/Cargo.toml
+++ b/crates/model-macros/Cargo.toml
@@ -13,6 +13,6 @@ serde = []
 
 [dependencies]
 convert_case = "0.11"
-syn = { version = "2", features = ["full", "extra-traits"] }
+syn = { version = "3", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"

--- a/crates/open/Cargo.toml
+++ b/crates/open/Cargo.toml
@@ -25,7 +25,7 @@ dotenvy = { version = "0.15", optional = true }
 flate2 = { version = "1", optional = true }
 gix-url = "0.36"
 open = "5"
-prettyplease = "0.3"
+prettyplease.workspace = true
 quent-build-info = { path = "../build-info" }
 quote = "1"
 # `rustls-tls-native-roots` (OS trust store) rather than `rustls-tls` (bundled
@@ -34,7 +34,7 @@ quote = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json.workspace = true
-syn = { version = "3", features = ["full", "parsing"] }
+syn.workspace = true
 tar = { version = "0.4", optional = true }
 tempfile = { version = "3", optional = true }
 thiserror.workspace = true

--- a/crates/open/Cargo.toml
+++ b/crates/open/Cargo.toml
@@ -25,7 +25,7 @@ dotenvy = { version = "0.15", optional = true }
 flate2 = { version = "1", optional = true }
 gix-url = "0.36"
 open = "5"
-prettyplease = "0.2"
+prettyplease = "0.3"
 quent-build-info = { path = "../build-info" }
 quote = "1"
 # `rustls-tls-native-roots` (OS trust store) rather than `rustls-tls` (bundled
@@ -34,7 +34,7 @@ quote = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json.workspace = true
-syn = { version = "2", features = ["full", "parsing"] }
+syn = { version = "3", features = ["full", "parsing"] }
 tar = { version = "0.4", optional = true }
 tempfile = { version = "3", optional = true }
 thiserror.workspace = true


### PR DESCRIPTION
# Description

Bumps `syn` 2 → 3 and `prettyplease` 0.2 → 0.3 in a single change, because
the two cannot be upgraded independently, and moves both to
`[workspace.dependencies]` so they stay in lockstep going forward.

`prettyplease` 0.3.0 is the first release built against `syn` 3, and it
exposes `syn::File` in its public API. Both `crates/codegen/src/common.rs`
and `crates/open/src/wrapper.rs` construct a `syn::File` and hand it to
`prettyplease::unparse`, so bumping either side alone puts two incompatible
`syn` versions on that boundary and fails to compile:

- syn-only (as in #505): `` the trait `syn::parse::Parse` is not implemented
  for `syn::file::File` `` — `syn::parse2` resolves to syn 3 while the
  inferred `File` comes from syn 2 via prettyplease.
- prettyplease-only: the mirrored `E0308`, `expected syn::file::File`
  (3.0.3), `found syn::File` (2.0.118).

Changes:

- Pin `syn = { version = "3.0.3", features = ["full", "parsing"] }` and
  `prettyplease = "0.3.0"` in `[workspace.dependencies]`
- `crates/codegen`, `crates/open`, `crates/instrumentation-build` and
  `crates/model-macros` now use `workspace = true`; model-macros keeps its
  extra `extra-traits` feature on top of the workspace base
- Regenerated `Cargo.lock` and `crates/instrumentation-build/example/Cargo.lock`

No source changes were needed — the syn 3 APIs used here (`parse2`,
`parse_str`, `File`, derive-input types) are unchanged. `syn 2.0.118` remains
in the lockfile as a transitive dependency of `bindgen`, `prost-build`,
`tonic-build` and `wit-bindgen`, which is expected and does not conflict.

## Related Issues

Supersedes #505 and #513, which split this upgrade across two PRs and
therefore both fail CI.

## Testing

- `pixi run cargo fmt --all --check` — clean
- `pixi run cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `pixi run cargo test --workspace --all-features --locked --all-targets` — all pass
- `pixi run cargo deny check` — advisories, bans, licenses, sources ok
- `cargo test --locked` in `crates/instrumentation-build/example` (its own
  workspace) — builds and passes
- The workspace-deps commit leaves `Cargo.lock` byte-identical, confirming
  the refactor is resolution-neutral

The `quent-open compatibility` job could not be run locally (it needs a
published prior commit), but its failure on #505 was this exact compile
error, which no longer reproduces.

## Screenshots

N/A — no UI changes.