### PR TITLE
feat(ui):  long entities swimlanes 3.5

### DIFF
--- a/ui/packages/@quent/client/src/entityList.test.ts
+++ b/ui/packages/@quent/client/src/entityList.test.ts
@@ -3,8 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { keepPreviousData } from '@tanstack/react-query';
-import type { EntityListResponse } from '@quent/utils';
-import { entityListInfiniteQueryOptions, entityListQueryOptions } from './entityList';
+import { entityListQueryOptions } from './entityList';
 
 describe('entityListQueryOptions', () => {
   it('copies selected operator IDs into the entity-list request', () => {
@@ -30,23 +29,5 @@ describe('entityListQueryOptions', () => {
       }),
     ]);
     expect(options.placeholderData).toBe(keepPreviousData);
-  });
-
-  it('continues paging until all matching entities are loaded', () => {
-    const options = entityListInfiniteQueryOptions({
-      engineId: 'engine-1',
-      queryId: 'query-1',
-      window: { start: 0, end: 1 },
-      maxItems: 1,
-    });
-    const item = {} as EntityListResponse['items'][number];
-    const firstPage: EntityListResponse = { items: [item], total: 3 };
-    const secondPage: EntityListResponse = { items: [item], total: 3 };
-
-    expect(options.placeholderData).toBe(keepPreviousData);
-    expect(options.getNextPageParam?.(secondPage, [firstPage, secondPage], 1, [0, 1])).toBe(2);
-    expect(
-      options.getNextPageParam?.({ items: [item], total: 2 }, [firstPage, secondPage], 1, [0, 1])
-    ).toBeUndefined();
   });
 });

--- a/ui/packages/@quent/client/src/entityList.ts
+++ b/ui/packages/@quent/client/src/entityList.ts
@@ -1,13 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  infiniteQueryOptions,
-  keepPreviousData,
-  queryOptions,
-  useInfiniteQuery,
-  useQuery,
-} from '@tanstack/react-query';
+import { keepPreviousData, queryOptions, useQuery } from '@tanstack/react-query';
 import type {
   EntityListRequest,
   EntityScope,
@@ -82,30 +76,3 @@ export const useEntityList = (
   params: EntityListParams,
   options?: { staleTime?: number; enabled?: boolean }
 ) => useQuery(entityListQueryOptions(params, options));
-
-type PaginatedEntityListParams = EntityListParams & { maxItems: number };
-
-export const entityListInfiniteQueryOptions = (
-  params: PaginatedEntityListParams,
-  options?: { staleTime?: number; enabled?: boolean }
-) => {
-  const initialRequest = buildRequest({ ...params, page: 0 });
-  return infiniteQueryOptions({
-    queryKey: ['entityList', 'infinite', params.engineId, initialRequest],
-    queryFn: ({ pageParam }) =>
-      fetchEntityList(params.engineId, buildRequest({ ...params, page: pageParam })),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, pages) => {
-      const loadedCount = pages.reduce((count, page) => count + page.items.length, 0);
-      return lastPage.items.length > 0 && loadedCount < lastPage.total ? pages.length : undefined;
-    },
-    staleTime: options?.staleTime ?? DEFAULT_STALE_TIME,
-    enabled: options?.enabled ?? true,
-    placeholderData: keepPreviousData,
-  });
-};
-
-export const useInfiniteEntityList = (
-  params: PaginatedEntityListParams,
-  options?: { staleTime?: number; enabled?: boolean }
-) => useInfiniteQuery(entityListInfiniteQueryOptions(params, options));

--- a/ui/packages/@quent/client/src/index.ts
+++ b/ui/packages/@quent/client/src/index.ts
@@ -25,7 +25,7 @@ export { queriesQueryOptions } from './queries';
 export { singleTimelineQueryOptions } from './timeline';
 export { bulkTimelineQueryOptions } from './bulkTimelines';
 export { dataFlowQueryOptions } from './dataFlow';
-export { entityListInfiniteQueryOptions, entityListQueryOptions } from './entityList';
+export { entityListQueryOptions } from './entityList';
 
 // Hooks
 export { useQueryBundle } from './queryBundle';
@@ -34,4 +34,4 @@ export { useQueryGroups } from './queryGroups';
 export { useQueries } from './queries';
 export { useTimeline } from './timeline';
 export { useDataFlow } from './dataFlow';
-export { useEntityList, useInfiniteEntityList } from './entityList';
+export { useEntityList } from './entityList';

