### PR TITLE
feat(codegen): add default-on NVTX capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,6 +2642,8 @@ version = "0.1.0"
 dependencies = [
  "cxx",
  "cxx-build",
+ "nvtx-bridge",
+ "nvtx-injection",
  "quent-codegen",
  "quent-legacy-readme-example",
 ]
@@ -2974,6 +2976,8 @@ version = "0.1.0"
 dependencies = [
  "cxx",
  "cxx-build",
+ "nvtx-bridge",
+ "nvtx-injection",
  "quent-codegen",
  "quent-qe-cpp-instrumentation",
  "quent-stdlib",

--- a/crates/codegen/src/cxx_bridge.rs
+++ b/crates/codegen/src/cxx_bridge.rs
@@ -478,6 +478,41 @@ fn emit_context_bridge(
     let build_wraps: Vec<&TokenStream> = observer_fields.iter().map(|o| &o.wrap).collect();
     let field_inits: Vec<syn::Ident> = observer_fields.iter().map(|o| o.field.clone()).collect();
 
+    let nvtx_imports = model.nvtx.then(|| {
+        quote! {
+            use nvtx_bridge;
+            use nvtx_injection;
+        }
+    });
+    let nvtx_struct_field = model.nvtx.then(|| {
+        quote! {
+            _nvtx_pipeline: Option<Box<dyn std::any::Any + Send + Sync>>
+        }
+    });
+    let nvtx_tuple_binding = model.nvtx.then(|| quote! { _nvtx_pipeline, });
+    let nvtx_noop_value = model.nvtx.then(|| quote! { None, });
+    let nvtx_active_setup = model.nvtx.then(|| {
+        quote! {
+            let pipeline = inner
+                .observer::<nvtx_bridge::NvtxEventEntity>(&options)
+                .await
+                .map_err(|e| e.to_string())?;
+            let sender = pipeline.sender();
+            let context_id = id;
+            // The injection hook is process-global and one-shot. A later
+            // generated context keeps its own pipeline alive but cannot replace
+            // the first context's capture destination.
+            let _ = nvtx_injection::install_hook(move |event| {
+                sender.emit(context_id, nvtx_bridge::NvtxEventEntity::from(event))
+            })
+            .ok();
+            let _nvtx_pipeline: Option<Box<dyn std::any::Any + Send + Sync>> =
+                Some(Box::new(pipeline));
+        }
+    });
+    let nvtx_active_value = model.nvtx.then(|| quote! { _nvtx_pipeline, });
+    let nvtx_field_init = model.nvtx.then(|| quote! { _nvtx_pipeline, });
+
     let accessors: Vec<TokenStream> = observer_fields
         .iter()
         .map(|o| {
@@ -494,6 +529,7 @@ fn emit_context_bridge(
 
     // Rust impl part — formatted via prettyplease.
     let impl_tokens = quote! {
+        #nvtx_imports
         use std::sync::Arc;
 
         pub struct ExporterOptions {
@@ -552,6 +588,7 @@ fn emit_context_bridge(
 
         pub struct Context {
             #(#struct_fields,)*
+            #nvtx_struct_field
         }
 
         impl Context {
@@ -572,8 +609,11 @@ fn emit_context_bridge(
             // constructing its exporter from the options, bound to the id)
             // concurrently on the context's runtime, block until done. The
             // observers keep the runtime alive; `inner` drops here.
-            let (#(#build_fields,)*) = match options.inner {
-                None => (#(#build_wraps(#q::Observer::<#build_event_tys>::noop()),)*),
+            let (#(#build_fields,)* #nvtx_tuple_binding) = match options.inner {
+                None => (
+                    #(#build_wraps(#q::Observer::<#build_event_tys>::noop()),)*
+                    #nvtx_noop_value
+                ),
                 Some(options) => {
                     let inner = #q::ContextInner::try_new(id).map_err(|e| e.to_string())?;
                     #q::write_sidecar(
@@ -586,12 +626,17 @@ fn emit_context_bridge(
                             #(inner.observer::<#build_event_tys>(&options),)*
                         )
                         .map_err(|e| e.to_string())?;
-                        Ok::<_, String>((#(#build_wraps(#build_fields),)*))
+                        #nvtx_active_setup
+                        Ok::<_, String>((
+                            #(#build_wraps(#build_fields),)*
+                            #nvtx_active_value
+                        ))
                     })?
                 }
             };
             Ok(Box::new(Context {
                 #(#field_inits,)*
+                #nvtx_field_init
             }))
         }
     };

--- a/crates/codegen/tests/cxx_bridge_generation.rs
+++ b/crates/codegen/tests/cxx_bridge_generation.rs
@@ -177,7 +177,39 @@ fn generate_query_engine_cxx_bridge() {
             .content
             .contains("io::ExporterOptions::Collector")
     );
+    assert!(context_file.content.contains("use nvtx_bridge;"));
+    assert!(context_file.content.contains("use nvtx_injection;"));
+    assert!(
+        context_file
+            .content
+            .contains("_nvtx_pipeline: Option<Box<dyn std::any::Any + Send + Sync>>")
+    );
+    assert!(
+        context_file
+            .content
+            .contains("observer::<nvtx_bridge::NvtxEventEntity>(&options)")
+    );
+    assert!(
+        context_file
+            .content
+            .contains("nvtx_injection::install_hook")
+    );
+    assert!(context_file.content.contains("_nvtx_pipeline,"));
     assert!(!context_file.content.contains("exporter: String"));
+}
+
+#[test]
+fn cxx_bridge_can_opt_out_of_nvtx() {
+    let mut builder = quent_query_engine_model::QueryEngineModel::build("QueryEngine");
+    builder.nvtx = false;
+
+    let files = emit_cxx(&builder, &CxxOptions::default());
+    let context = files.iter().find(|file| file.name == "context.rs").unwrap();
+
+    assert!(!context.content.contains("nvtx_bridge"));
+    assert!(!context.content.contains("nvtx_injection"));
+    assert!(!context.content.contains("_nvtx_pipeline"));
+    syn::parse_file(&context.content).unwrap();
 }
 
 #[test]

--- a/crates/model-macros/src/lib.rs
+++ b/crates/model-macros/src/lib.rs
@@ -63,8 +63,8 @@ pub fn derive_resizable_resource(input: TokenStream) -> TokenStream {
 
 /// Composes a model's entities into a model type and event enum.
 ///
-/// Fields may appear in any order; `name` and `root` are required, `entities` is
-/// optional.
+/// Fields may appear in any order; `name` and `root` are required. `entities`
+/// and `analyzer` are optional. `nvtx` is optional and defaults to `true`.
 ///
 /// ```ignore
 /// model! {
@@ -72,6 +72,7 @@ pub fn derive_resizable_resource(input: TokenStream) -> TokenStream {
 ///     root: Cluster,
 ///     entities: { Worker, Thread, Task },
 ///     analyzer: "my-analyzer", // optional: crate providing the QuentViewer
+///     nvtx: false,              // optional: disable CXX NVTX capture
 /// }
 /// ```
 #[proc_macro]

--- a/crates/model-macros/src/model_macro.rs
+++ b/crates/model-macros/src/model_macro.rs
@@ -14,6 +14,7 @@
 //!         quent_stdlib::memory::Memory,
 //!     },
 //!     analyzer: "my-analyzer", // optional: crate providing the QuentViewer
+//!     nvtx: false,              // optional: defaults to true
 //! }
 //! ```
 //!
@@ -23,7 +24,7 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
-use syn::{LitStr, Path, Token};
+use syn::{LitBool, LitStr, Path, Token};
 
 struct DefineModelInput {
     name: Ident,
@@ -32,6 +33,8 @@ struct DefineModelInput {
     /// Optional `analyzer: "<crate>"`: the cargo package providing this model's
     /// `QuentViewer` entry, recorded in the provenance sidecar.
     analyzer_package: Option<LitStr>,
+    /// Whether generated CXX contexts attach an NVTX capture pipeline.
+    nvtx: bool,
 }
 
 impl Parse for DefineModelInput {
@@ -42,6 +45,7 @@ impl Parse for DefineModelInput {
         let mut root: Option<Path> = None;
         let mut components: Option<Vec<Path>> = None;
         let mut analyzer_package: Option<LitStr> = None;
+        let mut nvtx: Option<LitBool> = None;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -78,11 +82,16 @@ impl Parse for DefineModelInput {
                         return Err(dup());
                     }
                 }
+                "nvtx" => {
+                    if nvtx.replace(input.parse()?).is_some() {
+                        return Err(dup());
+                    }
+                }
                 other => {
                     return Err(syn::Error::new_spanned(
                         &key,
                         format!(
-                            "unknown `model!` field `{other}`; expected `name`, `root`, `entities`, or `analyzer`"
+                            "unknown `model!` field `{other}`; expected `name`, `root`, `entities`, `analyzer`, or `nvtx`"
                         ),
                     ));
                 }
@@ -99,6 +108,7 @@ impl Parse for DefineModelInput {
             root,
             components: components.unwrap_or_default(),
             analyzer_package,
+            nvtx: nvtx.map(|value| value.value).unwrap_or(true),
         })
     }
 }
@@ -147,6 +157,8 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
     let model_type = format_ident!("{}Model", name);
     let event_type = format_ident!("{}Event", name);
+    let nvtx_options_type = format_ident!("__{}NvtxOptions", name);
+    let nvtx = input.nvtx;
 
     let root = &input.root;
 
@@ -409,8 +421,17 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
     };
 
     let output = quote! {
+        #[doc(hidden)]
+        pub struct #nvtx_options_type;
+
+        impl quent_model::ModelComponent for #nvtx_options_type {
+            fn collect(builder: &mut quent_model::ModelBuilder) {
+                builder.nvtx = #nvtx;
+            }
+        }
+
         #[doc = #doc_model]
-        pub type #model_type = quent_model::Model<#model_tuple>;
+        pub type #model_type = quent_model::Model<(#model_tuple, #nvtx_options_type)>;
 
         #[doc = #doc_event]
         #[derive(#serde_derives)]
@@ -562,6 +583,7 @@ mod parse_tests {
             input.analyzer_package.map(|l| l.value()),
             Some("my-analyzer".to_string())
         );
+        assert!(input.nvtx);
     }
 
     #[test]
@@ -569,5 +591,13 @@ mod parse_tests {
         let input: DefineModelInput = syn::parse_str("name: App, root: a::Root").unwrap();
         assert!(input.analyzer_package.is_none());
         assert!(input.components.is_empty());
+        assert!(input.nvtx);
+    }
+
+    #[test]
+    fn parses_nvtx_opt_out() {
+        let input: DefineModelInput =
+            syn::parse_str("name: App, root: a::Root, nvtx: false").unwrap();
+        assert!(!input.nvtx);
     }
 }

--- a/crates/model/src/model.rs
+++ b/crates/model/src/model.rs
@@ -59,12 +59,26 @@ impl<T: ModelComponent> Model<T> {
 /// The codegen binary calls `Model::build()` which populates this builder
 /// via `ModelComponent::collect()` calls. The builder is then consumed to
 /// produce the final resolved model representation.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ModelBuilder {
     pub name: String,
     pub fsms: Vec<FsmDef>,
     pub entities: Vec<EntityDef>,
     pub resource_groups: Vec<ResourceGroupDef>,
+    /// Whether CXX instrumentation should attach the NVTX capture pipeline.
+    pub nvtx: bool,
+}
+
+impl Default for ModelBuilder {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            fsms: Vec::new(),
+            entities: Vec::new(),
+            resource_groups: Vec::new(),
+            nvtx: true,
+        }
+    }
 }
 
 impl ModelBuilder {

--- a/crates/model/tests/define_model.rs
+++ b/crates/model/tests/define_model.rs
@@ -51,6 +51,16 @@ quent_model::model! {
     },
 }
 
+quent_model::model! {
+    name: TestWithoutNvtx,
+    root: TestRoot,
+    entities: {
+        SimpleFsm,
+        SimpleEntity,
+    },
+    nvtx: false,
+}
+
 #[test]
 fn define_model_generates_event_enum() {
     // The enum TestEvent should have variants for each component
@@ -62,9 +72,17 @@ fn define_model_generates_event_enum() {
 
 #[test]
 fn define_model_generates_model_type() {
+    assert!(quent_model::ModelBuilder::default().nvtx);
     let builder = TestModel::build("Test");
     assert_eq!(builder.fsms.len(), 1);
     assert_eq!(builder.entities.len(), 2); // TestRoot + SimpleEntity
+    assert!(builder.nvtx);
+}
+
+#[test]
+fn define_model_can_disable_nvtx() {
+    let builder = TestWithoutNvtxModel::build("TestWithoutNvtx");
+    assert!(!builder.nvtx);
 }
 
 #[test]

--- a/domains/query_engine/tests/cpp/bridge/Cargo.toml
+++ b/domains/query_engine/tests/cpp/bridge/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = ["staticlib"]
 
 [dependencies]
 cxx = "1"
+nvtx-bridge = { path = "../../../../../integrations/nvtx/bridge" }
+nvtx-injection = { path = "../../../../../integrations/nvtx/injection" }
 quent-qe-cpp-instrumentation = { path = "../instrumentation" }
 quent-stdlib = { path = "../../../../../crates/stdlib" }
 

--- a/examples/legacy/cpp-integration/bridge/Cargo.toml
+++ b/examples/legacy/cpp-integration/bridge/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = ["staticlib"]
 
 [dependencies]
 cxx = "1"
+nvtx-bridge = { path = "../../../../integrations/nvtx/bridge" }
+nvtx-injection = { path = "../../../../integrations/nvtx/injection" }
 quent-readme-example = { package = "quent-legacy-readme-example", path = "../../readme" }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- make NVTX capture default-on for `model!` models emitted through the CXX bridge
- allow `model!` callers to disable CXX NVTX capture with `nvtx: false`
- keep the generated CXX context's NVTX observer pipeline alive and install the process-global injection hook
- add the NVTX runtime dependencies to generated CXX bridge consumers

## Scope
- this PR is intentionally limited to the CXX codegen path needed by `sirius-db/sirius#1439`
- NVTX is not exposed through the YAML model format
- schema-driven unification across Rust, CXX, and Python is tracked in #618

## Reconciliation
- rebase the codegen change onto current `main` (`e99109e`)
- drop the superseded mock UI commit; the NVTX UI is now provided by #586
- move the legacy C++ bridge dependency update to the path introduced by #627

This supplies the remaining Quent codegen support needed by sirius-db/sirius#1439.

## Testing
- `pixi run cargo fmt --all -- --check`
- `pixi run cargo check -p quent-bridge -p quent-qe-bridge --locked`
- `pixi run cargo test -p quent-codegen -p quent-model -p quent-model-macros -p quent-yaml --locked`
