### PR TITLE
fix(schema, vibe): share Svelte runtime in Pages build

### DIFF
--- a/experimental/vibe/ui/schema-explorer/index.html
+++ b/experimental/vibe/ui/schema-explorer/index.html
@@ -6,6 +6,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
     <title>Quent Schema Explorer</title>
   </head>
   <body>

--- a/experimental/vibe/ui/schema-viewer/vite.config.ts
+++ b/experimental/vibe/ui/schema-viewer/vite.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
       fileName: (_format, entryName) => `${entryName}.js`,
       cssFileName: 'schema-viewer',
     },
+    rolldownOptions: {
+      external: (id) => id === 'svelte' || id.startsWith('svelte/'),
+    },
   },
 });
 


### PR DESCRIPTION
# Description

Externalize Svelte from the schema-viewer bundle so the viewer and custom node components share one runtime in production. This fixes the null `nodes` crash on GitHub Pages.

Also suppress the unnecessary `/favicon.ico` request.

## Related Issues

Follow-up to #451.

## Testing

- Full experimental schema CI
- Pages-equivalent headless browser test: HTTP 200, graph rendered, no console or page errors
- License and whitespace checks

_Written by Codex._