### PR TITLE
fix(ui): resolve production bundle warnings

### DIFF
--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -144,8 +144,6 @@ export type { DAGData, QueryPlanDataItem, QueryPlanNodeData } from './services/q
 // DAGNode, DAGEdge, StatValue re-exported via services/query-plan/types (avoid direct @quent/utils re-export here)
 
 // ─── Timeline components ──────────────────────────────────────────────────────
-export { CHART_GROUP } from './timeline/Timeline';
-export { Timeline } from './timeline/Timeline';
 export { TimelineController } from './timeline/TimelineController';
 export { TimelineRuler } from './timeline/TimelineRuler';
 export { TimelineSkeleton } from './timeline/TimelineSkeleton';
@@ -165,6 +163,7 @@ export {
   ROLLUP_TIMELINE_COLOR_DARK,
 } from './timeline/timelineEchartsTheme';
 export {
+  CHART_GROUP,
   DEFAULT_TIMELINE_HEIGHT,
   TIMELINE_SPACING,
   TIMELINE_X_AXIS_ANIMATION,

--- a/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
@@ -9,7 +9,6 @@ vi.mock('../lib/echarts', () => ({
   disconnect: vi.fn(),
   getInstanceByDom: vi.fn(),
 }));
-vi.mock('../timeline/Timeline', () => ({ CHART_GROUP: 'timeline-sync-group' }));
 
 import {
   nanosToMs,

--- a/ui/packages/@quent/components/src/lib/timeline.utils.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.ts
@@ -31,7 +31,7 @@ import { collectResourceTypesFromTree, getIconForType } from './resource.utils';
 import { EntityTypeValue, EntityRefKey, EntityTypeKey } from '@quent/utils';
 import type { EChartsInstance } from 'echarts-for-react';
 import { connect } from './echarts';
-import { CHART_GROUP } from '../timeline/Timeline';
+import { CHART_GROUP } from '../timeline/types';
 import { MAX_TIMELINE_BINS } from '@quent/utils';
 
 // Suppress unused import warning — getColorForKey is used by consumers of this module

--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -12,7 +12,7 @@ import { useChartConnect } from '../lib/useChartConnect';
 import { useMinZoomSpanPct } from '../lib/useMinZoomSpanPct';
 import { useTimelineWheelNavigation } from '../lib/useTimelineWheelNavigation';
 import { echarts } from '../lib/echarts';
-import { CHART_GROUP } from '../timeline/Timeline';
+import { CHART_GROUP } from '../timeline/types';
 import { useTimelineEchartsTheme } from '../timeline/timelineEchartsTheme';
 import { HiddenScroll } from '../ui/thin-scroll';
 import {

--- a/ui/packages/@quent/components/src/timeline/Timeline.tsx
+++ b/ui/packages/@quent/components/src/timeline/Timeline.tsx
@@ -9,7 +9,13 @@ import type { LineSeriesOption } from 'echarts/charts';
 import type { EChartsInstance } from 'echarts-for-react';
 import { withOpacity } from '@quent/utils';
 import type { TimelineSeriesEntry } from './types';
-import { TimelineSeries, TimelineMark, TIMELINE_SPACING, TIMELINE_X_AXIS_ANIMATION } from './types';
+import {
+  CHART_GROUP,
+  TimelineSeries,
+  TimelineMark,
+  TIMELINE_SPACING,
+  TIMELINE_X_AXIS_ANIMATION,
+} from './types';
 import {
   MARK_AREA_BORDER_OPACITY,
   MARK_AREA_FILL_OPACITY,
@@ -25,7 +31,6 @@ import { useMinZoomSpanPct } from '../lib/useMinZoomSpanPct';
 import { useTimelineWheelNavigation } from '../lib/useTimelineWheelNavigation';
 import { Opts } from 'echarts-for-react/lib/types';
 
-export const CHART_GROUP = 'timeline-sync-group';
 const DIMMED_OPACITY = 0.25;
 
 /**

--- a/ui/packages/@quent/components/src/timeline/types.ts
+++ b/ui/packages/@quent/components/src/timeline/types.ts
@@ -33,6 +33,7 @@ export type TimelineMark = {
 };
 
 export const DEFAULT_TIMELINE_HEIGHT = 45;
+export const CHART_GROUP = 'timeline-sync-group';
 
 // left/right spacing needs to be consistent across all timelines
 // so axes line up. top/bottom spacing can be overridden, but defaults still

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     }),
   ],
   build: {
+    chunkSizeWarningLimit: 1337,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
# Description

Prevent expected UI bundle diagnostics from producing noisy Cargo warnings.

- Raise the Vite chunk warning threshold to 1337 kB.
- Move `CHART_GROUP` into the shared timeline types module.
- Remove the unused static `Timeline` barrel export so the existing lazy import creates a separate chunk.
- Preserve the `lazy` and `Suspense` loading behavior.

## Related issues

Closes #43

## Testing

- Built the `@quent/components` package with tsdown.
- Built the complete Vite production application.
- Ran all 51 timeline utility tests.
- Ran Prettier checks on the changed component files.
- Ran `git diff --check`.

_Written by Codex._