--- a/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
+++ b/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
@@ -42,7 +42,7 @@ export interface GanttChartProps<T extends GanttDatum> {
   isDark: boolean;
   seriesName: string;
   renderItem: GanttRenderItem;
-  emptyMessage: string;
+  emptyMessage: ReactNode;
   cursor?: GanttSeriesCursor;
   onEvents?: EChartsEvents;
   gridSpacing?: GanttGridSpacing;

--- a/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
+++ b/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
@@ -47,6 +47,7 @@ export interface GanttChartProps<T extends GanttDatum> {
   onEvents?: EChartsEvents;
   gridSpacing?: GanttGridSpacing;
   contentPaddingBottom?: number;
+  animateHeight?: boolean;
   renderTooltip?: (hover: GanttHover | null) => ReactNode;
 }
 
@@ -64,6 +65,7 @@ export function GanttChart<T extends GanttDatum>({
   onEvents,
   gridSpacing,
   contentPaddingBottom = 0,
+  animateHeight = false,
   renderTooltip,
 }: GanttChartProps<T>) {
   const { themeName } = useTimelineEchartsTheme(isDark);
@@ -143,7 +145,15 @@ export function GanttChart<T extends GanttDatum>({
 
   return (
     <>
-      <HiddenScroll ref={wrapperRef} className="relative" style={{ height: wrapperHeight }}>
+      <HiddenScroll
+        ref={wrapperRef}
+        className={
+          animateHeight
+            ? 'relative transition-[height] duration-150 ease-out motion-reduce:transition-none'
+            : 'relative'
+        }
+        style={{ height: wrapperHeight }}
+      >
         <EChartsReactCore
           echarts={echarts}
           theme={themeName}

--- a/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
+++ b/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
@@ -46,6 +46,7 @@ export interface GanttChartProps<T extends GanttDatum> {
   cursor?: GanttSeriesCursor;
   onEvents?: EChartsEvents;
   gridSpacing?: GanttGridSpacing;
+  contentPaddingBottom?: number;
   renderTooltip?: (hover: GanttHover | null) => ReactNode;
 }
 
@@ -62,6 +63,7 @@ export function GanttChart<T extends GanttDatum>({
   cursor,
   onEvents,
   gridSpacing,
+  contentPaddingBottom = 0,
   renderTooltip,
 }: GanttChartProps<T>) {
   const { themeName } = useTimelineEchartsTheme(isDark);
@@ -79,7 +81,7 @@ export function GanttChart<T extends GanttDatum>({
       rowCount: maxRow + 1,
     };
   }, [data]);
-  const chartHeight = Math.max(height, rowCount * rowHeight);
+  const chartHeight = Math.max(height, rowCount * rowHeight + contentPaddingBottom);
   const wrapperHeight = Math.min(chartHeight, maxHeight);
 
   const option = useMemo(

--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -117,10 +117,8 @@ export {
   buildTimelineMarks,
   collectVisibleEntries,
   getAdaptiveNumBins,
-  getFsmTypeName,
   getLongEntitiesThreshold,
   getLongFsms,
-  getResourceTypeName,
   getTimelineConfig,
   getTimelineXAxisIntervalMs,
   mergeOverlaySeries,
@@ -130,6 +128,7 @@ export {
   transformResourceTree,
 } from './lib/timeline.utils';
 export type { AxisPointerSyncOptions } from './lib/timeline.utils';
+export { getFsmTypeName, getResourceTypeName } from '@quent/utils';
 
 // ─── Services – query-plan ────────────────────────────────────────────────────
 export {

--- a/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
@@ -119,21 +119,23 @@ describe('nanosToMs', () => {
 // ---- getLongEntitiesThreshold ----------------------------------------------
 
 describe('getLongEntitiesThreshold', () => {
-  it('uses the current balanced threshold by default', () => {
-    expect(getLongEntitiesThreshold(200)).toBe(2);
+  it('uses the middle density threshold by default', () => {
+    expect(getLongEntitiesThreshold(200)).toBe(3);
   });
 
   it.each([
-    ['less', 4],
-    ['balanced', 2],
-    ['more', 1],
-  ] as const)('maps %s density to its bin multiplier', (density, expected) => {
+    [1, 5],
+    [2, 4],
+    [3, 3],
+    [4, 2],
+    [5, 1],
+  ] as const)('maps density %s to its bin multiplier', (density, expected) => {
     expect(getLongEntitiesThreshold(200, density)).toBe(expected);
   });
 
   it('scales linearly with the visible window', () => {
-    expect(getLongEntitiesThreshold(100)).toBe(1);
-    expect(getLongEntitiesThreshold(400)).toBe(4);
+    expect(getLongEntitiesThreshold(100)).toBe(1.5);
+    expect(getLongEntitiesThreshold(400)).toBe(6);
   });
 
   it('returns 0 for a zero-second window', () => {

--- a/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
@@ -120,26 +120,30 @@ describe('nanosToMs', () => {
 
 describe('getLongEntitiesThreshold', () => {
   it('uses the middle density threshold by default', () => {
-    expect(getLongEntitiesThreshold(200)).toBe(3);
+    expect(getLongEntitiesThreshold(200, 200)).toBe(1);
   });
 
   it.each([
-    [1, 5],
-    [2, 4],
-    [3, 3],
-    [4, 2],
-    [5, 1],
+    [1, 100],
+    [2, 10],
+    [3, 1],
+    [4, 0.1],
+    [5, 0.01],
   ] as const)('maps density %s to its bin multiplier', (density, expected) => {
-    expect(getLongEntitiesThreshold(200, density)).toBe(expected);
+    expect(getLongEntitiesThreshold(200, 200, density)).toBe(expected);
   });
 
   it('scales linearly with the visible window', () => {
-    expect(getLongEntitiesThreshold(100)).toBe(1.5);
-    expect(getLongEntitiesThreshold(400)).toBe(6);
+    expect(getLongEntitiesThreshold(100, 200)).toBe(0.5);
+    expect(getLongEntitiesThreshold(400, 200)).toBe(2);
+  });
+
+  it('uses the returned bin count', () => {
+    expect(getLongEntitiesThreshold(200, 400)).toBe(0.5);
   });
 
   it('returns 0 for a zero-second window', () => {
-    expect(getLongEntitiesThreshold(0)).toBe(0);
+    expect(getLongEntitiesThreshold(0, 200)).toBe(0);
   });
 });
 

--- a/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.test.ts
@@ -119,8 +119,16 @@ describe('nanosToMs', () => {
 // ---- getLongEntitiesThreshold ----------------------------------------------
 
 describe('getLongEntitiesThreshold', () => {
-  it('returns the bin-scaled threshold for a 200-second window', () => {
+  it('uses the current balanced threshold by default', () => {
     expect(getLongEntitiesThreshold(200)).toBe(2);
+  });
+
+  it.each([
+    ['less', 4],
+    ['balanced', 2],
+    ['more', 1],
+  ] as const)('maps %s density to its bin multiplier', (density, expected) => {
+    expect(getLongEntitiesThreshold(200, density)).toBe(expected);
   });
 
   it('scales linearly with the visible window', () => {

--- a/ui/packages/@quent/components/src/lib/timeline.utils.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.ts
@@ -293,19 +293,6 @@ export function mergeOverlaySeries(
   return merged;
 }
 
-/** Extract the resource_type_name from a TimelineRequest (empty string for Resource requests) */
-export function getResourceTypeName(params: TimelineRequest<OperatorFilter> | undefined): string {
-  if (!params) return '';
-  if ('ResourceGroup' in params) return params.ResourceGroup.resource_type_name;
-  return '';
-}
-
-/** Extract the entity_type_name (FSM filter) from a TimelineRequest */
-export function getFsmTypeName(params: TimelineRequest<OperatorFilter>): string | null {
-  if ('ResourceGroup' in params) return params.ResourceGroup.entity_filter.entity_type_name;
-  return params.Resource.entity_filter.entity_type_name;
-}
-
 /** Clone entries and set operator_id on each TimelineRequest */
 export function setOperatorOnEntry(
   entry: TimelineRequest<OperatorFilter>,

--- a/ui/packages/@quent/components/src/lib/timeline.utils.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.ts
@@ -30,7 +30,7 @@ import { entityRefToEntitiesKey } from './queryBundle.utils';
 import { collectResourceTypesFromTree, getIconForType } from './resource.utils';
 import { EntityTypeValue, EntityRefKey, EntityTypeKey } from '@quent/utils';
 import type { EChartsInstance } from 'echarts-for-react';
-import type { LongEntityDensity } from '@quent/hooks';
+import { LONG_ENTITY_DENSITIES, type LongEntityDensity } from '@quent/hooks';
 import { connect } from './echarts';
 import { CHART_GROUP } from '../timeline/types';
 import { MAX_TIMELINE_BINS } from '@quent/utils';
@@ -38,13 +38,7 @@ import { MAX_TIMELINE_BINS } from '@quent/utils';
 // Suppress unused import warning — getColorForKey is used by consumers of this module
 void getColorForKey;
 
-const LONG_ENTITY_DENSITY_MULTIPLIERS: Record<LongEntityDensity, number> = {
-  1: 100,
-  2: 10,
-  3: 1,
-  4: 0.1,
-  5: 0.01,
-};
+const LONG_ENTITY_DENSITY_MULTIPLIERS = [100, 10, 1, 0.1, 0.01] as const;
 
 /** Minimum bin duration in nanoseconds — the backend cannot produce sub-1ns bins. */
 export const MIN_BIN_DURATION_NS = 10;
@@ -75,7 +69,9 @@ export function getLongEntitiesThreshold(
   numBins: number,
   density: LongEntityDensity = 3
 ): number {
-  return LONG_ENTITY_DENSITY_MULTIPLIERS[density] * (windowSeconds / numBins);
+  return (
+    LONG_ENTITY_DENSITY_MULTIPLIERS[density - LONG_ENTITY_DENSITIES[0]] * (windowSeconds / numBins)
+  );
 }
 
 export function buildBinnedTimelineSeries(

--- a/ui/packages/@quent/components/src/lib/timeline.utils.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.ts
@@ -37,10 +37,13 @@ import { MAX_TIMELINE_BINS } from '@quent/utils';
 
 // Suppress unused import warning — getColorForKey is used by consumers of this module
 void getColorForKey;
+
 const LONG_ENTITY_DENSITY_MULTIPLIERS: Record<LongEntityDensity, number> = {
-  less: 4,
-  balanced: 2,
-  more: 1,
+  1: 100,
+  2: 10,
+  3: 1,
+  4: 0.1,
+  5: 0.01,
 };
 
 /** Minimum bin duration in nanoseconds — the backend cannot produce sub-1ns bins. */
@@ -69,7 +72,7 @@ export function getAdaptiveNumBins(): number {
 /** Threshold for "long" entities as a density-adjusted multiple of the current bin duration. */
 export function getLongEntitiesThreshold(
   windowSeconds: number,
-  density: LongEntityDensity = 'balanced'
+  density: LongEntityDensity = 3
 ): number {
   const numBins = getAdaptiveNumBins();
   return LONG_ENTITY_DENSITY_MULTIPLIERS[density] * (windowSeconds / numBins);

--- a/ui/packages/@quent/components/src/lib/timeline.utils.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.ts
@@ -30,13 +30,18 @@ import { entityRefToEntitiesKey } from './queryBundle.utils';
 import { collectResourceTypesFromTree, getIconForType } from './resource.utils';
 import { EntityTypeValue, EntityRefKey, EntityTypeKey } from '@quent/utils';
 import type { EChartsInstance } from 'echarts-for-react';
+import type { LongEntityDensity } from '@quent/hooks';
 import { connect } from './echarts';
 import { CHART_GROUP } from '../timeline/types';
 import { MAX_TIMELINE_BINS } from '@quent/utils';
 
 // Suppress unused import warning — getColorForKey is used by consumers of this module
 void getColorForKey;
-const LONG_ENTITIES_BIN_MULTIPLIER = 2;
+const LONG_ENTITY_DENSITY_MULTIPLIERS: Record<LongEntityDensity, number> = {
+  less: 4,
+  balanced: 2,
+  more: 1,
+};
 
 /** Minimum bin duration in nanoseconds — the backend cannot produce sub-1ns bins. */
 export const MIN_BIN_DURATION_NS = 10;
@@ -61,10 +66,13 @@ export function getAdaptiveNumBins(): number {
   return MAX_TIMELINE_BINS;
 }
 
-/** Threshold for "long" entities as a fraction of the current bin duration. */
-export function getLongEntitiesThreshold(windowSeconds: number): number {
+/** Threshold for "long" entities as a density-adjusted multiple of the current bin duration. */
+export function getLongEntitiesThreshold(
+  windowSeconds: number,
+  density: LongEntityDensity = 'balanced'
+): number {
   const numBins = getAdaptiveNumBins();
-  return LONG_ENTITIES_BIN_MULTIPLIER * (windowSeconds / numBins);
+  return LONG_ENTITY_DENSITY_MULTIPLIERS[density] * (windowSeconds / numBins);
 }
 
 export function buildBinnedTimelineSeries(

--- a/ui/packages/@quent/components/src/lib/timeline.utils.ts
+++ b/ui/packages/@quent/components/src/lib/timeline.utils.ts
@@ -69,12 +69,12 @@ export function getAdaptiveNumBins(): number {
   return MAX_TIMELINE_BINS;
 }
 
-/** Threshold for "long" entities as a density-adjusted multiple of the current bin duration. */
+/** Threshold for "long" entities using the bin count returned by the timeline response. */
 export function getLongEntitiesThreshold(
   windowSeconds: number,
+  numBins: number,
   density: LongEntityDensity = 3
 ): number {
-  const numBins = getAdaptiveNumBins();
   return LONG_ENTITY_DENSITY_MULTIPLIERS[density] * (windowSeconds / numBins);
 }
 

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../timeline/timelineEchartsTheme', () => ({
 
 vi.mock('../gantt-chart/GanttChart', () => ({
   GanttChart: (props: {
+    animateHeight: boolean;
     contentPaddingBottom: number;
     emptyMessage: ReactNode;
     gridSpacing: { bottom: number };
@@ -76,6 +77,7 @@ describe('LongEntitiesGantt', () => {
 
     expect(mocks.ganttChart).toHaveBeenLastCalledWith(
       expect.objectContaining({
+        animateHeight: true,
         contentPaddingBottom: 12,
         gridSpacing: expect.objectContaining({ bottom: 14.5 }),
         maxHeight: 75,
@@ -84,6 +86,7 @@ describe('LongEntitiesGantt', () => {
 
     const expandButton = screen.getByRole('button', { name: 'Expand entities chart' });
     expect(expandButton).toHaveStyle({ right: '10px' });
+    expect(expandButton).toHaveClass('focus-visible:ring-0', 'focus-visible:ring-offset-0');
     fireEvent.click(expandButton);
     expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 96 }));
 

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LongEntitiesGantt } from './LongEntitiesGantt';
+
+vi.mock('@quent/hooks', () => ({
+  useZoomRange: () => ({ start: 0, end: 1 }),
+}));
+
+vi.mock('../timeline/timelineEchartsTheme', () => ({
+  MARK_AREA_BORDER_OPACITY: 0.8,
+  MARK_AREA_FILL_OPACITY: 0.2,
+  useTimelineEchartsTheme: () => ({ textColor: '#000000' }),
+}));
+
+vi.mock('../gantt-chart/GanttChart', () => ({
+  GanttChart: ({ emptyMessage }: { emptyMessage: ReactNode }) => <div>{emptyMessage}</div>,
+}));
+
+describe('LongEntitiesGantt', () => {
+  it('explains the active threshold when no entities match', () => {
+    render(
+      <LongEntitiesGantt entries={[]} durationSeconds={1} minUsageSeconds={0.06} isDark={false} />
+    );
+
+    expect(screen.getByText('No Matching Entities')).toBeInTheDocument();
+    expect(
+      screen.getByText('Showing entities longer than 60.0ms. Zoom to see more.')
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
@@ -22,7 +22,12 @@ vi.mock('../timeline/timelineEchartsTheme', () => ({
 }));
 
 vi.mock('../gantt-chart/GanttChart', () => ({
-  GanttChart: (props: { emptyMessage: ReactNode; maxHeight: number }) => {
+  GanttChart: (props: {
+    contentPaddingBottom: number;
+    emptyMessage: ReactNode;
+    gridSpacing: { bottom: number };
+    maxHeight: number;
+  }) => {
     mocks.ganttChart(props);
     return <div>{props.emptyMessage}</div>;
   },
@@ -69,10 +74,18 @@ describe('LongEntitiesGantt', () => {
       />
     );
 
-    expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 75 }));
+    expect(mocks.ganttChart).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        contentPaddingBottom: 12,
+        gridSpacing: expect.objectContaining({ bottom: 14.5 }),
+        maxHeight: 75,
+      })
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Expand entities chart' }));
-    expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 84 }));
+    const expandButton = screen.getByRole('button', { name: 'Expand entities chart' });
+    expect(expandButton).toHaveStyle({ right: '10px' });
+    fireEvent.click(expandButton);
+    expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 96 }));
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse entities chart' }));
     expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 75 }));

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.test.tsx
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { LongEntitiesGantt } from './LongEntitiesGantt';
+import type { LongEntityEntry } from './types';
+
+const mocks = vi.hoisted(() => ({
+  ganttChart: vi.fn(),
+}));
 
 vi.mock('@quent/hooks', () => ({
   useZoomRange: () => ({ start: 0, end: 1 }),
@@ -17,7 +22,10 @@ vi.mock('../timeline/timelineEchartsTheme', () => ({
 }));
 
 vi.mock('../gantt-chart/GanttChart', () => ({
-  GanttChart: ({ emptyMessage }: { emptyMessage: ReactNode }) => <div>{emptyMessage}</div>,
+  GanttChart: (props: { emptyMessage: ReactNode; maxHeight: number }) => {
+    mocks.ganttChart(props);
+    return <div>{props.emptyMessage}</div>;
+  },
 }));
 
 describe('LongEntitiesGantt', () => {
@@ -30,5 +38,43 @@ describe('LongEntitiesGantt', () => {
     expect(
       screen.getByText('Showing entities longer than 60.0ms. Zoom to see more.')
     ).toBeInTheDocument();
+  });
+
+  it('expands to fit all rows and collapses to the default height', () => {
+    const entries: LongEntityEntry[] = [
+      {
+        entityId: 'entity-1',
+        label: 'Entity 1',
+        typeName: 'test',
+        startMs: 0,
+        endMs: 100,
+        rowIndex: 5,
+        segments: [
+          {
+            stateName: 'running',
+            startMs: 0,
+            endMs: 100,
+            color: '#76b900',
+          },
+        ],
+      },
+    ];
+
+    render(
+      <LongEntitiesGantt
+        entries={entries}
+        durationSeconds={1}
+        minUsageSeconds={0.06}
+        isDark={false}
+      />
+    );
+
+    expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 75 }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand entities chart' }));
+    expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 84 }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse entities chart' }));
+    expect(mocks.ganttChart).toHaveBeenLastCalledWith(expect.objectContaining({ maxHeight: 75 }));
   });
 });

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
@@ -19,6 +19,7 @@ import { getLongEntitySegmentsAtTimestamp } from './utils';
 import { PointerTooltipPortal } from '../ui/pointer-tooltip-portal';
 import { EntityTooltipContent, type ActiveMark } from '../timeline/TimelineTooltip';
 import { Button } from '../ui/button';
+import { TIMELINE_SPACING } from '../timeline/types';
 
 export const LONG_ENTITIES_TIMELINE_HEIGHT = 75;
 const LABEL_FONT_SIZE = 9;
@@ -26,6 +27,7 @@ const BAR_HEIGHT = LABEL_FONT_SIZE + 4;
 /** Vertical gap between stacked rows. */
 const ROW_GAP = 1;
 const ROW_HEIGHT = BAR_HEIGHT + ROW_GAP;
+const RESIZE_CONTROL_HEIGHT = 12;
 /** Radius applied only to the outer corners of each entity's segment run. */
 const CORNER_RADIUS = 2;
 const SERIES_NAME = 'long-entity-segment';
@@ -56,11 +58,15 @@ export function LongEntitiesGantt({
   const { textColor } = useTimelineEchartsTheme(isDark);
   const zoomRange = useZoomRange();
   const [isExpanded, setIsExpanded] = useState(false);
+  const rowCount = useMemo(
+    () => entries.reduce((count, entry) => Math.max(count, entry.rowIndex + 1), 0),
+    [entries]
+  );
+  const canResize = rowCount * ROW_HEIGHT > height;
+  const resizeControlHeight = canResize ? RESIZE_CONTROL_HEIGHT : 0;
   const contentHeight = useMemo(() => {
-    const rowCount = entries.reduce((count, entry) => Math.max(count, entry.rowIndex + 1), 0);
-    return Math.max(height, rowCount * ROW_HEIGHT);
-  }, [entries, height]);
-  const canResize = contentHeight > height;
+    return Math.max(height, rowCount * ROW_HEIGHT + resizeControlHeight);
+  }, [height, resizeControlHeight, rowCount]);
   // One custom-series datum per segment, tagged with its parent entry/segment.
   const customSeriesData = useMemo<SegmentDatum[]>(() => {
     const data: SegmentDatum[] = [];
@@ -179,7 +185,7 @@ export function LongEntitiesGantt({
   );
 
   return (
-    <div>
+    <div className="relative">
       <GanttChart
         data={customSeriesData}
         durationSeconds={durationSeconds}
@@ -189,6 +195,11 @@ export function LongEntitiesGantt({
         isDark={isDark}
         seriesName={SERIES_NAME}
         renderItem={renderItem}
+        contentPaddingBottom={resizeControlHeight}
+        gridSpacing={{
+          ...TIMELINE_SPACING,
+          bottom: TIMELINE_SPACING.bottom + resizeControlHeight,
+        }}
         emptyMessage={
           <div className="flex flex-col items-center gap-0.5 text-center text-muted-foreground opacity-50">
             <div className="font-medium">No Matching Entities</div>
@@ -205,7 +216,8 @@ export function LongEntitiesGantt({
           type="button"
           variant="ghost"
           size="xs"
-          className="h-3 w-full rounded-none border-t border-border/50 p-0 text-muted-foreground [&_svg]:size-3"
+          className="absolute bottom-0 left-0 z-10 h-3 rounded-none border-t border-border/50 bg-background/90 p-0 text-muted-foreground backdrop-blur-sm [&_svg]:size-3"
+          style={{ right: TIMELINE_SPACING.right }}
           aria-label={isExpanded ? 'Collapse entities chart' : 'Expand entities chart'}
           aria-expanded={isExpanded}
           onClick={event => {

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 import {
   MARK_AREA_BORDER_OPACITY,
@@ -17,6 +18,7 @@ import { clipRectByRect } from '../gantt-chart/utils';
 import { getLongEntitySegmentsAtTimestamp } from './utils';
 import { PointerTooltipPortal } from '../ui/pointer-tooltip-portal';
 import { EntityTooltipContent, type ActiveMark } from '../timeline/TimelineTooltip';
+import { Button } from '../ui/button';
 
 export const LONG_ENTITIES_TIMELINE_HEIGHT = 75;
 const LABEL_FONT_SIZE = 9;
@@ -53,6 +55,12 @@ export function LongEntitiesGantt({
 }: LongEntitiesGanttProps) {
   const { textColor } = useTimelineEchartsTheme(isDark);
   const zoomRange = useZoomRange();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const contentHeight = useMemo(() => {
+    const rowCount = entries.reduce((count, entry) => Math.max(count, entry.rowIndex + 1), 0);
+    return Math.max(height, rowCount * ROW_HEIGHT);
+  }, [entries, height]);
+  const canResize = contentHeight > height;
   // One custom-series datum per segment, tagged with its parent entry/segment.
   const customSeriesData = useMemo<SegmentDatum[]>(() => {
     const data: SegmentDatum[] = [];
@@ -171,25 +179,43 @@ export function LongEntitiesGantt({
   );
 
   return (
-    <GanttChart
-      data={customSeriesData}
-      durationSeconds={durationSeconds}
-      height={height}
-      maxHeight={height}
-      rowHeight={ROW_HEIGHT}
-      isDark={isDark}
-      seriesName={SERIES_NAME}
-      renderItem={renderItem}
-      emptyMessage={
-        <div className="flex flex-col items-center gap-0.5 text-center text-muted-foreground opacity-50">
-          <div className="font-medium">No Matching Entities</div>
-          <div className="text-xs">
-            Showing entities longer than {formatDuration(minUsageSeconds * 1_000, 1)}. Zoom to see
-            more.
+    <div>
+      <GanttChart
+        data={customSeriesData}
+        durationSeconds={durationSeconds}
+        height={height}
+        maxHeight={isExpanded ? contentHeight : height}
+        rowHeight={ROW_HEIGHT}
+        isDark={isDark}
+        seriesName={SERIES_NAME}
+        renderItem={renderItem}
+        emptyMessage={
+          <div className="flex flex-col items-center gap-0.5 text-center text-muted-foreground opacity-50">
+            <div className="font-medium">No Matching Entities</div>
+            <div className="text-xs">
+              Showing entities longer than {formatDuration(minUsageSeconds * 1_000, 1)}. Zoom to see
+              more.
+            </div>
           </div>
-        </div>
-      }
-      renderTooltip={renderTooltip}
-    />
+        }
+        renderTooltip={renderTooltip}
+      />
+      {canResize && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="h-3 w-full rounded-none border-t border-border/50 p-0 text-muted-foreground [&_svg]:size-3"
+          aria-label={isExpanded ? 'Collapse entities chart' : 'Expand entities chart'}
+          aria-expanded={isExpanded}
+          onClick={event => {
+            event.stopPropagation();
+            setIsExpanded(current => !current);
+          }}
+        >
+          {isExpanded ? <ChevronUp /> : <ChevronDown />}
+        </Button>
+      )}
+    </div>
   );
 }

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
@@ -195,6 +195,7 @@ export function LongEntitiesGantt({
         isDark={isDark}
         seriesName={SERIES_NAME}
         renderItem={renderItem}
+        animateHeight
         contentPaddingBottom={resizeControlHeight}
         gridSpacing={{
           ...TIMELINE_SPACING,
@@ -216,7 +217,7 @@ export function LongEntitiesGantt({
           type="button"
           variant="ghost"
           size="xs"
-          className="absolute bottom-0 left-0 z-10 h-3 rounded-none border-t border-border/50 bg-background/90 p-0 text-muted-foreground backdrop-blur-sm [&_svg]:size-3"
+          className="absolute bottom-0 left-0 z-10 h-3 rounded-none border-t border-border/50 bg-background/90 p-0 text-muted-foreground backdrop-blur-sm focus-visible:bg-accent focus-visible:ring-0 focus-visible:ring-offset-0 [&_svg]:size-3"
           style={{ right: TIMELINE_SPACING.right }}
           aria-label={isExpanded ? 'Collapse entities chart' : 'Expand entities chart'}
           aria-expanded={isExpanded}

--- a/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
+++ b/ui/packages/@quent/components/src/long-entities/LongEntitiesGantt.tsx
@@ -9,7 +9,7 @@ import {
   useTimelineEchartsTheme,
 } from '../timeline/timelineEchartsTheme';
 import { useZoomRange } from '@quent/hooks';
-import { withOpacity } from '@quent/utils';
+import { formatDuration, withOpacity } from '@quent/utils';
 import type { LongEntityEntry } from './types';
 import { GanttChart, type GanttRenderItem } from '../gantt-chart/GanttChart';
 import type { GanttHover } from '../gantt-chart/hover';
@@ -38,6 +38,7 @@ type SegmentDatum = {
 export interface LongEntitiesGanttProps {
   entries: LongEntityEntry[];
   durationSeconds: number;
+  minUsageSeconds: number;
   height?: number;
   /** Whether dark mode is active. Passed explicitly to decouple from ThemeContext. */
   isDark: boolean;
@@ -46,6 +47,7 @@ export interface LongEntitiesGanttProps {
 export function LongEntitiesGantt({
   entries,
   durationSeconds,
+  minUsageSeconds,
   height = LONG_ENTITIES_TIMELINE_HEIGHT,
   isDark,
 }: LongEntitiesGanttProps) {
@@ -178,7 +180,15 @@ export function LongEntitiesGantt({
       isDark={isDark}
       seriesName={SERIES_NAME}
       renderItem={renderItem}
-      emptyMessage="No entities"
+      emptyMessage={
+        <div className="flex flex-col items-center gap-0.5 text-center text-muted-foreground opacity-50">
+          <div className="font-medium">No Matching Entities</div>
+          <div className="text-xs">
+            Showing entities longer than {formatDuration(minUsageSeconds * 1_000, 1)}. Zoom to see
+            more.
+          </div>
+        </div>
+      }
       renderTooltip={renderTooltip}
     />
   );

--- a/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.test.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TimelineSettingsPopover } from './TimelineSettingsPopover';
+
+const mocks = vi.hoisted(() => ({
+  density: 'balanced' as 'less' | 'balanced' | 'more',
+  setDensity: vi.fn(),
+}));
+
+vi.mock('@quent/hooks', () => ({
+  useLongEntityDensity: () => mocks.density,
+  useSetLongEntityDensity: () => mocks.setDensity,
+}));
+
+vi.mock('../ui/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe('TimelineSettingsPopover', () => {
+  beforeEach(() => {
+    mocks.density = 'balanced';
+    mocks.setDensity.mockClear();
+  });
+
+  it('renders the three entity density snap points', () => {
+    render(<TimelineSettingsPopover />);
+
+    const slider = screen.getByRole('slider', { name: 'Entities' });
+    expect(slider).toHaveAttribute('min', '0');
+    expect(slider).toHaveAttribute('max', '2');
+    expect(slider).toHaveAttribute('step', '1');
+    expect(slider).toHaveValue('1');
+    expect(screen.getByText('Less')).toBeInTheDocument();
+    expect(screen.getByText('Balanced')).toBeInTheDocument();
+    expect(screen.getByText('More')).toBeInTheDocument();
+  });
+
+  it('updates the density when the slider moves', () => {
+    render(<TimelineSettingsPopover />);
+
+    fireEvent.change(screen.getByRole('slider', { name: 'Entities' }), {
+      target: { value: '2' },
+    });
+
+    expect(mocks.setDensity).toHaveBeenCalledWith('more');
+  });
+});

--- a/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.test.tsx
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TimelineSettingsPopover } from './TimelineSettingsPopover';
 
 const mocks = vi.hoisted(() => ({
-  density: 'balanced' as 'less' | 'balanced' | 'more',
+  density: 3 as 1 | 2 | 3 | 4 | 5,
   setDensity: vi.fn(),
 }));
 
@@ -24,20 +24,19 @@ vi.mock('../ui/popover', () => ({
 
 describe('TimelineSettingsPopover', () => {
   beforeEach(() => {
-    mocks.density = 'balanced';
+    mocks.density = 3;
     mocks.setDensity.mockClear();
   });
 
-  it('renders the three entity density snap points', () => {
+  it('renders the five entity density snap points', () => {
     render(<TimelineSettingsPopover />);
 
     const slider = screen.getByRole('slider', { name: 'Entities' });
-    expect(slider).toHaveAttribute('min', '0');
-    expect(slider).toHaveAttribute('max', '2');
+    expect(slider).toHaveAttribute('min', '1');
+    expect(slider).toHaveAttribute('max', '5');
     expect(slider).toHaveAttribute('step', '1');
-    expect(slider).toHaveValue('1');
+    expect(slider).toHaveValue('3');
     expect(screen.getByText('Less')).toBeInTheDocument();
-    expect(screen.getByText('Balanced')).toBeInTheDocument();
     expect(screen.getByText('More')).toBeInTheDocument();
   });
 
@@ -45,9 +44,9 @@ describe('TimelineSettingsPopover', () => {
     render(<TimelineSettingsPopover />);
 
     fireEvent.change(screen.getByRole('slider', { name: 'Entities' }), {
-      target: { value: '2' },
+      target: { value: '5' },
     });
 
-    expect(mocks.setDensity).toHaveBeenCalledWith('more');
+    expect(mocks.setDensity).toHaveBeenCalledWith(5);
   });
 });

--- a/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.test.tsx
@@ -4,14 +4,16 @@
 import type { ReactNode } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LongEntityDensity } from '@quent/hooks';
 import { TimelineSettingsPopover } from './TimelineSettingsPopover';
 
 const mocks = vi.hoisted(() => ({
-  density: 3 as 1 | 2 | 3 | 4 | 5,
+  density: 3 as LongEntityDensity,
   setDensity: vi.fn(),
 }));
 
-vi.mock('@quent/hooks', () => ({
+vi.mock('@quent/hooks', async importOriginal => ({
+  ...(await importOriginal<typeof import('@quent/hooks')>()),
   useLongEntityDensity: () => mocks.density,
   useSetLongEntityDensity: () => mocks.setDensity,
 }));

--- a/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.tsx
@@ -10,13 +10,12 @@ import {
 } from '@quent/hooks';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 
-const DENSITY_STEPS: LongEntityDensity[] = ['less', 'balanced', 'more'];
+const DENSITY_RANGE: readonly [LongEntityDensity, LongEntityDensity] = [1, 5];
 
 export function TimelineSettingsPopover() {
   const density = useLongEntityDensity();
   const setDensity = useSetLongEntityDensity();
   const sliderId = useId();
-  const value = DENSITY_STEPS.indexOf(density);
 
   return (
     <Popover>
@@ -37,20 +36,25 @@ export function TimelineSettingsPopover() {
         <input
           id={sliderId}
           type="range"
-          min={0}
-          max={DENSITY_STEPS.length - 1}
+          min={DENSITY_RANGE[0]}
+          max={DENSITY_RANGE[1]}
           step={1}
-          value={value}
-          aria-valuetext={density}
+          value={density}
+          aria-valuetext={`${density} out of ${DENSITY_RANGE[1]}`}
           onChange={event => {
-            const nextDensity = DENSITY_STEPS[Number(event.target.value)];
-            if (nextDensity) setDensity(nextDensity);
+            const nextDensity = Number(event.target.value);
+            if (
+              Number.isInteger(nextDensity) &&
+              nextDensity >= DENSITY_RANGE[0] &&
+              nextDensity <= DENSITY_RANGE[1]
+            ) {
+              setDensity(nextDensity as LongEntityDensity);
+            }
           }}
           className="mt-2 h-1.5 w-full cursor-pointer accent-primary"
         />
         <div aria-hidden className="mt-1 flex justify-between text-[10px] text-muted-foreground">
           <span>Less</span>
-          <span>Balanced</span>
           <span>More</span>
         </div>
       </PopoverContent>

--- a/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.tsx
@@ -2,9 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Settings } from 'lucide-react';
+import { useId } from 'react';
+import {
+  useLongEntityDensity,
+  useSetLongEntityDensity,
+  type LongEntityDensity,
+} from '@quent/hooks';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 
+const DENSITY_STEPS: LongEntityDensity[] = ['less', 'balanced', 'more'];
+
 export function TimelineSettingsPopover() {
+  const density = useLongEntityDensity();
+  const setDensity = useSetLongEntityDensity();
+  const sliderId = useId();
+  const value = DENSITY_STEPS.indexOf(density);
+
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -17,7 +30,30 @@ export function TimelineSettingsPopover() {
           <Settings className="h-3.5 w-3.5" />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="text-xs text-muted-foreground">No settings yet.</PopoverContent>
+      <PopoverContent className="w-56">
+        <label htmlFor={sliderId} className="text-xs font-medium text-foreground">
+          Entities
+        </label>
+        <input
+          id={sliderId}
+          type="range"
+          min={0}
+          max={DENSITY_STEPS.length - 1}
+          step={1}
+          value={value}
+          aria-valuetext={density}
+          onChange={event => {
+            const nextDensity = DENSITY_STEPS[Number(event.target.value)];
+            if (nextDensity) setDensity(nextDensity);
+          }}
+          className="mt-2 h-1.5 w-full cursor-pointer accent-primary"
+        />
+        <div aria-hidden className="mt-1 flex justify-between text-[10px] text-muted-foreground">
+          <span>Less</span>
+          <span>Balanced</span>
+          <span>More</span>
+        </div>
+      </PopoverContent>
     </Popover>
   );
 }

--- a/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineSettingsPopover.tsx
@@ -4,13 +4,19 @@
 import { Settings } from 'lucide-react';
 import { useId } from 'react';
 import {
+  LONG_ENTITY_DENSITIES,
   useLongEntityDensity,
   useSetLongEntityDensity,
   type LongEntityDensity,
 } from '@quent/hooks';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 
-const DENSITY_RANGE: readonly [LongEntityDensity, LongEntityDensity] = [1, 5];
+const DENSITY_MIN = Math.min(...LONG_ENTITY_DENSITIES);
+const DENSITY_MAX = Math.max(...LONG_ENTITY_DENSITIES);
+
+function isLongEntityDensity(value: number): value is LongEntityDensity {
+  return LONG_ENTITY_DENSITIES.some(density => density === value);
+}
 
 export function TimelineSettingsPopover() {
   const density = useLongEntityDensity();
@@ -36,19 +42,15 @@ export function TimelineSettingsPopover() {
         <input
           id={sliderId}
           type="range"
-          min={DENSITY_RANGE[0]}
-          max={DENSITY_RANGE[1]}
+          min={DENSITY_MIN}
+          max={DENSITY_MAX}
           step={1}
           value={density}
-          aria-valuetext={`${density} out of ${DENSITY_RANGE[1]}`}
+          aria-valuetext={`${density} out of ${DENSITY_MAX}`}
           onChange={event => {
             const nextDensity = Number(event.target.value);
-            if (
-              Number.isInteger(nextDensity) &&
-              nextDensity >= DENSITY_RANGE[0] &&
-              nextDensity <= DENSITY_RANGE[1]
-            ) {
-              setDensity(nextDensity as LongEntityDensity);
+            if (isLongEntityDensity(nextDensity)) {
+              setDensity(nextDensity);
             }
           }}
           className="mt-2 h-1.5 w-full cursor-pointer accent-primary"

--- a/ui/packages/@quent/components/src/timeline/TimelineToolbar.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineToolbar.tsx
@@ -4,8 +4,9 @@
 import { Maximize2 } from 'lucide-react';
 import { useSetZoomRange, useSetDebouncedZoomRange } from '@quent/hooks';
 import { QueryToolbar } from './QueryToolbar';
+import { TimelineSettingsPopover } from './TimelineSettingsPopover';
 
-/** Toolbar for the timeline view: shows the active operator filter and zoom reset. */
+/** Toolbar for the timeline view: shows the active operator filter, zoom reset, and settings. */
 export function TimelineToolbar({ durationSeconds }: { durationSeconds: number }) {
   const setZoomRange = useSetZoomRange();
   const setDebouncedZoomRange = useSetDebouncedZoomRange();
@@ -26,6 +27,8 @@ export function TimelineToolbar({ durationSeconds }: { durationSeconds: number }
         <Maximize2 className="h-3 w-3" />
         <span>Reset zoom</span>
       </button>
+      <div className="h-3 w-px bg-border" />
+      <TimelineSettingsPopover />
     </QueryToolbar>
   );
 }

--- a/ui/packages/@quent/components/src/timeline/TimelineTooltip.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineTooltip.test.tsx
@@ -103,20 +103,13 @@ describe('TooltipContent active marks', () => {
     expect(screen.getAllByText('500.00ms')).toHaveLength(6);
   });
 
-  it('uses compact rows when more than six entities overlap', () => {
+  it('caps detailed rows and reports entities not shown', () => {
     render(<EntityTooltipContent timestamp={1_000} windowMs={5_000} activeMarks={makeMarks(7)} />);
 
-    expect(screen.getByText('task-6')).toBeInTheDocument();
-    expect(screen.queryByText('duration')).not.toBeInTheDocument();
-    expect(screen.queryByText('500.00ms')).not.toBeInTheDocument();
-  });
-
-  it('caps compact rows and reports entities not shown', () => {
-    render(<EntityTooltipContent timestamp={1_000} windowMs={5_000} activeMarks={makeMarks(10)} />);
-
     expect(screen.getByText('task-0')).toBeInTheDocument();
-    expect(screen.getByText('task-7')).toBeInTheDocument();
-    expect(screen.queryByText('task-8')).not.toBeInTheDocument();
-    expect(screen.getByText('2 more entities not shown')).toBeInTheDocument();
+    expect(screen.getByText('task-5')).toBeInTheDocument();
+    expect(screen.queryByText('task-6')).not.toBeInTheDocument();
+    expect(screen.getAllByText('500.00ms')).toHaveLength(6);
+    expect(screen.getByText('1 more entity not shown')).toBeInTheDocument();
   });
 });

--- a/ui/packages/@quent/components/src/timeline/TimelineTooltip.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineTooltip.test.tsx
@@ -12,6 +12,13 @@ const tagged = (v: object) => v as unknown as DynamicValue;
 
 describe('TooltipContent active marks', () => {
   const series = [{ color: '#8884d8', name: 'computing', value: 1 }];
+  const makeMarks = (count: number): ActiveMark[] =>
+    Array.from({ length: count }, (_, index) => ({
+      label: `task-${index}`,
+      stateName: 'computing',
+      color: '#ff0000',
+      durationMs: 500,
+    }));
 
   const renderWithMarks = (marks: ActiveMark[]) =>
     render(<TooltipContent timestamp={3360} series={series} windowMs={5300} activeMarks={marks} />);
@@ -88,5 +95,28 @@ describe('TooltipContent active marks', () => {
     expect(screen.getByText('task-0')).toBeInTheDocument();
     expect(screen.getByText('loading')).toBeInTheDocument();
     expect(screen.queryByText('Total')).not.toBeInTheDocument();
+  });
+
+  it('keeps full details for six or fewer overlapping entities', () => {
+    render(<EntityTooltipContent timestamp={1_000} windowMs={5_000} activeMarks={makeMarks(6)} />);
+
+    expect(screen.getAllByText('500.00ms')).toHaveLength(6);
+  });
+
+  it('uses compact rows when more than six entities overlap', () => {
+    render(<EntityTooltipContent timestamp={1_000} windowMs={5_000} activeMarks={makeMarks(7)} />);
+
+    expect(screen.getByText('task-6')).toBeInTheDocument();
+    expect(screen.queryByText('duration')).not.toBeInTheDocument();
+    expect(screen.queryByText('500.00ms')).not.toBeInTheDocument();
+  });
+
+  it('caps compact rows and reports entities not shown', () => {
+    render(<EntityTooltipContent timestamp={1_000} windowMs={5_000} activeMarks={makeMarks(10)} />);
+
+    expect(screen.getByText('task-0')).toBeInTheDocument();
+    expect(screen.getByText('task-7')).toBeInTheDocument();
+    expect(screen.queryByText('task-8')).not.toBeInTheDocument();
+    expect(screen.getByText('2 more entities not shown')).toBeInTheDocument();
   });
 });

--- a/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
@@ -199,43 +199,62 @@ function MarkDetailRow({ name, value }: { name: string; value: string }) {
   );
 }
 
+const DETAILED_ACTIVE_MARK_LIMIT = 6;
+const COMPACT_ACTIVE_MARK_LIMIT = 8;
+
 function ActiveMarksSection({ marks }: { marks: ActiveMark[] }) {
   if (marks.length === 0) return null;
+  const isCompact = marks.length > DETAILED_ACTIVE_MARK_LIMIT;
+  const visibleMarks = isCompact ? marks.slice(0, COMPACT_ACTIVE_MARK_LIMIT) : marks;
+  const hiddenCount = marks.length - visibleMarks.length;
+
   return (
     <div className="mt-1 pt-1 border-t border-border">
-      {marks.map((m, i) => (
+      {visibleMarks.map((m, i) => (
         <div key={i}>
           <div className="flex items-center gap-1">
             <ColorSwatch color={m.color} />
             <DataText className="text-muted-foreground">{m.label}</DataText>
             <DataText className="text-foreground font-medium ml-auto">{m.stateName}</DataText>
           </div>
-          {m.durationMs !== undefined && (
-            <MarkDetailRow name="duration" value={formatDuration(m.durationMs)} />
-          )}
-          {m.attributes?.map(attr => (
-            <MarkDetailRow
-              key={attr.key}
-              name={attr.key}
-              value={formatAttributeValue(attr.key, attr.value)}
-            />
-          ))}
-          {m.derivedAttributes && m.derivedAttributes.length > 0 && (
+          {!isCompact && (
             <>
-              <DataText as="div" className="pl-3 pt-0.5 text-muted-foreground italic opacity-70">
-                derived
-              </DataText>
-              {m.derivedAttributes.map(attr => (
+              {m.durationMs !== undefined && (
+                <MarkDetailRow name="duration" value={formatDuration(m.durationMs)} />
+              )}
+              {m.attributes?.map(attr => (
                 <MarkDetailRow
                   key={attr.key}
                   name={attr.key}
                   value={formatAttributeValue(attr.key, attr.value)}
                 />
               ))}
+              {m.derivedAttributes && m.derivedAttributes.length > 0 && (
+                <>
+                  <DataText
+                    as="div"
+                    className="pl-3 pt-0.5 text-muted-foreground italic opacity-70"
+                  >
+                    derived
+                  </DataText>
+                  {m.derivedAttributes.map(attr => (
+                    <MarkDetailRow
+                      key={attr.key}
+                      name={attr.key}
+                      value={formatAttributeValue(attr.key, attr.value)}
+                    />
+                  ))}
+                </>
+              )}
             </>
           )}
         </div>
       ))}
+      {hiddenCount > 0 && (
+        <DataText as="div" className="pt-1 text-muted-foreground">
+          {hiddenCount} more {hiddenCount === 1 ? 'entity' : 'entities'} not shown
+        </DataText>
+      )}
     </div>
   );
 }
@@ -347,7 +366,7 @@ export function EntityTooltipContent({
   activeMarks: ActiveMark[];
 }) {
   return (
-    <div className="px-2 py-1.5 bg-popover rounded text-[11px] text-foreground leading-tight shadow-md z-50">
+    <div className="max-h-[50vh] overflow-hidden px-2 py-1.5 bg-popover rounded text-[11px] text-foreground leading-tight shadow-md z-50">
       <DataText as="div" className="font-semibold mb-1 text-muted-foreground">
         {formatDurationForWindow(timestamp, windowMs)}
       </DataText>

--- a/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
@@ -357,7 +357,7 @@ export function EntityTooltipContent({
   activeMarks: ActiveMark[];
 }) {
   return (
-    <div className="max-h-[50vh] overflow-hidden px-2 py-1.5 bg-popover rounded text-[11px] text-foreground leading-tight shadow-md z-50">
+    <div className="max-h-[50vh] overflow-y-auto overflow-x-hidden px-2 py-1.5 bg-popover rounded text-[11px] text-foreground leading-tight shadow-md z-50">
       <DataText as="div" className="font-semibold mb-1 text-muted-foreground">
         {formatDurationForWindow(timestamp, windowMs)}
       </DataText>

--- a/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
@@ -199,13 +199,11 @@ function MarkDetailRow({ name, value }: { name: string; value: string }) {
   );
 }
 
-const DETAILED_ACTIVE_MARK_LIMIT = 6;
-const COMPACT_ACTIVE_MARK_LIMIT = 8;
+const ACTIVE_MARK_LIMIT = 6;
 
 function ActiveMarksSection({ marks }: { marks: ActiveMark[] }) {
   if (marks.length === 0) return null;
-  const isCompact = marks.length > DETAILED_ACTIVE_MARK_LIMIT;
-  const visibleMarks = isCompact ? marks.slice(0, COMPACT_ACTIVE_MARK_LIMIT) : marks;
+  const visibleMarks = marks.slice(0, ACTIVE_MARK_LIMIT);
   const hiddenCount = marks.length - visibleMarks.length;
 
   return (
@@ -217,35 +215,28 @@ function ActiveMarksSection({ marks }: { marks: ActiveMark[] }) {
             <DataText className="text-muted-foreground">{m.label}</DataText>
             <DataText className="text-foreground font-medium ml-auto">{m.stateName}</DataText>
           </div>
-          {!isCompact && (
+          {m.durationMs !== undefined && (
+            <MarkDetailRow name="duration" value={formatDuration(m.durationMs)} />
+          )}
+          {m.attributes?.map(attr => (
+            <MarkDetailRow
+              key={attr.key}
+              name={attr.key}
+              value={formatAttributeValue(attr.key, attr.value)}
+            />
+          ))}
+          {m.derivedAttributes && m.derivedAttributes.length > 0 && (
             <>
-              {m.durationMs !== undefined && (
-                <MarkDetailRow name="duration" value={formatDuration(m.durationMs)} />
-              )}
-              {m.attributes?.map(attr => (
+              <DataText as="div" className="pl-3 pt-0.5 text-muted-foreground italic opacity-70">
+                derived
+              </DataText>
+              {m.derivedAttributes.map(attr => (
                 <MarkDetailRow
                   key={attr.key}
                   name={attr.key}
                   value={formatAttributeValue(attr.key, attr.value)}
                 />
               ))}
-              {m.derivedAttributes && m.derivedAttributes.length > 0 && (
-                <>
-                  <DataText
-                    as="div"
-                    className="pl-3 pt-0.5 text-muted-foreground italic opacity-70"
-                  >
-                    derived
-                  </DataText>
-                  {m.derivedAttributes.map(attr => (
-                    <MarkDetailRow
-                      key={attr.key}
-                      name={attr.key}
-                      value={formatAttributeValue(attr.key, attr.value)}
-                    />
-                  ))}
-                </>
-              )}
             </>
           )}
         </div>

--- a/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineTooltip.tsx
@@ -357,7 +357,7 @@ export function EntityTooltipContent({
   activeMarks: ActiveMark[];
 }) {
   return (
-    <div className="max-h-[50vh] overflow-y-auto overflow-x-hidden px-2 py-1.5 bg-popover rounded text-[11px] text-foreground leading-tight shadow-md z-50">
+    <div className="overflow-x-hidden px-2 py-1.5 bg-popover rounded text-[11px] text-foreground leading-tight shadow-md z-50">
       <DataText as="div" className="font-semibold mb-1 text-muted-foreground">
         {formatDurationForWindow(timestamp, windowMs)}
       </DataText>

--- a/ui/packages/@quent/hooks/src/atoms/timeline.ts
+++ b/ui/packages/@quent/hooks/src/atoms/timeline.ts
@@ -42,6 +42,11 @@ export const zoomRangeAtom = atom<ZoomRange>({ start: 0, end: 0 });
 /** Debounced zoom range — settles after ZOOM_DEBOUNCE_MS, drives the bulk query */
 export const debouncedZoomRangeAtom = atom<ZoomRange>({ start: 0, end: 0 });
 
+export type LongEntityDensity = 'less' | 'balanced' | 'more';
+
+/** Controls the minimum usage threshold for entities shown in timeline rows. */
+export const longEntityDensityAtom = atom<LongEntityDensity>('balanced');
+
 /**
  * Pointer-level hover state used to drive an app-rendered timeline tooltip.
  *

--- a/ui/packages/@quent/hooks/src/atoms/timeline.ts
+++ b/ui/packages/@quent/hooks/src/atoms/timeline.ts
@@ -42,7 +42,8 @@ export const zoomRangeAtom = atom<ZoomRange>({ start: 0, end: 0 });
 /** Debounced zoom range — settles after ZOOM_DEBOUNCE_MS, drives the bulk query */
 export const debouncedZoomRangeAtom = atom<ZoomRange>({ start: 0, end: 0 });
 
-export type LongEntityDensity = 1 | 2 | 3 | 4 | 5;
+export const LONG_ENTITY_DENSITIES = [1, 2, 3, 4, 5] as const;
+export type LongEntityDensity = (typeof LONG_ENTITY_DENSITIES)[number];
 
 /** Controls the minimum usage threshold for entities shown in timeline rows. */
 export const longEntityDensityAtom = atom<LongEntityDensity>(3);

--- a/ui/packages/@quent/hooks/src/atoms/timeline.ts
+++ b/ui/packages/@quent/hooks/src/atoms/timeline.ts
@@ -42,10 +42,10 @@ export const zoomRangeAtom = atom<ZoomRange>({ start: 0, end: 0 });
 /** Debounced zoom range — settles after ZOOM_DEBOUNCE_MS, drives the bulk query */
 export const debouncedZoomRangeAtom = atom<ZoomRange>({ start: 0, end: 0 });
 
-export type LongEntityDensity = 'less' | 'balanced' | 'more';
+export type LongEntityDensity = 1 | 2 | 3 | 4 | 5;
 
 /** Controls the minimum usage threshold for entities shown in timeline rows. */
-export const longEntityDensityAtom = atom<LongEntityDensity>('balanced');
+export const longEntityDensityAtom = atom<LongEntityDensity>(3);
 
 /**
  * Pointer-level hover state used to drive an app-rendered timeline tooltip.

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -21,6 +21,8 @@ export {
   useSetZoomRange,
   useDebouncedZoomRange,
   useSetDebouncedZoomRange,
+  useLongEntityDensity,
+  useSetLongEntityDensity,
   useTimelineHover,
   useSetTimelineHover,
   useStartTimeMs,
@@ -34,7 +36,7 @@ export {
 
 // Timeline cache key helpers (consumers need these to address per-item data)
 export { timelineCacheKey } from './atoms/timeline';
-export type { TimelineCacheParams, TimelineHoverState } from './atoms/timeline';
+export type { LongEntityDensity, TimelineCacheParams, TimelineHoverState } from './atoms/timeline';
 export { bulkEntryId } from './timeline/timeline.utils';
 
 // Complex timeline hooks

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -17,6 +17,7 @@ export { useHoveredWorkerId, useSetHoveredWorkerId } from './dag/useHoveredWorke
 // Timeline hooks
 export {
   useTimelineData,
+  useReturnedTimelineNumBins,
   useZoomRange,
   useSetZoomRange,
   useDebouncedZoomRange,

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -18,6 +18,7 @@ export { useHoveredWorkerId, useSetHoveredWorkerId } from './dag/useHoveredWorke
 export {
   useTimelineData,
   useReturnedTimelineNumBins,
+  useReturnedTimelineIsStale,
   useZoomRange,
   useSetZoomRange,
   useDebouncedZoomRange,

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -36,7 +36,7 @@ export {
 } from './timeline/useTimelineAtoms';
 
 // Timeline cache key helpers (consumers need these to address per-item data)
-export { timelineCacheKey } from './atoms/timeline';
+export { LONG_ENTITY_DENSITIES, timelineCacheKey } from './atoms/timeline';
 export type { LongEntityDensity, TimelineCacheParams, TimelineHoverState } from './atoms/timeline';
 export { bulkEntryId } from './timeline/timeline.utils';
 

--- a/ui/packages/@quent/hooks/src/timeline/timeline.utils.ts
+++ b/ui/packages/@quent/hooks/src/timeline/timeline.utils.ts
@@ -2,19 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { TimelineRequest, OperatorFilter } from '@quent/utils';
-
-/** Extract the resource_type_name from a TimelineRequest (empty string for Resource requests) */
-export function getResourceTypeName(params: TimelineRequest<OperatorFilter> | undefined): string {
-  if (!params) return '';
-  if ('ResourceGroup' in params) return params.ResourceGroup.resource_type_name;
-  return '';
-}
-
-/** Extract the entity_type_name (FSM filter) from a TimelineRequest */
-export function getFsmTypeName(params: TimelineRequest<OperatorFilter>): string | null {
-  if ('ResourceGroup' in params) return params.ResourceGroup.entity_filter.entity_type_name;
-  return params.Resource.entity_filter.entity_type_name;
-}
+export { getFsmTypeName, getResourceTypeName } from '@quent/utils';
 
 /** Stable request-entry key for bulk timeline fetches. Omit operatorId for the base variant. */
 export function bulkEntryId(resourceId: string, operatorId?: string | null): string {

--- a/ui/packages/@quent/hooks/src/timeline/useBulkTimelineFetch.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useBulkTimelineFetch.ts
@@ -18,7 +18,7 @@ import {
   setOperatorOnEntry,
   bulkEntryId,
 } from './timeline.utils';
-import { timelineCacheKey, timelineDataMapAtom } from '../atoms/timeline';
+import { bulkInitializedAtom, timelineCacheKey, timelineDataMapAtom } from '../atoms/timeline';
 
 /**
  * Mirrors TimelineCacheParams so meta can be passed directly to timelineCacheKey.
@@ -128,7 +128,7 @@ export function useBulkTimelineFetch({
     requestKey,
   } = useMemo(() => buildMergedBulkEntries(entries, operatorId), [entries, operatorId]);
 
-  const { data } = useQuery<BulkTimelinesResponse>({
+  const { data, isFetched } = useQuery<BulkTimelinesResponse>({
     queryKey: ['bulkTimelines', engineId, queryId, debouncedZoomRange, requestKey],
     queryFn: () =>
       fetchBulkTimelines(engineId, {
@@ -144,6 +144,10 @@ export function useBulkTimelineFetch({
     if (!data) return;
     applyBulkTimelineResponse(data, idToMeta, store);
   }, [data, store, idToMeta]);
+
+  useEffect(() => {
+    if (isFetched) store.set(bulkInitializedAtom, true);
+  }, [isFetched, store]);
 
   return data;
 }

--- a/ui/packages/@quent/hooks/src/timeline/useBulkTimelines.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useBulkTimelines.ts
@@ -13,7 +13,6 @@ import {
   timelineDataMapAtom,
   zoomRangeAtom,
   debouncedZoomRangeAtom,
-  bulkInitializedAtom,
   visibleEntriesAtom,
 } from '../atoms/timeline';
 import { selectedNodeIdsAtom } from '../atoms/dag';
@@ -124,19 +123,13 @@ export function useBulkTimelines<T extends TreeNode>({
     store.set(visibleEntriesAtom, baseVisibleEntries);
   }, [baseVisibleEntries, store]);
 
-  const bulkData = useBulkTimelineFetch({
+  useBulkTimelineFetch({
     engineId,
     queryId,
     debouncedZoomRange,
     entries: baseVisibleEntries,
     operatorId,
   });
-
-  useEffect(() => {
-    if (bulkData) {
-      store.set(bulkInitializedAtom, true);
-    }
-  }, [bulkData, store]);
 
   // Zoom change handler — stable, uses store imperatively
   const handleZoomChange = useCallback(

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.test.tsx
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.test.tsx
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react';
+import { Provider, createStore } from 'jotai';
+import { describe, expect, it } from 'vitest';
+import type { OperatorFilter, SingleTimelineResponse, TimelineRequest } from '@quent/utils';
+import { timelineCacheKey, timelineDataMapAtom, visibleEntriesAtom } from '../atoms/timeline';
+import { useReturnedTimelineNumBins } from './useTimelineAtoms';
+
+describe('useReturnedTimelineNumBins', () => {
+  it('reads the returned bin count for the visible resource request', () => {
+    const store = createStore();
+    const request: TimelineRequest<OperatorFilter> = {
+      Resource: {
+        resource_id: 'resource-1',
+        long_entities_threshold_s: null,
+        entity_filter: { entity_type_name: 'fsm-1' },
+        application: { operator_ids: [] },
+        config: { num_bins: 200, start: 0, end: 1 },
+      },
+    };
+    const cacheKey = timelineCacheKey({
+      resourceId: 'resource-1',
+      resourceTypeName: '',
+      fsmTypeName: 'fsm-1',
+    });
+    const response: SingleTimelineResponse = {
+      config: {
+        span: { start: 0, end: 1 },
+        bin_duration: 0.0025,
+        num_bins: 400n,
+      },
+      data: {} as SingleTimelineResponse['data'],
+    };
+    store.set(visibleEntriesAtom, { 'resource-1': request });
+    store.set(timelineDataMapAtom, { [cacheKey]: response });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    const { result } = renderHook(() => useReturnedTimelineNumBins('resource-1'), { wrapper });
+
+    expect(result.current).toBe(400);
+  });
+});

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.test.tsx
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.test.tsx
@@ -6,8 +6,13 @@ import { renderHook } from '@testing-library/react';
 import { Provider, createStore } from 'jotai';
 import { describe, expect, it } from 'vitest';
 import type { OperatorFilter, SingleTimelineResponse, TimelineRequest } from '@quent/utils';
-import { timelineCacheKey, timelineDataMapAtom, visibleEntriesAtom } from '../atoms/timeline';
-import { useReturnedTimelineNumBins } from './useTimelineAtoms';
+import {
+  debouncedZoomRangeAtom,
+  timelineCacheKey,
+  timelineDataMapAtom,
+  visibleEntriesAtom,
+} from '../atoms/timeline';
+import { useReturnedTimelineIsStale, useReturnedTimelineNumBins } from './useTimelineAtoms';
 
 describe('useReturnedTimelineNumBins', () => {
   it('reads the returned bin count for the visible resource request', () => {
@@ -21,21 +26,22 @@ describe('useReturnedTimelineNumBins', () => {
         config: { num_bins: 200, start: 0, end: 1 },
       },
     };
-    const cacheKey = timelineCacheKey({
-      resourceId: 'resource-1',
-      resourceTypeName: '',
-      fsmTypeName: 'fsm-1',
-    });
     const response: SingleTimelineResponse = {
       config: {
-        span: { start: 0, end: 1 },
+        span: { start: -0.001, end: 1.001 },
         bin_duration: 0.0025,
         num_bins: 400n,
       },
       data: {} as SingleTimelineResponse['data'],
     };
+    const cacheKey = timelineCacheKey({
+      resourceId: 'resource-1',
+      resourceTypeName: '',
+      fsmTypeName: 'fsm-1',
+    });
     store.set(visibleEntriesAtom, { 'resource-1': request });
     store.set(timelineDataMapAtom, { [cacheKey]: response });
+    store.set(debouncedZoomRangeAtom, { start: 0, end: 1 });
     const wrapper = ({ children }: PropsWithChildren) => (
       <Provider store={store}>{children}</Provider>
     );
@@ -64,5 +70,47 @@ describe('useReturnedTimelineNumBins', () => {
     const { result } = renderHook(() => useReturnedTimelineNumBins('resource-1'), { wrapper });
 
     expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined while the cached response belongs to the previous viewport', () => {
+    const store = createStore();
+    const request: TimelineRequest<OperatorFilter> = {
+      Resource: {
+        resource_id: 'resource-1',
+        long_entities_threshold_s: null,
+        entity_filter: { entity_type_name: 'fsm-1' },
+        application: { operator_ids: [] },
+        config: { num_bins: 200, start: 0.25, end: 1 },
+      },
+    };
+    const cacheKey = timelineCacheKey({
+      resourceId: 'resource-1',
+      resourceTypeName: '',
+      fsmTypeName: 'fsm-1',
+    });
+    const response: SingleTimelineResponse = {
+      config: {
+        span: { start: 0, end: 1 },
+        bin_duration: 0.0025,
+        num_bins: 400n,
+      },
+      data: {} as SingleTimelineResponse['data'],
+    };
+    store.set(visibleEntriesAtom, { 'resource-1': request });
+    store.set(timelineDataMapAtom, { [cacheKey]: response });
+    store.set(debouncedZoomRangeAtom, { start: 0.25, end: 1 });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        numBins: useReturnedTimelineNumBins('resource-1'),
+        isStale: useReturnedTimelineIsStale('resource-1'),
+      }),
+      { wrapper }
+    );
+
+    expect(result.current).toEqual({ numBins: undefined, isStale: true });
   });
 });

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.test.tsx
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.test.tsx
@@ -44,4 +44,25 @@ describe('useReturnedTimelineNumBins', () => {
 
     expect(result.current).toBe(400);
   });
+
+  it('returns undefined when no response is cached', () => {
+    const store = createStore();
+    const request: TimelineRequest<OperatorFilter> = {
+      Resource: {
+        resource_id: 'resource-1',
+        long_entities_threshold_s: null,
+        entity_filter: { entity_type_name: 'fsm-1' },
+        application: { operator_ids: [] },
+        config: { num_bins: 200, start: 0, end: 1 },
+      },
+    };
+    store.set(visibleEntriesAtom, { 'resource-1': request });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    const { result } = renderHook(() => useReturnedTimelineNumBins('resource-1'), { wrapper });
+
+    expect(result.current).toBeUndefined();
+  });
 });

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
@@ -14,7 +14,7 @@ import {
   longEntityDensityAtom,
   timelineCacheKey,
 } from '../atoms/timeline';
-import type { ZoomRange, SingleTimelineResponse } from '@quent/utils';
+import { type ZoomRange, type SingleTimelineResponse } from '@quent/utils';
 import { getFsmTypeName, getResourceTypeName } from './timeline.utils';
 
 // Record-based replacement for atomFamily(timelineDataAtom(key))

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
@@ -14,8 +14,12 @@ import {
   longEntityDensityAtom,
   timelineCacheKey,
 } from '../atoms/timeline';
-import { type ZoomRange, type SingleTimelineResponse } from '@quent/utils';
-import { getFsmTypeName, getResourceTypeName } from './timeline.utils';
+import {
+  getFsmTypeName,
+  getResourceTypeName,
+  type ZoomRange,
+  type SingleTimelineResponse,
+} from '@quent/utils';
 
 // Record-based replacement for atomFamily(timelineDataAtom(key))
 export function useTimelineData(key: string): SingleTimelineResponse | undefined {

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
@@ -27,23 +27,37 @@ export function useTimelineData(key: string): SingleTimelineResponse | undefined
   return map[key];
 }
 
-function useReturnedTimelineData(resourceId: string): SingleTimelineResponse | undefined {
+function useReturnedTimelineState(resourceId: string): {
+  data: SingleTimelineResponse | undefined;
+  isStale: boolean;
+} {
   const timelineDataMap = useAtomValue(timelineDataMapAtom);
   const visibleEntries = useAtomValue(visibleEntriesAtom);
+  const activeSpan = useAtomValue(debouncedZoomRangeAtom);
   const request = visibleEntries[resourceId];
-  if (!request) return undefined;
+  if (!request) return { data: undefined, isStale: false };
   const key = timelineCacheKey({
     resourceId,
     resourceTypeName: getResourceTypeName(request),
     fsmTypeName: getFsmTypeName(request),
   });
-  return timelineDataMap[key];
+  const data = timelineDataMap[key];
+  if (!data) return { data: undefined, isStale: false };
+  const tolerance = data.config.bin_duration;
+  const matchesActiveSpan =
+    Math.abs(data.config.span.start - activeSpan.start) <= tolerance &&
+    Math.abs(data.config.span.end - activeSpan.end) <= tolerance;
+  return matchesActiveSpan ? { data, isStale: false } : { data: undefined, isStale: true };
 }
 
 export function useReturnedTimelineNumBins(resourceId: string): number | undefined {
-  const data = useReturnedTimelineData(resourceId);
+  const { data } = useReturnedTimelineState(resourceId);
   const numBins = Number(data?.config.num_bins);
   return Number.isInteger(numBins) && numBins > 0 ? numBins : undefined;
+}
+
+export function useReturnedTimelineIsStale(resourceId: string): boolean {
+  return useReturnedTimelineState(resourceId).isStale;
 }
 
 export const useZoomRange = () => useAtomValue(zoomRangeAtom);

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
@@ -11,6 +11,7 @@ import {
   startTimeMsAtom,
   bulkInitializedAtom,
   visibleEntriesAtom,
+  longEntityDensityAtom,
 } from '../atoms/timeline';
 import type { ZoomRange, SingleTimelineResponse } from '@quent/utils';
 
@@ -24,6 +25,8 @@ export const useZoomRange = () => useAtomValue(zoomRangeAtom);
 export const useSetZoomRange = () => useSetAtom(zoomRangeAtom);
 export const useDebouncedZoomRange = () => useAtomValue(debouncedZoomRangeAtom);
 export const useSetDebouncedZoomRange = () => useSetAtom(debouncedZoomRangeAtom);
+export const useLongEntityDensity = () => useAtomValue(longEntityDensityAtom);
+export const useSetLongEntityDensity = () => useSetAtom(longEntityDensityAtom);
 export const useTimelineHover = () => useAtomValue(timelineHoverAtom);
 export const useSetTimelineHover = () => useSetAtom(timelineHoverAtom);
 export const useStartTimeMs = () => useAtomValue(startTimeMsAtom);

--- a/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
+++ b/ui/packages/@quent/hooks/src/timeline/useTimelineAtoms.ts
@@ -12,13 +12,34 @@ import {
   bulkInitializedAtom,
   visibleEntriesAtom,
   longEntityDensityAtom,
+  timelineCacheKey,
 } from '../atoms/timeline';
 import type { ZoomRange, SingleTimelineResponse } from '@quent/utils';
+import { getFsmTypeName, getResourceTypeName } from './timeline.utils';
 
 // Record-based replacement for atomFamily(timelineDataAtom(key))
 export function useTimelineData(key: string): SingleTimelineResponse | undefined {
   const map = useAtomValue(timelineDataMapAtom);
   return map[key];
+}
+
+function useReturnedTimelineData(resourceId: string): SingleTimelineResponse | undefined {
+  const timelineDataMap = useAtomValue(timelineDataMapAtom);
+  const visibleEntries = useAtomValue(visibleEntriesAtom);
+  const request = visibleEntries[resourceId];
+  if (!request) return undefined;
+  const key = timelineCacheKey({
+    resourceId,
+    resourceTypeName: getResourceTypeName(request),
+    fsmTypeName: getFsmTypeName(request),
+  });
+  return timelineDataMap[key];
+}
+
+export function useReturnedTimelineNumBins(resourceId: string): number | undefined {
+  const data = useReturnedTimelineData(resourceId);
+  const numBins = Number(data?.config.num_bins);
+  return Number.isInteger(numBins) && numBins > 0 ? numBins : undefined;
 }
 
 export const useZoomRange = () => useAtomValue(zoomRangeAtom);

--- a/ui/packages/@quent/utils/src/index.ts
+++ b/ui/packages/@quent/utils/src/index.ts
@@ -4,6 +4,7 @@
 // Utilities
 export { cn } from './cn';
 export { parseJsonWithBigInt } from './parseJsonWithBigInt';
+export { getFsmTypeName, getResourceTypeName } from './timeline';
 
 // Color utilities
 export {

--- a/ui/packages/@quent/utils/src/timeline.ts
+++ b/ui/packages/@quent/utils/src/timeline.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OperatorFilter, TimelineRequest } from './types';
+
+export function getResourceTypeName(request: TimelineRequest<OperatorFilter> | undefined): string {
+  if (!request || !('ResourceGroup' in request)) return '';
+  return request.ResourceGroup.resource_type_name;
+}
+
+export function getFsmTypeName(request: TimelineRequest<OperatorFilter>): string | null {
+  return 'ResourceGroup' in request
+    ? request.ResourceGroup.entity_filter.entity_type_name
+    : request.Resource.entity_filter.entity_type_name;
+}

--- a/ui/src/components/LongEntitiesRow.test.tsx
+++ b/ui/src/components/LongEntitiesRow.test.tsx
@@ -8,7 +8,7 @@ import { LongEntitiesRow } from './LongEntitiesRow';
 
 const mocks = vi.hoisted(() => ({
   buildLongEntityEntries: vi.fn((items: unknown[]) => items),
-  fetchNextPage: vi.fn(),
+  debouncedZoomRange: { start: 0.2, end: 0.6 },
   getLongEntitiesThreshold: vi.fn(
     (_windowSeconds: number, density: 'less' | 'balanced' | 'more') =>
       ({ less: 0.12, balanced: 0.06, more: 0.03 })[density]
@@ -17,15 +17,15 @@ const mocks = vi.hoisted(() => ({
   longEntitiesGantt: vi.fn(
     (_props: { entries: unknown[]; height: number; minUsageSeconds: number }) => null
   ),
-  useInfiniteEntityList: vi.fn(),
+  useEntityList: vi.fn(),
 }));
 
 vi.mock('@quent/client', () => ({
-  useInfiniteEntityList: mocks.useInfiniteEntityList,
+  useEntityList: mocks.useEntityList,
 }));
 
 vi.mock('@quent/hooks', () => ({
-  useDebouncedZoomRange: () => ({ start: 0.2, end: 0.6 }),
+  useDebouncedZoomRange: () => mocks.debouncedZoomRange,
   useLongEntityDensity: () => mocks.longEntityDensity,
   useSelectedNodeIds: () => new Set(['operator-1']),
 }));
@@ -47,13 +47,11 @@ vi.mock('@quent/components', () => ({
 describe('LongEntitiesRow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.debouncedZoomRange = { start: 0.2, end: 0.6 };
     mocks.longEntityDensity = 'balanced';
-    mocks.useInfiniteEntityList.mockReturnValue({
+    mocks.useEntityList.mockReturnValue({
       data: undefined,
-      fetchNextPage: mocks.fetchNextPage,
-      hasNextPage: false,
       isFetching: false,
-      isFetchingNextPage: false,
       isPlaceholderData: false,
     });
   });
@@ -72,7 +70,7 @@ describe('LongEntitiesRow', () => {
 
     expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[0]).toBeCloseTo(0.4);
     expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[1]).toBe('balanced');
-    expect(mocks.useInfiniteEntityList).toHaveBeenCalledWith(
+    expect(mocks.useEntityList).toHaveBeenCalledWith(
       expect.objectContaining({
         window: { start: 0.2, end: 0.6 },
         operatorIds: ['operator-1'],
@@ -99,7 +97,7 @@ describe('LongEntitiesRow', () => {
       />
     );
 
-    expect(mocks.useInfiniteEntityList).toHaveBeenCalledWith(
+    expect(mocks.useEntityList).toHaveBeenCalledWith(
       expect.objectContaining({ minUsageSeconds: 0.12 })
     );
   });
@@ -126,12 +124,9 @@ describe('LongEntitiesRow', () => {
   });
 
   it('renders a chart-shaped skeleton during the initial load', () => {
-    mocks.useInfiniteEntityList.mockReturnValue({
+    mocks.useEntityList.mockReturnValue({
       data: undefined,
-      fetchNextPage: mocks.fetchNextPage,
-      hasNextPage: false,
       isFetching: true,
-      isFetchingNextPage: false,
       isPlaceholderData: false,
     });
 
@@ -151,15 +146,12 @@ describe('LongEntitiesRow', () => {
     expect(screen.queryByText('Loading entities…')).not.toBeInTheDocument();
   });
 
-  it('loads the next page and appends its entities', () => {
+  it('increases the entity limit and keeps it across viewport changes', () => {
     const firstEntity = { id: 'entity-1' };
     const secondEntity = { id: 'entity-2' };
-    mocks.useInfiniteEntityList.mockReturnValue({
-      data: { pages: [{ items: [firstEntity], total: 2 }] },
-      fetchNextPage: mocks.fetchNextPage,
-      hasNextPage: true,
+    mocks.useEntityList.mockReturnValue({
+      data: { items: [firstEntity], total: 2 },
       isFetching: false,
-      isFetchingNextPage: false,
       isPlaceholderData: false,
     });
 
@@ -176,23 +168,24 @@ describe('LongEntitiesRow', () => {
     const button = screen.getByRole('button', { name: 'Show more (1 of 2)' });
     expect(screen.getByTestId('long-entities-gantt').nextElementSibling).toContainElement(button);
     fireEvent.click(button);
-    expect(mocks.fetchNextPage).toHaveBeenCalledOnce();
+    expect(mocks.useEntityList).toHaveBeenLastCalledWith(
+      expect.objectContaining({ maxItems: 200 })
+    );
 
-    mocks.useInfiniteEntityList.mockReturnValue({
-      data: {
-        pages: [
-          { items: [firstEntity], total: 2 },
-          { items: [secondEntity], total: 2 },
-        ],
-      },
-      fetchNextPage: mocks.fetchNextPage,
-      hasNextPage: false,
+    mocks.debouncedZoomRange = { start: 0.3, end: 0.7 };
+    mocks.useEntityList.mockReturnValue({
+      data: { items: [firstEntity, secondEntity], total: 2 },
       isFetching: false,
-      isFetchingNextPage: false,
       isPlaceholderData: false,
     });
     rerender(<LongEntitiesRow {...props} />);
 
+    expect(mocks.useEntityList).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        window: { start: 0.3, end: 0.7 },
+        maxItems: 200,
+      })
+    );
     expect(mocks.buildLongEntityEntries).toHaveBeenLastCalledWith(
       [firstEntity, secondEntity],
       {},
@@ -202,14 +195,49 @@ describe('LongEntitiesRow', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
+  it('keeps a loading button when more entities will remain', () => {
+    const firstEntity = { id: 'entity-1' };
+    mocks.useEntityList.mockReturnValue({
+      data: { items: [firstEntity], total: 250 },
+      isFetching: false,
+      isPlaceholderData: false,
+    });
+
+    const props = {
+      engineId: 'engine-1',
+      queryId: 'query-1',
+      resourceId: 'resource-1',
+      durationSeconds: 1,
+      fsmTypes: {},
+      isDark: false,
+    };
+    const { rerender } = render(<LongEntitiesRow {...props} />);
+
+    mocks.useEntityList.mockReturnValue({
+      data: { items: [firstEntity], total: 250 },
+      isFetching: true,
+      isPlaceholderData: true,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Show more (1 of 250)' }));
+
+    expect(screen.getByRole('button', { name: 'Loading...' })).toBeDisabled();
+
+    const secondEntity = { id: 'entity-2' };
+    mocks.useEntityList.mockReturnValue({
+      data: { items: [firstEntity, secondEntity], total: 250 },
+      isFetching: false,
+      isPlaceholderData: false,
+    });
+    rerender(<LongEntitiesRow {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Show more (2 of 250)' })).toBeEnabled();
+  });
+
   it('keeps the previous entities visible while a changed request loads', () => {
     const previousEntity = { id: 'entity-1' };
-    mocks.useInfiniteEntityList.mockReturnValue({
-      data: { pages: [{ items: [previousEntity], total: 2 }] },
-      fetchNextPage: mocks.fetchNextPage,
-      hasNextPage: true,
+    mocks.useEntityList.mockReturnValue({
+      data: { items: [previousEntity], total: 2 },
       isFetching: true,
-      isFetchingNextPage: false,
       isPlaceholderData: true,
     });
 

--- a/ui/src/components/LongEntitiesRow.test.tsx
+++ b/ui/src/components/LongEntitiesRow.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   ),
   longEntityDensity: 3 as LongEntityDensity,
   returnedNumBins: 400 as number | undefined,
+  returnedTimelineIsStale: false,
   longEntitiesGantt: vi.fn(
     (_props: { entries: unknown[]; height: number; minUsageSeconds: number }) => null
   ),
@@ -32,6 +33,7 @@ vi.mock('@quent/hooks', () => ({
   useBulkInitialized: () => mocks.bulkInitialized,
   useDebouncedZoomRange: () => mocks.debouncedZoomRange,
   useLongEntityDensity: () => mocks.longEntityDensity,
+  useReturnedTimelineIsStale: () => mocks.returnedTimelineIsStale,
   useReturnedTimelineNumBins: () => mocks.returnedNumBins,
   useSelectedNodeIds: () => new Set(['operator-1']),
 }));
@@ -57,6 +59,7 @@ describe('LongEntitiesRow', () => {
     mocks.debouncedZoomRange = { start: 0.2, end: 0.6 };
     mocks.longEntityDensity = 3;
     mocks.returnedNumBins = 400;
+    mocks.returnedTimelineIsStale = false;
     mocks.useEntityList.mockReturnValue({
       data: undefined,
       isFetching: false,
@@ -160,6 +163,35 @@ describe('LongEntitiesRow', () => {
       { enabled: false }
     );
     expect(screen.getByRole('status', { name: 'Loading entities' })).toBeInTheDocument();
+  });
+
+  it('keeps the previous chart visible while a new viewport timeline loads', () => {
+    const previousEntity = { id: 'entity-1' };
+    mocks.useEntityList.mockReturnValue({
+      data: { items: [previousEntity], total: 1 },
+      isFetching: false,
+      isPlaceholderData: false,
+    });
+    const props = {
+      engineId: 'engine-1',
+      queryId: 'query-1',
+      resourceId: 'resource-1',
+      durationSeconds: 1,
+      fsmTypes: {},
+      isDark: false,
+    };
+    const { rerender } = render(<LongEntitiesRow {...props} />);
+
+    mocks.returnedNumBins = undefined;
+    mocks.returnedTimelineIsStale = true;
+    rerender(<LongEntitiesRow {...props} />);
+
+    expect(mocks.useEntityList).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minUsageSeconds: null }),
+      { enabled: false }
+    );
+    expect(screen.queryByRole('status', { name: 'Loading entities' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('long-entities-gantt')).toBeInTheDocument();
   });
 
   it('can limit FSM states to those used on the associated resource', () => {

--- a/ui/src/components/LongEntitiesRow.test.tsx
+++ b/ui/src/components/LongEntitiesRow.test.tsx
@@ -10,10 +10,10 @@ const mocks = vi.hoisted(() => ({
   buildLongEntityEntries: vi.fn((items: unknown[]) => items),
   debouncedZoomRange: { start: 0.2, end: 0.6 },
   getLongEntitiesThreshold: vi.fn(
-    (_windowSeconds: number, density: 'less' | 'balanced' | 'more') =>
-      ({ less: 0.12, balanced: 0.06, more: 0.03 })[density]
+    (_windowSeconds: number, density: 1 | 2 | 3 | 4 | 5) =>
+      ({ 1: 0.15, 2: 0.12, 3: 0.09, 4: 0.06, 5: 0.03 })[density]
   ),
-  longEntityDensity: 'balanced' as 'less' | 'balanced' | 'more',
+  longEntityDensity: 3 as 1 | 2 | 3 | 4 | 5,
   longEntitiesGantt: vi.fn(
     (_props: { entries: unknown[]; height: number; minUsageSeconds: number }) => null
   ),
@@ -48,7 +48,7 @@ describe('LongEntitiesRow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.debouncedZoomRange = { start: 0.2, end: 0.6 };
-    mocks.longEntityDensity = 'balanced';
+    mocks.longEntityDensity = 3;
     mocks.useEntityList.mockReturnValue({
       data: undefined,
       isFetching: false,
@@ -69,22 +69,22 @@ describe('LongEntitiesRow', () => {
     );
 
     expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[0]).toBeCloseTo(0.4);
-    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[1]).toBe('balanced');
+    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[1]).toBe(3);
     expect(mocks.useEntityList).toHaveBeenCalledWith(
       expect.objectContaining({
         window: { start: 0.2, end: 0.6 },
         operatorIds: ['operator-1'],
-        minUsageSeconds: 0.06,
+        minUsageSeconds: 0.09,
         maxItems: 100,
       })
     );
     expect(mocks.longEntitiesGantt.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({ height: 110, minUsageSeconds: 0.06 })
+      expect.objectContaining({ height: 110, minUsageSeconds: 0.09 })
     );
   });
 
   it('uses the selected entity density in the query threshold', () => {
-    mocks.longEntityDensity = 'less';
+    mocks.longEntityDensity = 1;
 
     render(
       <LongEntitiesRow
@@ -98,7 +98,7 @@ describe('LongEntitiesRow', () => {
     );
 
     expect(mocks.useEntityList).toHaveBeenCalledWith(
-      expect.objectContaining({ minUsageSeconds: 0.12 })
+      expect.objectContaining({ minUsageSeconds: 0.15 })
     );
   });
 

--- a/ui/src/components/LongEntitiesRow.test.tsx
+++ b/ui/src/components/LongEntitiesRow.test.tsx
@@ -4,16 +4,17 @@
 import type { ButtonHTMLAttributes, HTMLAttributes } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LongEntityDensity } from '@quent/hooks';
 import { LongEntitiesRow } from './LongEntitiesRow';
 
 const mocks = vi.hoisted(() => ({
   buildLongEntityEntries: vi.fn((items: unknown[]) => items),
   debouncedZoomRange: { start: 0.2, end: 0.6 },
   getLongEntitiesThreshold: vi.fn(
-    (_windowSeconds: number, _numBins: number, density: 1 | 2 | 3 | 4 | 5) =>
+    (_windowSeconds: number, _numBins: number, density: LongEntityDensity) =>
       ({ 1: 0.15, 2: 0.12, 3: 0.09, 4: 0.06, 5: 0.03 })[density]
   ),
-  longEntityDensity: 3 as 1 | 2 | 3 | 4 | 5,
+  longEntityDensity: 3 as LongEntityDensity,
   returnedNumBins: 400 as number | undefined,
   longEntitiesGantt: vi.fn(
     (_props: { entries: unknown[]; height: number; minUsageSeconds: number }) => null

--- a/ui/src/components/LongEntitiesRow.test.tsx
+++ b/ui/src/components/LongEntitiesRow.test.tsx
@@ -9,8 +9,14 @@ import { LongEntitiesRow } from './LongEntitiesRow';
 const mocks = vi.hoisted(() => ({
   buildLongEntityEntries: vi.fn((items: unknown[]) => items),
   fetchNextPage: vi.fn(),
-  getLongEntitiesThreshold: vi.fn((_windowSeconds: number) => 0.06),
-  longEntitiesGantt: vi.fn((_props: { entries: unknown[]; height: number }) => null),
+  getLongEntitiesThreshold: vi.fn(
+    (_windowSeconds: number, density: 'less' | 'balanced' | 'more') =>
+      ({ less: 0.12, balanced: 0.06, more: 0.03 })[density]
+  ),
+  longEntityDensity: 'balanced' as 'less' | 'balanced' | 'more',
+  longEntitiesGantt: vi.fn(
+    (_props: { entries: unknown[]; height: number; minUsageSeconds: number }) => null
+  ),
   useInfiniteEntityList: vi.fn(),
 }));
 
@@ -20,6 +26,7 @@ vi.mock('@quent/client', () => ({
 
 vi.mock('@quent/hooks', () => ({
   useDebouncedZoomRange: () => ({ start: 0.2, end: 0.6 }),
+  useLongEntityDensity: () => mocks.longEntityDensity,
   useSelectedNodeIds: () => new Set(['operator-1']),
 }));
 
@@ -28,7 +35,7 @@ vi.mock('@quent/components', () => ({
     <button {...props}>{children}</button>
   ),
   LONG_ENTITIES_TIMELINE_HEIGHT: 110,
-  LongEntitiesGantt: (props: { entries: unknown[]; height: number }) => {
+  LongEntitiesGantt: (props: { entries: unknown[]; height: number; minUsageSeconds: number }) => {
     mocks.longEntitiesGantt(props);
     return <div data-testid="long-entities-gantt" />;
   },
@@ -40,6 +47,7 @@ vi.mock('@quent/components', () => ({
 describe('LongEntitiesRow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.longEntityDensity = 'balanced';
     mocks.useInfiniteEntityList.mockReturnValue({
       data: undefined,
       fetchNextPage: mocks.fetchNextPage,
@@ -63,6 +71,7 @@ describe('LongEntitiesRow', () => {
     );
 
     expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[0]).toBeCloseTo(0.4);
+    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[1]).toBe('balanced');
     expect(mocks.useInfiniteEntityList).toHaveBeenCalledWith(
       expect.objectContaining({
         window: { start: 0.2, end: 0.6 },
@@ -72,7 +81,26 @@ describe('LongEntitiesRow', () => {
       })
     );
     expect(mocks.longEntitiesGantt.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({ height: 110 })
+      expect.objectContaining({ height: 110, minUsageSeconds: 0.06 })
+    );
+  });
+
+  it('uses the selected entity density in the query threshold', () => {
+    mocks.longEntityDensity = 'less';
+
+    render(
+      <LongEntitiesRow
+        engineId="engine-1"
+        queryId="query-1"
+        resourceId="resource-1"
+        durationSeconds={1}
+        fsmTypes={{}}
+        isDark={false}
+      />
+    );
+
+    expect(mocks.useInfiniteEntityList).toHaveBeenCalledWith(
+      expect.objectContaining({ minUsageSeconds: 0.12 })
     );
   });
 

--- a/ui/src/components/LongEntitiesRow.test.tsx
+++ b/ui/src/components/LongEntitiesRow.test.tsx
@@ -10,10 +10,11 @@ const mocks = vi.hoisted(() => ({
   buildLongEntityEntries: vi.fn((items: unknown[]) => items),
   debouncedZoomRange: { start: 0.2, end: 0.6 },
   getLongEntitiesThreshold: vi.fn(
-    (_windowSeconds: number, density: 1 | 2 | 3 | 4 | 5) =>
+    (_windowSeconds: number, _numBins: number, density: 1 | 2 | 3 | 4 | 5) =>
       ({ 1: 0.15, 2: 0.12, 3: 0.09, 4: 0.06, 5: 0.03 })[density]
   ),
   longEntityDensity: 3 as 1 | 2 | 3 | 4 | 5,
+  returnedNumBins: 400 as number | undefined,
   longEntitiesGantt: vi.fn(
     (_props: { entries: unknown[]; height: number; minUsageSeconds: number }) => null
   ),
@@ -27,6 +28,7 @@ vi.mock('@quent/client', () => ({
 vi.mock('@quent/hooks', () => ({
   useDebouncedZoomRange: () => mocks.debouncedZoomRange,
   useLongEntityDensity: () => mocks.longEntityDensity,
+  useReturnedTimelineNumBins: () => mocks.returnedNumBins,
   useSelectedNodeIds: () => new Set(['operator-1']),
 }));
 
@@ -49,6 +51,7 @@ describe('LongEntitiesRow', () => {
     vi.clearAllMocks();
     mocks.debouncedZoomRange = { start: 0.2, end: 0.6 };
     mocks.longEntityDensity = 3;
+    mocks.returnedNumBins = 400;
     mocks.useEntityList.mockReturnValue({
       data: undefined,
       isFetching: false,
@@ -69,14 +72,16 @@ describe('LongEntitiesRow', () => {
     );
 
     expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[0]).toBeCloseTo(0.4);
-    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[1]).toBe(3);
+    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[1]).toBe(400);
+    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[2]).toBe(3);
     expect(mocks.useEntityList).toHaveBeenCalledWith(
       expect.objectContaining({
         window: { start: 0.2, end: 0.6 },
         operatorIds: ['operator-1'],
         minUsageSeconds: 0.09,
         maxItems: 100,
-      })
+      }),
+      { enabled: true }
     );
     expect(mocks.longEntitiesGantt.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({ height: 110, minUsageSeconds: 0.09 })
@@ -98,8 +103,31 @@ describe('LongEntitiesRow', () => {
     );
 
     expect(mocks.useEntityList).toHaveBeenCalledWith(
-      expect.objectContaining({ minUsageSeconds: 0.15 })
+      expect.objectContaining({ minUsageSeconds: 0.15 }),
+      { enabled: true }
     );
+  });
+
+  it('waits for the returned timeline bin count before fetching entities', () => {
+    mocks.returnedNumBins = undefined;
+
+    render(
+      <LongEntitiesRow
+        engineId="engine-1"
+        queryId="query-1"
+        resourceId="resource-1"
+        durationSeconds={1}
+        fsmTypes={{}}
+        isDark={false}
+      />
+    );
+
+    expect(mocks.getLongEntitiesThreshold).not.toHaveBeenCalled();
+    expect(mocks.useEntityList).toHaveBeenCalledWith(
+      expect.objectContaining({ minUsageSeconds: null }),
+      { enabled: false }
+    );
+    expect(screen.getByRole('status', { name: 'Loading entities' })).toBeInTheDocument();
   });
 
   it('can limit FSM states to those used on the associated resource', () => {
@@ -169,7 +197,8 @@ describe('LongEntitiesRow', () => {
     expect(screen.getByTestId('long-entities-gantt').nextElementSibling).toContainElement(button);
     fireEvent.click(button);
     expect(mocks.useEntityList).toHaveBeenLastCalledWith(
-      expect.objectContaining({ maxItems: 200 })
+      expect.objectContaining({ maxItems: 200 }),
+      { enabled: true }
     );
 
     mocks.debouncedZoomRange = { start: 0.3, end: 0.7 };
@@ -184,7 +213,8 @@ describe('LongEntitiesRow', () => {
       expect.objectContaining({
         window: { start: 0.3, end: 0.7 },
         maxItems: 200,
-      })
+      }),
+      { enabled: true }
     );
     expect(mocks.buildLongEntityEntries).toHaveBeenLastCalledWith(
       [firstEntity, secondEntity],

--- a/ui/src/components/LongEntitiesRow.test.tsx
+++ b/ui/src/components/LongEntitiesRow.test.tsx
@@ -5,9 +5,11 @@ import type { ButtonHTMLAttributes, HTMLAttributes } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LongEntityDensity } from '@quent/hooks';
+import { MAX_TIMELINE_BINS } from '@quent/utils';
 import { LongEntitiesRow } from './LongEntitiesRow';
 
 const mocks = vi.hoisted(() => ({
+  bulkInitialized: true,
   buildLongEntityEntries: vi.fn((items: unknown[]) => items),
   debouncedZoomRange: { start: 0.2, end: 0.6 },
   getLongEntitiesThreshold: vi.fn(
@@ -27,6 +29,7 @@ vi.mock('@quent/client', () => ({
 }));
 
 vi.mock('@quent/hooks', () => ({
+  useBulkInitialized: () => mocks.bulkInitialized,
   useDebouncedZoomRange: () => mocks.debouncedZoomRange,
   useLongEntityDensity: () => mocks.longEntityDensity,
   useReturnedTimelineNumBins: () => mocks.returnedNumBins,
@@ -50,6 +53,7 @@ vi.mock('@quent/components', () => ({
 describe('LongEntitiesRow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.bulkInitialized = true;
     mocks.debouncedZoomRange = { start: 0.2, end: 0.6 };
     mocks.longEntityDensity = 3;
     mocks.returnedNumBins = 400;
@@ -109,7 +113,34 @@ describe('LongEntitiesRow', () => {
     );
   });
 
-  it('waits for the returned timeline bin count before fetching entities', () => {
+  it('falls back to twice the maximum bin count when the timeline request fails', () => {
+    mocks.returnedNumBins = undefined;
+
+    render(
+      <LongEntitiesRow
+        engineId="engine-1"
+        queryId="query-1"
+        resourceId="resource-1"
+        durationSeconds={1}
+        fsmTypes={{}}
+        isDark={false}
+      />
+    );
+
+    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.[0]).toBeCloseTo(0.4);
+    expect(mocks.getLongEntitiesThreshold.mock.calls[0]?.slice(1)).toEqual([
+      MAX_TIMELINE_BINS * 2,
+      3,
+    ]);
+    expect(mocks.useEntityList).toHaveBeenCalledWith(
+      expect.objectContaining({ minUsageSeconds: 0.09 }),
+      { enabled: true }
+    );
+    expect(screen.getByTestId('long-entities-gantt')).toBeInTheDocument();
+  });
+
+  it('waits for the timeline request before using the fallback', () => {
+    mocks.bulkInitialized = false;
     mocks.returnedNumBins = undefined;
 
     render(

--- a/ui/src/components/LongEntitiesRow.tsx
+++ b/ui/src/components/LongEntitiesRow.tsx
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useEntityList } from '@quent/client';
 import {
   useBulkInitialized,
   useDebouncedZoomRange,
   useLongEntityDensity,
+  useReturnedTimelineIsStale,
   useReturnedTimelineNumBins,
   useSelectedNodeIds,
 } from '@quent/hooks';
@@ -53,6 +54,8 @@ export function LongEntitiesRow({
   const bulkInitialized = useBulkInitialized();
   const longEntityDensity = useLongEntityDensity();
   const returnedNumBins = useReturnedTimelineNumBins(resourceId);
+  const returnedTimelineIsStale = useReturnedTimelineIsStale(resourceId);
+  const previousMinUsageSeconds = useRef<number | null>(null);
   const [maxEntities, setMaxEntities] = useState(ENTITIES_PER_PAGE);
   const operatorIds = useMemo(() => [...selectedNodeIds], [selectedNodeIds]);
   const zoomWindow =
@@ -60,11 +63,17 @@ export function LongEntitiesRow({
       ? debouncedZoomRange
       : { start: 0, end: durationSeconds };
 
-  const numBins = returnedNumBins ?? (bulkInitialized ? MAX_TIMELINE_BINS * 2 : undefined);
+  const defaultNumBins = MAX_TIMELINE_BINS * 2;
+  const initializedAndNoBins = !returnedTimelineIsStale && bulkInitialized;
+  const numBins = returnedNumBins ?? (initializedAndNoBins ? defaultNumBins : undefined);
+
+  // Retain the rendered threshold while the next viewport loads.
   const minUsageSeconds =
     numBins == null
       ? null
       : getLongEntitiesThreshold(zoomWindow.end - zoomWindow.start, numBins, longEntityDensity);
+  if (minUsageSeconds != null) previousMinUsageSeconds.current = minUsageSeconds;
+  const displayedMinUsageSeconds = minUsageSeconds ?? previousMinUsageSeconds.current;
 
   const { data, isFetching, isPlaceholderData } = useEntityList(
     {
@@ -96,7 +105,7 @@ export function LongEntitiesRow({
   const isLoadingMore = isPlaceholderData && entities.length < maxEntities;
   const showMoreButton = hasMoreEntities && (!isLoadingMore || maxEntities < totalEntities);
 
-  if (minUsageSeconds == null || (!data && isFetching)) {
+  if (displayedMinUsageSeconds == null || (!data && isFetching)) {
     return (
       <div
         role="status"
@@ -116,7 +125,7 @@ export function LongEntitiesRow({
       <LongEntitiesGantt
         entries={entries}
         durationSeconds={durationSeconds}
-        minUsageSeconds={minUsageSeconds}
+        minUsageSeconds={displayedMinUsageSeconds}
         height={LONG_ENTITIES_TIMELINE_HEIGHT}
         isDark={isDark}
       />

--- a/ui/src/components/LongEntitiesRow.tsx
+++ b/ui/src/components/LongEntitiesRow.tsx
@@ -3,7 +3,7 @@
 
 import { useMemo } from 'react';
 import { useInfiniteEntityList } from '@quent/client';
-import { useDebouncedZoomRange, useSelectedNodeIds } from '@quent/hooks';
+import { useDebouncedZoomRange, useLongEntityDensity, useSelectedNodeIds } from '@quent/hooks';
 import type { FsmTypeDecl } from '@quent/utils';
 import {
   Button,
@@ -44,12 +44,16 @@ export function LongEntitiesRow({
 }: LongEntitiesRowProps) {
   const selectedNodeIds = useSelectedNodeIds();
   const debouncedZoomRange = useDebouncedZoomRange();
+  const longEntityDensity = useLongEntityDensity();
   const operatorIds = useMemo(() => [...selectedNodeIds], [selectedNodeIds]);
   const zoomWindow =
     debouncedZoomRange.end > debouncedZoomRange.start
       ? debouncedZoomRange
       : { start: 0, end: durationSeconds };
-  const minUsageSeconds = getLongEntitiesThreshold(zoomWindow.end - zoomWindow.start);
+  const minUsageSeconds = getLongEntitiesThreshold(
+    zoomWindow.end - zoomWindow.start,
+    longEntityDensity
+  );
 
   const { data, fetchNextPage, hasNextPage, isFetching, isPlaceholderData } = useInfiniteEntityList(
     {
@@ -97,6 +101,7 @@ export function LongEntitiesRow({
       <LongEntitiesGantt
         entries={entries}
         durationSeconds={durationSeconds}
+        minUsageSeconds={minUsageSeconds}
         height={LONG_ENTITIES_TIMELINE_HEIGHT}
         isDark={isDark}
       />

--- a/ui/src/components/LongEntitiesRow.tsx
+++ b/ui/src/components/LongEntitiesRow.tsx
@@ -4,12 +4,13 @@
 import { useMemo, useState } from 'react';
 import { useEntityList } from '@quent/client';
 import {
+  useBulkInitialized,
   useDebouncedZoomRange,
   useLongEntityDensity,
   useReturnedTimelineNumBins,
   useSelectedNodeIds,
 } from '@quent/hooks';
-import type { FsmTypeDecl } from '@quent/utils';
+import { type FsmTypeDecl, MAX_TIMELINE_BINS } from '@quent/utils';
 import {
   Button,
   LONG_ENTITIES_TIMELINE_HEIGHT,
@@ -49,6 +50,7 @@ export function LongEntitiesRow({
 }: LongEntitiesRowProps) {
   const selectedNodeIds = useSelectedNodeIds();
   const debouncedZoomRange = useDebouncedZoomRange();
+  const bulkInitialized = useBulkInitialized();
   const longEntityDensity = useLongEntityDensity();
   const returnedNumBins = useReturnedTimelineNumBins(resourceId);
   const [maxEntities, setMaxEntities] = useState(ENTITIES_PER_PAGE);
@@ -57,14 +59,12 @@ export function LongEntitiesRow({
     debouncedZoomRange.end > debouncedZoomRange.start
       ? debouncedZoomRange
       : { start: 0, end: durationSeconds };
+
+  const numBins = returnedNumBins ?? (bulkInitialized ? MAX_TIMELINE_BINS * 2 : undefined);
   const minUsageSeconds =
-    returnedNumBins == null
+    numBins == null
       ? null
-      : getLongEntitiesThreshold(
-          zoomWindow.end - zoomWindow.start,
-          returnedNumBins,
-          longEntityDensity
-        );
+      : getLongEntitiesThreshold(zoomWindow.end - zoomWindow.start, numBins, longEntityDensity);
 
   const { data, isFetching, isPlaceholderData } = useEntityList(
     {
@@ -77,7 +77,7 @@ export function LongEntitiesRow({
       maxItems: maxEntities,
       filter: { scope: { Resource: { resource_id: resourceId } } },
     },
-    { enabled: returnedNumBins != null }
+    { enabled: numBins != null }
   );
 
   const entities = useMemo(() => data?.items ?? [], [data]);

--- a/ui/src/components/LongEntitiesRow.tsx
+++ b/ui/src/components/LongEntitiesRow.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo } from 'react';
-import { useInfiniteEntityList } from '@quent/client';
+import { useMemo, useState } from 'react';
+import { useEntityList } from '@quent/client';
 import { useDebouncedZoomRange, useLongEntityDensity, useSelectedNodeIds } from '@quent/hooks';
 import type { FsmTypeDecl } from '@quent/utils';
 import {
@@ -45,6 +45,7 @@ export function LongEntitiesRow({
   const selectedNodeIds = useSelectedNodeIds();
   const debouncedZoomRange = useDebouncedZoomRange();
   const longEntityDensity = useLongEntityDensity();
+  const [maxEntities, setMaxEntities] = useState(ENTITIES_PER_PAGE);
   const operatorIds = useMemo(() => [...selectedNodeIds], [selectedNodeIds]);
   const zoomWindow =
     debouncedZoomRange.end > debouncedZoomRange.start
@@ -55,20 +56,18 @@ export function LongEntitiesRow({
     longEntityDensity
   );
 
-  const { data, fetchNextPage, hasNextPage, isFetching, isPlaceholderData } = useInfiniteEntityList(
-    {
-      engineId,
-      queryId,
-      window: zoomWindow,
-      operatorIds,
-      minUsageSeconds,
-      sortDir: 'Desc',
-      maxItems: ENTITIES_PER_PAGE,
-      filter: { scope: { Resource: { resource_id: resourceId } } },
-    }
-  );
+  const { data, isFetching, isPlaceholderData } = useEntityList({
+    engineId,
+    queryId,
+    window: zoomWindow,
+    operatorIds,
+    minUsageSeconds,
+    sortDir: 'Desc',
+    maxItems: maxEntities,
+    filter: { scope: { Resource: { resource_id: resourceId } } },
+  });
 
-  const entities = useMemo(() => data?.pages.flatMap(page => page.items) ?? [], [data]);
+  const entities = useMemo(() => data?.items ?? [], [data]);
   const entries = useMemo(
     () =>
       buildLongEntityEntries(
@@ -79,7 +78,10 @@ export function LongEntitiesRow({
       ),
     [entities, fsmStateScope, fsmTypes, isDark, resourceId]
   );
-  const totalEntities = data?.pages[data.pages.length - 1]?.total ?? entities.length;
+  const totalEntities = data?.total ?? entities.length;
+  const hasMoreEntities = entities.length < totalEntities;
+  const isLoadingMore = isPlaceholderData && entities.length < maxEntities;
+  const showMoreButton = hasMoreEntities && (!isLoadingMore || maxEntities < totalEntities);
 
   if (!data && isFetching) {
     return (
@@ -106,7 +108,7 @@ export function LongEntitiesRow({
         isDark={isDark}
       />
 
-      {hasNextPage && !isPlaceholderData && (
+      {showMoreButton && (
         <div className="flex justify-center border-t border-border/50 py-1">
           <Button
             type="button"
@@ -116,10 +118,10 @@ export function LongEntitiesRow({
             disabled={isFetching}
             onClick={event => {
               event.stopPropagation();
-              void fetchNextPage();
+              setMaxEntities(current => current + ENTITIES_PER_PAGE);
             }}
           >
-            Show more ({entities.length} of {totalEntities})
+            {isLoadingMore ? 'Loading...' : `Show more (${entities.length} of ${totalEntities})`}
           </Button>
         </div>
       )}

--- a/ui/src/components/LongEntitiesRow.tsx
+++ b/ui/src/components/LongEntitiesRow.tsx
@@ -3,7 +3,12 @@
 
 import { useMemo, useState } from 'react';
 import { useEntityList } from '@quent/client';
-import { useDebouncedZoomRange, useLongEntityDensity, useSelectedNodeIds } from '@quent/hooks';
+import {
+  useDebouncedZoomRange,
+  useLongEntityDensity,
+  useReturnedTimelineNumBins,
+  useSelectedNodeIds,
+} from '@quent/hooks';
 import type { FsmTypeDecl } from '@quent/utils';
 import {
   Button,
@@ -45,27 +50,35 @@ export function LongEntitiesRow({
   const selectedNodeIds = useSelectedNodeIds();
   const debouncedZoomRange = useDebouncedZoomRange();
   const longEntityDensity = useLongEntityDensity();
+  const returnedNumBins = useReturnedTimelineNumBins(resourceId);
   const [maxEntities, setMaxEntities] = useState(ENTITIES_PER_PAGE);
   const operatorIds = useMemo(() => [...selectedNodeIds], [selectedNodeIds]);
   const zoomWindow =
     debouncedZoomRange.end > debouncedZoomRange.start
       ? debouncedZoomRange
       : { start: 0, end: durationSeconds };
-  const minUsageSeconds = getLongEntitiesThreshold(
-    zoomWindow.end - zoomWindow.start,
-    longEntityDensity
-  );
+  const minUsageSeconds =
+    returnedNumBins == null
+      ? null
+      : getLongEntitiesThreshold(
+          zoomWindow.end - zoomWindow.start,
+          returnedNumBins,
+          longEntityDensity
+        );
 
-  const { data, isFetching, isPlaceholderData } = useEntityList({
-    engineId,
-    queryId,
-    window: zoomWindow,
-    operatorIds,
-    minUsageSeconds,
-    sortDir: 'Desc',
-    maxItems: maxEntities,
-    filter: { scope: { Resource: { resource_id: resourceId } } },
-  });
+  const { data, isFetching, isPlaceholderData } = useEntityList(
+    {
+      engineId,
+      queryId,
+      window: zoomWindow,
+      operatorIds,
+      minUsageSeconds,
+      sortDir: 'Desc',
+      maxItems: maxEntities,
+      filter: { scope: { Resource: { resource_id: resourceId } } },
+    },
+    { enabled: returnedNumBins != null }
+  );
 
   const entities = useMemo(() => data?.items ?? [], [data]);
   const entries = useMemo(
@@ -83,7 +96,7 @@ export function LongEntitiesRow({
   const isLoadingMore = isPlaceholderData && entities.length < maxEntities;
   const showMoreButton = hasMoreEntities && (!isLoadingMore || maxEntities < totalEntities);
 
-  if (!data && isFetching) {
+  if (minUsageSeconds == null || (!data && isFetching)) {
     return (
       <div
         role="status"


### PR DESCRIPTION
# Description
This iteration is to improve usability when handling large numbers of entities. 
* Adds expand/collapse controls for long entities swimlanes
* Adds loader and persistent page size for "show more" functionality. Reduces jumpyness by not hiding/showing the button while loading, and keeps page size when Zooming/Panning so swimlanes jump less.
* Update tooltip to truncate after showing a certain number of entities when many are overlapping. Not being able to show all information should be mitigated by the detail panel https://github.com/rapidsai/quent/pull/564. Future iterations may also add aggregate stats about the entities if too many to show all individually.
* More informative "No Entities" message, shows the threshold being used
* Adds rough setting for long entities threshold (show less <--> show more)

## Related Issues
Fixes: #98 
Relates to: #215 

## Testing
* Simulate a query with many entities and many threads so there are many concurrent entities in the chart. 
`cargo run -p quent-simulator -- --num-query-groups 1 --num-queries 1 --num-workers 2 --num-threads 24 --num-tasks 65536 --exporter collector --collector-address http://localhost:7836`
* Open query and open any resource with entities that have usage on that resource
* Change the entities slider to show more/less entities (changes the long entity threshold in the request)
* Entity rows are expandable/collapsible
* Resource tree virtualization works as expected (opening every resource will not overwhelp the browser), charts render as they scroll into view.

## Screenshots
Demo with an absurd (i think?) amount of entities. Every interaction should be able to handle huge amounts of entities. It can get a little jumpy when there are so many, but the price we pay RN. 

https://github.com/user-attachments/assets/b245bc12-6774-4467-8f30-afe063321313


