### PR TITLE
fix(ui): satisfy prettier lint in DataFlowMatrix and NodeFlowBar

### DIFF
--- a/ui/packages/@quent/components/src/dag/DataFlowMatrix.tsx
+++ b/ui/packages/@quent/components/src/dag/DataFlowMatrix.tsx
@@ -74,10 +74,7 @@ export const DataFlowMatrix = ({
       <table className="mt-1 text-xs min-w-full border-separate border-spacing-0 whitespace-nowrap">
         <thead>
           <tr>
-            <th
-              scope="col"
-              className="text-left font-normal text-muted-foreground pr-2"
-            >
+            <th scope="col" className="text-left font-normal text-muted-foreground pr-2">
               State / {meta.decl.dimension_name}
             </th>
             {dimensionColumns.map(({ key: k }) => (
@@ -92,10 +89,7 @@ export const DataFlowMatrix = ({
                 </span>
               </th>
             ))}
-            <th
-              scope="col"
-              className="text-right font-medium text-muted-foreground pl-1.5"
-            >
+            <th scope="col" className="text-right font-medium text-muted-foreground pl-1.5">
               Total
             </th>
           </tr>
@@ -110,10 +104,7 @@ export const DataFlowMatrix = ({
                 </span>
               </th>
               {dimensionColumns.map(({ key: k, index: dimensionIndex }) => (
-                <td
-                  key={k.key}
-                  className="text-right px-1.5 text-muted-foreground"
-                >
+                <td key={k.key} className="text-right px-1.5 text-muted-foreground">
                   <DataText>
                     {fmt(operatorFrame.matrix[stateIndex]?.[dimensionIndex] ?? 0)}
                   </DataText>

--- a/ui/packages/@quent/components/src/query-plan/NodeFlowBar.tsx
+++ b/ui/packages/@quent/components/src/query-plan/NodeFlowBar.tsx
@@ -94,9 +94,16 @@ export const NodeFlowBar = memo(
       : '';
 
     return (
-      <div className="w-full" style={{ marginTop: FLOW_BAR_TOP_MARGIN }} data-testid="node-flow-bar">
+      <div
+        className="w-full"
+        style={{ marginTop: FLOW_BAR_TOP_MARGIN }}
+        data-testid="node-flow-bar"
+      >
         <div
-          className={cn('w-full overflow-hidden rounded-sm', hasData ? 'bg-muted/40' : 'bg-transparent')}
+          className={cn(
+            'w-full overflow-hidden rounded-sm',
+            hasData ? 'bg-muted/40' : 'bg-transparent'
+          )}
           style={{ height: FLOW_BAR_TRACK_HEIGHT }}
         >
           <div className="flex h-full" style={{ width: filledWidth, transition: BAR_TRANSITION }}>
@@ -135,7 +142,10 @@ export const NodeFlowBar = memo(
           </div>
         </div>
         <div
-          className={cn('w-full overflow-hidden rounded-sm', hasData ? 'bg-muted/40' : 'bg-transparent')}
+          className={cn(
+            'w-full overflow-hidden rounded-sm',
+            hasData ? 'bg-muted/40' : 'bg-transparent'
+          )}
           style={{ marginTop: FLOW_BAR_TRACK_GAP, height: FLOW_BAR_TRACK_HEIGHT }}
         >
           <div className="flex h-full" style={{ width: filledWidth, transition: BAR_TRANSITION }}>


### PR DESCRIPTION
## Summary
- format `DataFlowMatrix.tsx` to satisfy prettier lint
- format `NodeFlowBar.tsx` to satisfy prettier lint

## Testing
- pixi run pnpm --dir ui lint