### PR TITLE
fix(nvtx): share injection hook through dylib

### DIFF
--- a/integrations/nvtx/injection/Cargo.toml
+++ b/integrations/nvtx/injection/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 [lib]
 # cdylib = the NVTX_INJECTION64_PATH runtime attach path (primary);
 # rlib   = the static/link-time path and in-process unit tests.
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 libc = "0.2"
@@ -27,8 +27,8 @@ cc = { workspace = true, optional = true }
 [features]
 # static-injection: attach the injection in-process at link time instead of at
 # runtime. The default attach path is the cdylib NVTX `dlopen`s via
-# `NVTX_INJECTION64_PATH`; with this feature a strong `InitializeInjectionNvtx2`
-# symbol is linked into the consuming binary, so NVTX initializes injection at
-# its first NVTX call — no separate library to deploy. Linux-only. See the crate
-# docs ("Attach modes").
+# `NVTX_INJECTION64_PATH`; with this feature a strong
+# `InitializeInjectionNvtx2_fnptr` is linked into the consuming image and points
+# at Quent's internal initializer, so that image initializes injection at its
+# first NVTX call. Linux-only. See the crate docs ("Attach modes").
 static-injection = ["dep:cc"]

--- a/integrations/nvtx/injection/c/symbol.c
+++ b/integrations/nvtx/injection/c/symbol.c
@@ -7,9 +7,9 @@
  * NVTX declares `InitializeInjectionNvtx2_fnptr` as a WEAK symbol
  * (nvtxDetail/nvtxInit.h). A statically-linked injection library "wins" by
  * providing a STRONG definition of that same symbol pointing at its
- * `InitializeInjectionNvtx2` entry. Because our Rust `InitializeInjectionNvtx2`
- * is exported unmangled with C linkage, we only need to publish the strong
- * function-pointer symbol here.
+ * injector entry. Static builds give the Rust entry a Quent-private ABI name;
+ * this both avoids colliding with a consumer-owned public trampoline and lets
+ * that trampoline forward into the exact same in-process hook state.
  *
  * Compiled ONLY under the `static-injection` cargo feature via `cc` in
  * build.rs; the default (cdylib / NVTX_INJECTION64_PATH) path never links it,
@@ -19,10 +19,10 @@
 /* Matches NVTX's NvtxInitializeInjectionNvtxFunc_t:
  *   typedef int (*)(NvtxGetExportTableFunc_t). The export-table func is an
  *   opaque pointer at this boundary, so `void*` is ABI-compatible. */
-extern int InitializeInjectionNvtx2(void *get_export_table);
+extern int quent_InitializeInjectionNvtx2(void *get_export_table);
 
 typedef int (*NvtxInitializeInjectionNvtxFunc_t)(void *);
 
 /* Strong (non-weak) definition overriding NVTX's weak symbol. */
 NvtxInitializeInjectionNvtxFunc_t InitializeInjectionNvtx2_fnptr =
-    (NvtxInitializeInjectionNvtxFunc_t)InitializeInjectionNvtx2;
+    (NvtxInitializeInjectionNvtxFunc_t)quent_InitializeInjectionNvtx2;

--- a/integrations/nvtx/injection/src/init.rs
+++ b/integrations/nvtx/injection/src/init.rs
@@ -171,8 +171,20 @@ pub(crate) fn dispatch(event: NvtxEvent) {
 /// # Safety
 /// `get_export_table` must be the accessor NVTX supplies; calling this with an
 /// arbitrary pointer is undefined behavior. NVTX itself upholds this contract.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn InitializeInjectionNvtx2(
+// Static consumers may need to expose the NVTX-standard entry from a normal
+// object file (rather than from this archive, whose symbols are commonly
+// localized with `--exclude-libs`). Give that build an internal ABI name so a
+// consumer-owned exported trampoline can forward into this exact hook state.
+// The runtime-loaded library keeps exporting NVTX's required public name.
+#[cfg_attr(
+    feature = "static-injection",
+    unsafe(export_name = "quent_InitializeInjectionNvtx2")
+)]
+#[cfg_attr(
+    not(feature = "static-injection"),
+    unsafe(export_name = "InitializeInjectionNvtx2")
+)]
+pub unsafe extern "C" fn initialize_injection_nvtx2(
     get_export_table: NvtxGetExportTableFunc_t,
 ) -> c_int {
     // Contain any panic in the init path (e.g. a diagnostic write failing) so it
@@ -230,7 +242,7 @@ macro_rules! subscribe {
 ///
 /// # Safety
 /// `get_export_table` must be the accessor NVTX passes to
-/// [`InitializeInjectionNvtx2`].
+/// [`initialize_injection_nvtx2`].
 unsafe fn install_callbacks(get_export_table: NvtxGetExportTableFunc_t) -> bool {
     let Some(get_export_table) = get_export_table else {
         return false;

--- a/integrations/nvtx/injection/src/lib.rs
+++ b/integrations/nvtx/injection/src/lib.rs
@@ -15,9 +15,9 @@
 //! - **Runtime (default):** built as a cdylib; NVTX `dlopen`s it via
 //!   `NVTX_INJECTION64_PATH` and calls the injection entry.
 //! - **In-process (`static-injection` feature):** a strong
-//!   `InitializeInjectionNvtx2` symbol is linked into the consuming binary,
-//!   overriding NVTX's weak one, so NVTX initializes injection at its first NVTX
-//!   call — no cdylib to load and no `NVTX_INJECTION64_PATH`.
+//!   `InitializeInjectionNvtx2_fnptr` is linked into the consuming image and
+//!   points at Quent's internal initializer, overriding NVTX's weak pointer so
+//!   that image initializes injection at its first NVTX call.
 
 // Linux 64-bit only. NVTX injection relies on the ELF weak-symbol /
 // NVTX_INJECTION64_PATH mechanism; Windows and 32-bit are out of scope.
@@ -34,4 +34,6 @@ mod callbacks;
 mod convert;
 mod init;
 
-pub use init::{InitializeInjectionNvtx2, InstallHookError, install_hook};
+pub use init::{
+    InstallHookError, initialize_injection_nvtx2 as InitializeInjectionNvtx2, install_hook,
+};


### PR DESCRIPTION
## Summary
- route static NVTX initialization through a shared Rust hook instance
- keep the public NVTX entrypoint available while avoiding duplicate in-process hook state
- update static-injection docs/comments to match the actual fnptr-based mechanism

## Testing
- pixi run cargo test -p nvtx-injection --locked
- pixi run cargo test -p nvtx-injection --features static-injection --locked
- pixi run cargo clippy -p nvtx-injection --all-targets --all-features --locked -- -D warnings