### PR TITLE
fix(ui): resolve nanoid audit advisory

### DIFF
--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -58,6 +58,9 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
 
+overrides:
+  nanoid: 3.3.17
+
 importers:
 
   .:
@@ -3395,8 +3398,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7022,7 +7025,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -7101,7 +7104,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -7,6 +7,9 @@ packages:
   # `pnpm-workspace.yaml` re-references `../../packages/@quent/*` so its
   # `workspace:*` deps still resolve to source.
 
+overrides:
+  nanoid: 3.3.17
+
 catalog:
   '@tanstack/react-query': ^5.90.21
   '@tanstack/react-router': ^1.169.9


### PR DESCRIPTION
Pins the transitive nanoid dependency to 3.3.17 to resolve GHSA-2v37-7h3g-55p8, which is currently failing the shared UI Audit job across PRs.

Verification:
- pixi run pnpm --dir ui install --frozen-lockfile
- pixi run pnpm --dir ui audit --audit-level=high