### PR TITLE
feat(ui): render NVTX timeline lanes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvtx-server"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "moka",
+ "nvtx-analyzer",
+ "nvtx-bridge",
+ "nvtx-events",
+ "nvtx-ui",
+ "quent-events",
+ "quent-io",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "nvtx-ui"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "clap",
+ "nvtx-server",
  "quent-io",
  "quent-query-engine-server",
  "quent-simulator-analyzer",
@@ -3207,6 +3208,7 @@ dependencies = [
 name = "quent-simulator-ui-bindings"
 version = "0.1.0"
 dependencies = [
+ "nvtx-ui",
  "quent-query-engine-ui",
  "quent-simulator-ui",
  "quent-ui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "integrations/nvtx/example",
     "integrations/nvtx/analyzer",
     "integrations/nvtx/ui",
+    "integrations/nvtx/server",
     # Domain-specific crates
     "domains/query_engine/analyzer",
     "domains/query_engine/model",

--- a/crates/io/src/filesystem/mod.rs
+++ b/crates/io/src/filesystem/mod.rs
@@ -31,10 +31,10 @@ impl TryFrom<&str> for Format {
 }
 
 impl Format {
-    /// Detect the format of a context directory from the first recognized
-    /// `*.<ext>` event stream in any of its per-entity subdirectories. Returns
-    /// `None` if no readable stream with a known extension is present.
+    /// Detect the common format of a context's event streams. Returns `None` if
+    /// no recognized stream is present or streams use different formats.
     pub fn detect(context_dir: &std::path::Path) -> Option<Self> {
+        let mut detected = None;
         for entry in std::fs::read_dir(context_dir).ok()?.flatten() {
             if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                 continue;
@@ -48,10 +48,53 @@ impl Format {
                     .and_then(|ext| ext.to_str())
                     .and_then(|ext| Self::try_from(ext).ok())
                 {
-                    return Some(format);
+                    match detected {
+                        Some(existing) if existing != format => return None,
+                        None => detected = Some(format),
+                        _ => {}
+                    }
                 }
             }
         }
-        None
+        detected
+    }
+}
+
+#[cfg(all(test, feature = "ndjson"))]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use uuid::Uuid;
+
+    fn context_with_streams(streams: &[(&str, &str)]) -> PathBuf {
+        let context = std::env::temp_dir().join(format!("quent-format-{}", Uuid::now_v7()));
+        for &(entity, extension) in streams {
+            let stream_dir = context.join(entity);
+            std::fs::create_dir_all(&stream_dir).unwrap();
+            std::fs::write(stream_dir.join(format!("events.{extension}")), []).unwrap();
+        }
+        context
+    }
+
+    #[test]
+    fn detects_one_context_wide_format() {
+        let context =
+            context_with_streams(&[("EngineEvent", "ndjson"), ("NvtxEventEntity", "ndjson")]);
+        let detected = Format::detect(&context);
+        std::fs::remove_dir_all(context).unwrap();
+
+        assert_eq!(detected, Some(Format::Ndjson));
+    }
+
+    #[test]
+    #[cfg(feature = "msgpack")]
+    fn rejects_mixed_context_formats() {
+        let context =
+            context_with_streams(&[("EngineEvent", "ndjson"), ("NvtxEventEntity", "msgpack")]);
+        let detected = Format::detect(&context);
+        std::fs::remove_dir_all(context).unwrap();
+
+        assert_eq!(detected, None);
     }
 }

--- a/crates/open/src/viewer.rs
+++ b/crates/open/src/viewer.rs
@@ -90,7 +90,7 @@ async fn build_one(group: ViewerGroup) -> Result<BuiltViewer> {
     println!("building: {label}");
 
     let crate_dir = build_dir(&spec)?;
-    wrapper::generate(&spec, &crate_dir, wrapper::IO_PACKAGE)?;
+    wrapper::generate(&spec, &crate_dir, wrapper::IO_PACKAGE, true)?;
     let bin = match cargo_build(&crate_dir).await {
         // The pinned quent revision predates the `quent-exporter` → `quent-io`
         // rename (cargo found no `quent-io` package there, failing resolution
@@ -102,7 +102,26 @@ async fn build_one(group: ViewerGroup) -> Result<BuiltViewer> {
                 wrapper::IO_PACKAGE,
                 wrapper::LEGACY_IO_PACKAGE
             );
-            wrapper::generate(&spec, &crate_dir, wrapper::LEGACY_IO_PACKAGE)?;
+            wrapper::generate(&spec, &crate_dir, wrapper::LEGACY_IO_PACKAGE, true)?;
+            cargo_build(&crate_dir).await?
+        }
+        Err(error) if missing_package(&error, "nvtx-server") => {
+            println!(
+                "note: pinned quent has no `nvtx-server` package; retrying without NVTX routes"
+            );
+            wrapper::generate(&spec, &crate_dir, wrapper::IO_PACKAGE, false)?;
+            cargo_build(&crate_dir).await?
+        }
+        Err(error)
+            if missing_package(&error, wrapper::IO_PACKAGE)
+                || missing_package(&error, wrapper::LEGACY_IO_PACKAGE) =>
+        {
+            let io_package = if missing_package(&error, wrapper::LEGACY_IO_PACKAGE) {
+                wrapper::LEGACY_IO_PACKAGE
+            } else {
+                wrapper::IO_PACKAGE
+            };
+            wrapper::generate(&spec, &crate_dir, io_package, false)?;
             cargo_build(&crate_dir).await?
         }
         result => result?,

--- a/crates/open/src/wrapper.rs
+++ b/crates/open/src/wrapper.rs
@@ -35,10 +35,21 @@ pub const ADDR_ENV: &str = "QUENT_OPEN_ADDR";
 /// Write the wrapper crate (`Cargo.toml` + `src/main.rs`) into `crate_dir`.
 /// `io_package` is the name of quent's I/O crate at the pinned revision
 /// ([`IO_PACKAGE`], or [`LEGACY_IO_PACKAGE`] for revisions predating the rename).
-pub fn generate(spec: &ViewerSpec, crate_dir: &Path, io_package: &str) -> Result<()> {
+pub fn generate(
+    spec: &ViewerSpec,
+    crate_dir: &Path,
+    io_package: &str,
+    with_nvtx_routes: bool,
+) -> Result<()> {
     std::fs::create_dir_all(crate_dir.join("src"))?;
-    std::fs::write(crate_dir.join("Cargo.toml"), cargo_toml(spec, io_package))?;
-    std::fs::write(crate_dir.join("src/main.rs"), main_rs(spec))?;
+    std::fs::write(
+        crate_dir.join("Cargo.toml"),
+        cargo_toml(spec, io_package, with_nvtx_routes),
+    )?;
+    std::fs::write(
+        crate_dir.join("src/main.rs"),
+        main_rs(spec, with_nvtx_routes),
+    )?;
     Ok(())
 }
 
@@ -55,10 +66,10 @@ fn git_dep(url: String, rev: &str, features: &[&str]) -> Dependency {
 /// Wrapper `Cargo.toml`, built with `cargo-manifest`: pin quent crates to
 /// `quent.{remote,commit}` and the analyzer to `analyzer.{remote,commit}`; the
 /// empty `[workspace]` keeps the generated crate out of any parent workspace.
-fn cargo_toml(spec: &ViewerSpec, io_package: &str) -> String {
+fn cargo_toml(spec: &ViewerSpec, io_package: &str, with_nvtx_routes: bool) -> String {
     let quent = spec.quent.cargo_url();
     let q_rev = spec.quent.commit.as_str();
-    let dependencies = BTreeMap::from([
+    let mut dependencies = BTreeMap::from([
         (
             "quent-query-engine-server".to_string(),
             git_dep(quent.clone(), q_rev, &["ui"]),
@@ -70,7 +81,7 @@ fn cargo_toml(spec: &ViewerSpec, io_package: &str) -> String {
         (
             // All formats enabled so the analyzer can detect the artifact's format at runtime.
             io_package.to_string(),
-            git_dep(quent, q_rev, &["ndjson", "msgpack", "postcard"]),
+            git_dep(quent.clone(), q_rev, &["ndjson", "msgpack", "postcard"]),
         ),
         (
             spec.analyzer_package.clone(),
@@ -92,6 +103,9 @@ fn cargo_toml(spec: &ViewerSpec, io_package: &str) -> String {
         ),
         ("uuid".to_string(), Dependency::Simple("1".to_string())),
     ]);
+    if with_nvtx_routes {
+        dependencies.insert("nvtx-server".to_string(), git_dep(quent, q_rev, &[]));
+    }
 
     let mut package = Package::new(WRAPPER_PACKAGE.to_string(), "0.0.0".to_string());
     package.edition = Some(MaybeInherited::Local(Edition::E2024));
@@ -115,43 +129,85 @@ fn cargo_toml(spec: &ViewerSpec, io_package: &str) -> String {
 /// Wrapper `src/main.rs`: wire `<analyzer>::Viewer`'s analyzer/importer into
 /// `analyzer_service_router` and serve it. Root (`<context-uuid>/` subdirs) and
 /// bind address come from env so one built binary serves any artifacts.
-fn main_rs(spec: &ViewerSpec) -> String {
+fn main_rs(spec: &ViewerSpec, with_nvtx_routes: bool) -> String {
     let analyzer_crate = format_ident!("{}", spec.analyzer_crate());
     let (root_env, addr_env) = (ROOT_ENV, ADDR_ENV);
-    let tokens = quote! {
-        use std::net::SocketAddr;
-        use std::path::PathBuf;
+    let tokens = if with_nvtx_routes {
+        quote! {
+            use std::net::SocketAddr;
+            use std::path::PathBuf;
 
-        use quent_query_engine_analyzer::ui::QuentViewer;
-        use quent_query_engine_server::analyzer_cache::index_query_engines;
-        use quent_query_engine_server::analyzer_service_router;
-        use #analyzer_crate::Viewer;
+            use quent_query_engine_analyzer::ui::QuentViewer;
+            use quent_query_engine_server::analyzer_cache::index_query_engines;
+            use quent_query_engine_server::analyzer_service_router_with_routes;
+            use nvtx_server::{import_context_events, routes as nvtx_routes};
+            use #analyzer_crate::Viewer;
 
-        type Analyzer = <Viewer as QuentViewer>::Analyzer;
+            type Analyzer = <Viewer as QuentViewer>::Analyzer;
 
-        #[tokio::main]
-        async fn main() -> Result<(), Box<dyn std::error::Error>> {
-            let root = PathBuf::from(std::env::var(#root_env)?);
-            let addr: SocketAddr = std::env::var(#addr_env)?.parse()?;
+            #[tokio::main]
+            async fn main() -> Result<(), Box<dyn std::error::Error>> {
+                let root = PathBuf::from(std::env::var(#root_env)?);
+                let addr: SocketAddr = std::env::var(#addr_env)?.parse()?;
 
-            let import_root = root.clone();
-            let importer = move |id: uuid::Uuid| {
-                Ok(<Viewer as QuentViewer>::import_events(
-                    &import_root.join(id.to_string()),
-                )?)
-            };
-            let lister_root = root.clone();
-            let lister = move || index_query_engines(&lister_root);
+                let import_root = root.clone();
+                let importer = move |id: uuid::Uuid| {
+                    Ok(<Viewer as QuentViewer>::import_events(
+                        &import_root.join(id.to_string()),
+                        &import_root.join(id.to_string()),
+                    )?)
+                };
+                let lister_root = root.clone();
+                let lister = move || index_query_engines(&lister_root);
+                let nvtx_root = root.clone();
+                let nvtx_importer = move |id: uuid::Uuid| import_context_events(&nvtx_root, id);
 
-            let router = analyzer_service_router::<Analyzer>(
-                Box::new(importer),
-                Box::new(lister),
-                None,
-            )?;
+                let router = analyzer_service_router_with_routes::<Analyzer>(
+                    Box::new(importer),
+                    Box::new(lister),
+                    None,
+                    nvtx_routes(Box::new(nvtx_importer)),
+                )?;
 
-            let listener = tokio::net::TcpListener::bind(addr).await?;
-            axum::serve(listener, router.into_make_service()).await?;
-            Ok(())
+                let listener = tokio::net::TcpListener::bind(addr).await?;
+                axum::serve(listener, router.into_make_service()).await?;
+                Ok(())
+            }
+        }
+    } else {
+        quote! {
+            use std::net::SocketAddr;
+            use std::path::PathBuf;
+
+            use quent_query_engine_analyzer::ui::QuentViewer;
+            use quent_query_engine_server::analyzer_cache::index_query_engines;
+            use quent_query_engine_server::analyzer_service_router;
+            use #analyzer_crate::Viewer;
+
+            type Analyzer = <Viewer as QuentViewer>::Analyzer;
+
+            #[tokio::main]
+            async fn main() -> Result<(), Box<dyn std::error::Error>> {
+                let root = PathBuf::from(std::env::var(#root_env)?);
+                let addr: SocketAddr = std::env::var(#addr_env)?.parse()?;
+
+                let import_root = root.clone();
+                let importer = move |id: uuid::Uuid| {
+                    Ok(<Viewer as QuentViewer>::import_events(&import_root.join(id.to_string()))?)
+                };
+                let lister_root = root.clone();
+                let lister = move || index_query_engines(&lister_root);
+
+                let router = analyzer_service_router::<Analyzer>(
+                    Box::new(importer),
+                    Box::new(lister),
+                    None,
+                )?;
+
+                let listener = tokio::net::TcpListener::bind(addr).await?;
+                axum::serve(listener, router.into_make_service()).await?;
+                Ok(())
+            }
         }
     };
     let file = syn::parse2(tokens).expect("generated wrapper main.rs is valid Rust");
@@ -182,13 +238,14 @@ mod tests {
 
     #[test]
     fn cargo_toml_pins_quent_and_analyzer() {
-        let manifest: toml::Value = toml::from_str(&cargo_toml(&spec(), IO_PACKAGE)).unwrap();
+        let manifest: toml::Value = toml::from_str(&cargo_toml(&spec(), IO_PACKAGE, true)).unwrap();
         assert!(manifest.get("workspace").is_some(), "standalone workspace");
         let deps = &manifest["dependencies"];
         let server = &deps["quent-query-engine-server"];
         assert_eq!(server["git"].as_str().unwrap(), "https://example.com/quent");
         assert_eq!(server["rev"].as_str().unwrap(), "quentcommit");
         assert_eq!(server["features"][0].as_str().unwrap(), "ui");
+        assert_eq!(deps["nvtx-server"]["rev"].as_str().unwrap(), "quentcommit");
         // The exporter enables all formats so the analyzer detects the artifact's format at runtime.
         let exporter_features = deps["quent-io"]["features"].as_array().unwrap();
         for format in ["ndjson", "msgpack", "postcard"] {
@@ -207,10 +264,11 @@ mod tests {
         // Artifacts pinned to quent revisions predating the `quent-exporter` →
         // `quent-io` rename depend on the legacy package instead, same features.
         let manifest: toml::Value =
-            toml::from_str(&cargo_toml(&spec(), LEGACY_IO_PACKAGE)).unwrap();
+            toml::from_str(&cargo_toml(&spec(), LEGACY_IO_PACKAGE, false)).unwrap();
         let deps = &manifest["dependencies"];
         assert!(deps.get("quent-io").is_none());
         let exporter = &deps["quent-exporter"];
+        assert!(deps.get("nvtx-server").is_none());
         assert_eq!(
             exporter["git"].as_str().unwrap(),
             "https://example.com/quent"
@@ -224,9 +282,11 @@ mod tests {
 
     #[test]
     fn main_rs_wires_the_viewer() {
-        let main = main_rs(&spec());
+        let main = main_rs(&spec(), true);
         assert!(main.contains("use quent_simulator_analyzer::Viewer;"));
         assert!(main.contains("import_events"));
+        assert!(main.contains("import_context_events"));
+        assert!(main.contains("analyzer_service_router_with_routes"));
         assert!(main.contains("QUENT_OPEN_ADDR")); // bind address is configurable
     }
 }

--- a/domains/query_engine/server/src/analyzer_cache.rs
+++ b/domains/query_engine/server/src/analyzer_cache.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::Path;
 use std::{sync::Arc, time::Duration};
 
@@ -42,6 +42,8 @@ pub struct EngineIndex {
     contexts: HashMap<Uuid, BTreeSet<Uuid>>,
     /// Engine id to its workers and the context each was found in.
     workers: HashMap<Uuid, Vec<(Uuid, Uuid)>>,
+    /// Resource-group entities observed in each context, by engine ID.
+    context_resources: HashMap<Uuid, BTreeMap<Uuid, BTreeSet<Uuid>>>,
 }
 
 impl EngineIndex {
@@ -53,11 +55,21 @@ impl EngineIndex {
     }
 
     fn add_worker(&mut self, engine_id: Uuid, worker_id: Uuid, context_id: Uuid) {
-        self.attribute_context(engine_id, context_id);
+        self.attribute_resource(engine_id, context_id, worker_id);
         self.workers
             .entry(engine_id)
             .or_default()
             .push((worker_id, context_id));
+    }
+
+    fn attribute_resource(&mut self, engine_id: Uuid, context_id: Uuid, resource_id: Uuid) {
+        self.attribute_context(engine_id, context_id);
+        self.context_resources
+            .entry(engine_id)
+            .or_default()
+            .entry(context_id)
+            .or_default()
+            .insert(resource_id);
     }
 
     /// All known engine ids.
@@ -77,6 +89,21 @@ impl EngineIndex {
     /// `engine_id`'s workers as `(worker_id, context_id)` pairs.
     pub fn workers_of(&self, engine_id: Uuid) -> &[(Uuid, Uuid)] {
         self.workers.get(&engine_id).map_or(&[], Vec::as_slice)
+    }
+
+    /// Resource-group entity IDs observed in each context of `engine_id`.
+    pub fn context_resources_of(&self, engine_id: Uuid) -> BTreeMap<Uuid, Vec<Uuid>> {
+        let mut resources: BTreeMap<Uuid, Vec<Uuid>> = self
+            .contexts_of(engine_id)
+            .into_iter()
+            .map(|context_id| (context_id, Vec::new()))
+            .collect();
+        if let Some(by_context) = self.context_resources.get(&engine_id) {
+            for (&context_id, resource_ids) in by_context {
+                resources.insert(context_id, resource_ids.iter().copied().collect());
+            }
+        }
+        resources
     }
 }
 
@@ -116,7 +143,7 @@ pub fn index_query_engines(output_dir: &Path) -> ServerResult<EngineIndex> {
             for event in importer {
                 let event = event?;
                 if seen.insert(event.id) {
-                    index.attribute_context(event.id, context_id);
+                    index.attribute_resource(event.id, context_id, event.id);
                 }
             }
         }
@@ -202,6 +229,20 @@ where
         Ok((self.lister)()?.engine_ids().collect())
     }
 
+    /// List an engine's contributing contexts without blocking the async executor.
+    pub(crate) async fn contexts(&self, engine_id: Uuid) -> ServerResult<ui::EngineContexts> {
+        let lister = Arc::clone(&self.lister);
+        tokio::task::spawn_blocking(move || {
+            let index = lister()?;
+            Ok(ui::EngineContexts {
+                engine_id,
+                context_resources: index.context_resources_of(engine_id),
+            })
+        })
+        .await
+        .map_err(|error| ServerError::Cache(format!("blocking task panicked: {error}")))?
+    }
+
     pub(crate) async fn list_with_metadata(&self) -> ServerResult<Vec<ui::Engine>> {
         let lister = Arc::clone(&self.lister);
         let importer = Arc::clone(&self.importer);
@@ -239,5 +280,43 @@ where
             .await
             .map(|v| v.into_value())
             .map_err(|e: Arc<ServerError>| ServerError::Cache(format!("{e:?}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_context_inventory_is_deduplicated_and_sorted() {
+        let engine_id = Uuid::from_u128(1);
+        let earlier = Uuid::from_u128(2);
+        let later = Uuid::from_u128(3);
+        let mut index = EngineIndex::default();
+        index.attribute_context(engine_id, later);
+        index.attribute_context(engine_id, earlier);
+        index.attribute_context(engine_id, later);
+
+        assert_eq!(index.contexts_of(engine_id), vec![earlier, later]);
+        assert!(index.contexts_of(Uuid::from_u128(4)).is_empty());
+    }
+
+    #[test]
+    fn context_inventory_retains_resource_ownership() {
+        let engine_id = Uuid::from_u128(1);
+        let engine_context = Uuid::from_u128(2);
+        let worker_context = Uuid::from_u128(3);
+        let worker_id = Uuid::from_u128(4);
+        let mut index = EngineIndex::default();
+        index.attribute_resource(engine_id, engine_context, engine_id);
+        index.add_worker(engine_id, worker_id, worker_context);
+
+        assert_eq!(
+            index.context_resources_of(engine_id),
+            BTreeMap::from([
+                (engine_context, vec![engine_id]),
+                (worker_context, vec![worker_id]),
+            ])
+        );
     }
 }

--- a/domains/query_engine/server/src/lib.rs
+++ b/domains/query_engine/server/src/lib.rs
@@ -59,12 +59,29 @@ where
     A: UiAnalyzer + Send + Sync + 'static,
     <A as UiAnalyzer>::EntityRef: serde::Serialize,
 {
+    analyzer_service_router_with_routes::<A>(importer, lister, cors, AxumRouter::new())
+}
+
+/// Build the analyzer router and merge integration-owned routes before common
+/// CORS and embedded-UI fallback layers are installed.
+pub fn analyzer_service_router_with_routes<A>(
+    importer: Box<analyzer_cache::ImporterFn<A>>,
+    lister: Box<analyzer_cache::ListerFn>,
+    cors: Option<String>,
+    additional_routes: AxumRouter,
+) -> Result<AxumRouter, Box<dyn std::error::Error>>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+    <A as UiAnalyzer>::EntityRef: serde::Serialize,
+{
     let state = ServiceState {
         analyzers: AnalyzerCache::<A>::new(importer, lister),
         timelines: TimelineCache::new(),
     };
 
-    let mut http_routes = axum::Router::new().nest("/api/engines", ui::routes(state));
+    let mut http_routes = axum::Router::new()
+        .nest("/api/engines", ui::routes(state))
+        .merge(additional_routes);
 
     #[cfg(feature = "swagger")]
     {

--- a/domains/query_engine/server/src/ui.rs
+++ b/domains/query_engine/server/src/ui.rs
@@ -114,6 +114,33 @@ where
     Ok(Json(analyzer.query_engine_model().engine()?.to_ui()?))
 }
 
+/// List every Quent context attributed to an engine.
+#[cfg_attr(feature = "swagger", utoipa::path(
+    get,
+    path = "/api/engines/{engine_id}/contexts",
+    tag = "engines",
+    params(
+        ("engine_id" = Uuid, Path, description = "The engine ID")
+    ),
+    responses(
+        (status = 200, description = "Contexts contributing telemetry to the engine", body = Object)
+    )
+))]
+#[tracing::instrument(skip_all, err)]
+async fn engine_contexts<A>(
+    State(state): State<ServiceState<A>>,
+    Path(engine_id): Path<Uuid>,
+) -> ServerResult<Json<ui::EngineContexts>>
+where
+    A: UiAnalyzer + Send + Sync + 'static,
+{
+    let contexts = state.analyzers.contexts(engine_id).await.map_err(|error| {
+        tracing::error!(%error, %engine_id, "engine context inventory failed");
+        crate::error::ServerError::Cache("engine context inventory could not be loaded".to_owned())
+    })?;
+    Ok(Json(contexts))
+}
+
 // TODO(johanpel): pagination
 /// List all query groups for a given engine.
 #[cfg_attr(feature = "swagger", utoipa::path(
@@ -329,6 +356,7 @@ where
     paths(
         list_engines,
         engine,
+        engine_contexts,
         list_query_groups,
         list_queries,
         query,
@@ -353,6 +381,7 @@ where
     Router::new()
         .route("/", get(list_engines))
         .route("/{engine_id}", get(engine))
+        .route("/{engine_id}/contexts", get(engine_contexts))
         .route("/{engine_id}/query-groups", get(list_query_groups))
         .route(
             "/{engine_id}/query_group/{query_group_id}/queries",

--- a/domains/query_engine/ui/src/lib.rs
+++ b/domains/query_engine/ui/src/lib.rs
@@ -15,9 +15,20 @@ use quent_ui::{
     quantity::QuantitySpec,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use ts_rs::TS;
 use uuid::Uuid;
+
+/// Quent contexts whose streams contribute to one engine view.
+///
+/// This is intentionally an inventory only. It does not claim that every
+/// context contains a particular query or NVTX stream.
+#[derive(TS, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EngineContexts {
+    pub engine_id: Uuid,
+    /// Resource-group entities observed in each context, keyed by context ID.
+    pub context_resources: BTreeMap<Uuid, Vec<Uuid>>,
+}
 
 /// Global timeline-request parameter identifying the query to report on.
 #[derive(TS, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/examples/simulator/server/Cargo.toml
+++ b/examples/simulator/server/Cargo.toml
@@ -10,6 +10,7 @@ swagger = ["quent-query-engine-server/swagger"]
 [dependencies]
 axum = { version = "0.8.7" }
 clap = { version = "4.5", features = ["derive", "env"] }
+nvtx-server = { path = "../../../integrations/nvtx/server" }
 quent-io = { path = "../../../crates/io" }
 quent-query-engine-server = { path = "../../../domains/query_engine/server" }
 quent-simulator-analyzer = { path = "../analyzer" }

--- a/examples/simulator/server/src/main.rs
+++ b/examples/simulator/server/src/main.rs
@@ -4,10 +4,11 @@
 use std::{net::ToSocketAddrs, path::PathBuf};
 
 use clap::Parser;
+use nvtx_server::{import_context_events, routes as nvtx_routes};
 use quent_io::ExporterOptions;
 use quent_io::filesystem::{self, Format};
 use quent_query_engine_server::{
-    analyzer_cache::index_query_engines, analyzer_service_router, collector_service,
+    analyzer_cache::index_query_engines, analyzer_service_router_with_routes, collector_service,
     initialize_tracing,
 };
 use quent_simulator_analyzer::SimulatorUiAnalyzer;
@@ -88,6 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let importer_output_dir = output_dir.clone();
     let lister_output_dir = output_dir.clone();
+    let nvtx_output_dir = output_dir.clone();
 
     let format = match exporter.as_str() {
         "ndjson" => Format::Ndjson,
@@ -131,10 +133,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let analyzer = async {
         axum::serve(
             TcpListener::bind(analyzer_addr).await?,
-            analyzer_service_router::<SimulatorUiAnalyzer>(
+            analyzer_service_router_with_routes::<SimulatorUiAnalyzer>(
                 Box::new(importer),
                 Box::new(lister),
                 cors_address,
+                nvtx_routes(Box::new(move |context_id| {
+                    import_context_events(&nvtx_output_dir, context_id)
+                })),
             )?
             .into_make_service(),
         )

--- a/examples/simulator/ui-bindings/Cargo.toml
+++ b/examples/simulator/ui-bindings/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+nvtx-ui = { path = "../../../integrations/nvtx/ui" }
 quent-query-engine-ui = { path = "../../../domains/query_engine/ui" }
 quent-simulator-ui = { path = "../ui" }
 quent-ui = { path = "../../../crates/ui" }

--- a/examples/simulator/ui-bindings/src/lib.rs
+++ b/examples/simulator/ui-bindings/src/lib.rs
@@ -5,8 +5,9 @@
 
 use std::path::Path;
 
+use nvtx_ui::{NvtxCatalog, NvtxViewportRequest, NvtxViewportResponse};
 use quent_query_engine_ui::DataFlowTimelineBinned;
-use quent_query_engine_ui::{OperatorFilter, QueryBundle, QueryFilter};
+use quent_query_engine_ui::{EngineContexts, OperatorFilter, QueryBundle, QueryFilter};
 use quent_simulator_ui::EntityRef;
 use quent_ui::entities::{request::EntityListRequest, response::EntityListResponse};
 use quent_ui::timeline::{
@@ -34,6 +35,10 @@ pub fn generate(output_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     <BulkTimelinesResponse as TS>::export_all(&cfg)?;
     <CategoricalTimelineRequest<QueryFilter> as TS>::export_all(&cfg)?;
     <DataFlowTimelineBinned as TS>::export_all(&cfg)?;
+    <EngineContexts as TS>::export_all(&cfg)?;
+    <NvtxCatalog as TS>::export_all(&cfg)?;
+    <NvtxViewportRequest as TS>::export_all(&cfg)?;
+    <NvtxViewportResponse as TS>::export_all(&cfg)?;
 
     <EntityListRequest<QueryFilter, OperatorFilter> as TS>::export_all(&cfg)?;
     <EntityListResponse as TS>::export_all(&cfg)?;

--- a/integrations/nvtx/server/Cargo.toml
+++ b/integrations/nvtx/server/Cargo.toml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "nvtx-server"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[features]
+default = []
+real-capture-tests = ["nvtx-analyzer/real-capture-tests"]
+
+[dependencies]
+axum = { version = "0.8.7" }
+moka = { version = "0.12.13", features = ["future", "sync"] }
+nvtx-analyzer = { path = "../analyzer" }
+nvtx-bridge = { path = "../bridge" }
+nvtx-ui = { path = "../ui" }
+quent-events = { path = "../../../crates/events" }
+quent-io = { path = "../../../crates/io" }
+serde.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+tracing.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+nvtx-events = { path = "../events" }
+serde_json.workspace = true
+tempfile = "3"
+tower = { version = "0.5", features = ["util"] }

--- a/integrations/nvtx/server/src/lib.rs
+++ b/integrations/nvtx/server/src/lib.rs
@@ -1,0 +1,645 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Context-keyed NVTX reconstruction cache and Axum routes.
+
+use std::error::Error;
+use std::fmt;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use moka::{future::Cache as AsyncCache, sync::Cache as SyncCache};
+use nvtx_analyzer::{NvtxModel, NvtxModelBuilder};
+use nvtx_bridge::NvtxEventEntity;
+use nvtx_ui::{NvtxCatalog, NvtxViewportRequest, NvtxViewportResponse};
+use quent_events::{EntityEvent, Event};
+use quent_io::filesystem::{self, Format};
+use quent_io::{ImporterOptions, ImporterProvider};
+use tokio::sync::Semaphore;
+use uuid::Uuid;
+
+const MAX_BODY_BYTES: usize = 64 * 1024;
+const MAX_DOMAIN_FILTERS: usize = 256;
+const MAX_CATEGORY_FILTERS: usize = 4096;
+const MAX_CATALOG_ORIGINS: u64 = 32;
+const MAX_CONCURRENT_MODEL_TASKS: usize = 4;
+
+/// A redacted importer failure. Details are logged server-side and are never
+/// copied into an HTTP response.
+#[derive(Debug, Clone)]
+pub struct NvtxImporterError(String);
+
+impl NvtxImporterError {
+    pub fn new(error: impl fmt::Display) -> Self {
+        Self(error.to_string())
+    }
+}
+
+impl fmt::Display for NvtxImporterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for NvtxImporterError {}
+
+pub type NvtxImporterResult<T> = Result<T, NvtxImporterError>;
+
+/// Loads only one context's NVTX entity stream. `None` means the stream is not
+/// available; `Some(Vec::new())` is a present but empty stream.
+pub type NvtxImporterFn =
+    dyn Fn(Uuid) -> NvtxImporterResult<Option<Vec<Event<NvtxEventEntity>>>> + Send + Sync;
+
+/// Import one context's NVTX stream from the standard filesystem layout.
+pub fn import_context_events(
+    root: &Path,
+    context_id: Uuid,
+) -> NvtxImporterResult<Option<Vec<Event<NvtxEventEntity>>>> {
+    let context_dir = root.join(context_id.to_string());
+    let stream_dir = context_dir.join(<NvtxEventEntity as EntityEvent>::NAME);
+    if !stream_dir.is_dir() {
+        return Ok(None);
+    }
+    let mut stream_entries = std::fs::read_dir(&stream_dir).map_err(NvtxImporterError::new)?;
+    match stream_entries.next() {
+        None => return Ok(Some(Vec::new())),
+        Some(Err(error)) => return Err(NvtxImporterError::new(error)),
+        Some(Ok(_)) => {}
+    }
+    let format = Format::detect(&context_dir)
+        .ok_or_else(|| NvtxImporterError::new("unable to detect context stream format"))?;
+    let importer = <ImporterOptions as ImporterProvider<NvtxEventEntity>>::create_importer(
+        &ImporterOptions::FileSystem(filesystem::importer::Options {
+            format,
+            path: stream_dir,
+        }),
+    )
+    .map_err(NvtxImporterError::new)?;
+    importer
+        .collect::<quent_io::ImporterResult<Vec<_>>>()
+        .map(Some)
+        .map_err(NvtxImporterError::new)
+}
+
+struct CachedNvtx {
+    model: NvtxModel,
+    catalogs: SyncCache<u64, Arc<NvtxCatalog>>,
+}
+
+impl CachedNvtx {
+    fn new(model: NvtxModel) -> Self {
+        Self {
+            model,
+            catalogs: SyncCache::builder()
+                .max_capacity(MAX_CATALOG_ORIGINS)
+                .build(),
+        }
+    }
+
+    /// Return the catalog whose relative times use `query_start` as their origin.
+    fn catalog(&self, query_start: u64) -> Arc<NvtxCatalog> {
+        self.catalogs.get_with(query_start, || {
+            Arc::new(NvtxCatalog::from_model(&self.model, query_start))
+        })
+    }
+}
+
+/// Applies backpressure before scheduling expensive NVTX work on Tokio's
+/// blocking pool.
+#[derive(Clone)]
+struct NvtxTaskLimiter {
+    permits: Arc<Semaphore>,
+}
+
+impl NvtxTaskLimiter {
+    fn new(max_concurrency: usize) -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(max_concurrency)),
+        }
+    }
+
+    /// Wait for capacity, then retain that capacity until the blocking task exits.
+    async fn run<T>(&self, task: impl FnOnce() -> T + Send + 'static) -> Result<T, NvtxServerError>
+    where
+        T: Send + 'static,
+    {
+        let permit = Arc::clone(&self.permits)
+            .acquire_owned()
+            .await
+            .map_err(|error| NvtxServerError::Internal(error.to_string()))?;
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            task()
+        })
+        .await
+        .map_err(|error| NvtxServerError::Internal(error.to_string()))
+    }
+}
+
+#[derive(Clone)]
+struct NvtxModelCache {
+    models: AsyncCache<Uuid, Arc<CachedNvtx>>,
+    importer: Arc<NvtxImporterFn>,
+    tasks: NvtxTaskLimiter,
+}
+
+impl NvtxModelCache {
+    fn new(importer: Box<NvtxImporterFn>) -> Self {
+        Self {
+            models: AsyncCache::builder()
+                .max_capacity(128)
+                .time_to_idle(Duration::from_hours(24))
+                .build(),
+            importer: Arc::from(importer),
+            tasks: NvtxTaskLimiter::new(MAX_CONCURRENT_MODEL_TASKS),
+        }
+    }
+
+    /// Load and reconstruct one context, coalescing concurrent misses by ID.
+    async fn get(&self, context_id: Uuid) -> Result<Arc<CachedNvtx>, NvtxServerError> {
+        let importer = Arc::clone(&self.importer);
+        let tasks = self.tasks.clone();
+        self.models
+            .entry(context_id)
+            .or_try_insert_with(async move {
+                tasks
+                    .run(move || match importer(context_id) {
+                        Ok(Some(events)) => {
+                            let model = NvtxModelBuilder::build(events);
+                            Ok(Arc::new(CachedNvtx::new(model)))
+                        }
+                        Ok(None) => Err(NvtxServerError::NotFound),
+                        Err(error) => Err(NvtxServerError::Internal(error.to_string())),
+                    })
+                    .await?
+            })
+            .await
+            .map(|entry| entry.into_value())
+            .map_err(|error: Arc<NvtxServerError>| (*error).clone())
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+struct NvtxTimeOrigin {
+    query_start: u64,
+}
+
+#[derive(Debug, Clone)]
+enum NvtxServerError {
+    BadRequest(String),
+    NotFound,
+    Internal(String),
+}
+
+impl IntoResponse for NvtxServerError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
+            Self::NotFound => (StatusCode::NOT_FOUND, "NVTX stream not found").into_response(),
+            Self::Internal(error) => {
+                tracing::error!(%error, "NVTX context load failed");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "NVTX data could not be loaded",
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+/// Return stable metadata for a context relative to one query origin.
+async fn catalog(
+    State(cache): State<NvtxModelCache>,
+    AxumPath(context_id): AxumPath<Uuid>,
+    Query(origin): Query<NvtxTimeOrigin>,
+) -> Result<Json<NvtxCatalog>, NvtxServerError> {
+    let cached = cache.get(context_id).await?;
+    cache
+        .tasks
+        .run(move || Ok(Json((*cached.catalog(origin.query_start)).clone())))
+        .await?
+}
+
+/// Build lanes and statistics for one relative-time viewport.
+async fn viewport(
+    State(cache): State<NvtxModelCache>,
+    AxumPath(context_id): AxumPath<Uuid>,
+    Query(origin): Query<NvtxTimeOrigin>,
+    Json(request): Json<NvtxViewportRequest>,
+) -> Result<Json<NvtxViewportResponse>, NvtxServerError> {
+    validate_filter_count(&request)?;
+    let cached = cache.get(context_id).await?;
+    cache
+        .tasks
+        .run(move || {
+            let catalog = cached.catalog(origin.query_start);
+            NvtxViewportResponse::from_model_with_catalog(&cached.model, &catalog, request)
+                .map(Json)
+                .map_err(|error| NvtxServerError::BadRequest(error.to_string()))
+        })
+        .await?
+}
+
+/// Reject requests whose selector lists could cause disproportionate work.
+fn validate_filter_count(request: &NvtxViewportRequest) -> Result<(), NvtxServerError> {
+    if request.selections.len() > MAX_DOMAIN_FILTERS {
+        return Err(NvtxServerError::BadRequest(
+            "too many domain filters".to_owned(),
+        ));
+    }
+    let category_count = request
+        .selections
+        .iter()
+        .try_fold(0_usize, |total, selection| {
+            total.checked_add(selection.category_ids.len())
+        })
+        .ok_or_else(|| NvtxServerError::BadRequest("too many category filters".to_owned()))?;
+    if category_count > MAX_CATEGORY_FILTERS {
+        return Err(NvtxServerError::BadRequest(
+            "too many category filters".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+/// Context-keyed NVTX API routes.
+///
+/// Catalog and viewport requests require a `query_start` query parameter in
+/// Unix nanoseconds. Public viewport times are seconds relative to that origin.
+pub fn routes(importer: Box<NvtxImporterFn>) -> Router {
+    Router::new()
+        .route("/api/nvtx/contexts/{context_id}/catalog", get(catalog))
+        .route("/api/nvtx/contexts/{context_id}/viewport", post(viewport))
+        .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
+        .with_state(NvtxModelCache::new(importer))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Display;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use nvtx_events::{NvtxEvent, NvtxEventAttributes, NvtxMessage};
+    use tempfile::tempdir;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    const QUERY_START: u64 = 2_000_000_000;
+    const RANGE_END: u64 = 3_000_000_000;
+
+    fn catalog_uri(context_id: impl Display, query_start: u64) -> String {
+        format!("/api/nvtx/contexts/{context_id}/catalog?query_start={query_start}")
+    }
+
+    fn viewport_uri(context_id: impl Display) -> String {
+        format!("/api/nvtx/contexts/{context_id}/viewport?query_start={QUERY_START}")
+    }
+
+    fn range_events(context_id: Uuid) -> Vec<Event<NvtxEventEntity>> {
+        let attributes = NvtxEventAttributes {
+            message: Some(NvtxMessage::String("work".to_owned())),
+            ..Default::default()
+        };
+        vec![
+            Event::new(
+                context_id,
+                QUERY_START,
+                NvtxEventEntity(NvtxEvent::RangeStart {
+                    domain: 4,
+                    range_id: 9,
+                    attributes,
+                }),
+            ),
+            Event::new(
+                context_id,
+                RANGE_END,
+                NvtxEventEntity(NvtxEvent::RangeEnd {
+                    domain: 4,
+                    range_id: 9,
+                }),
+            ),
+        ]
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn model_work_runs_off_the_async_executor() {
+        let limiter = NvtxTaskLimiter::new(1);
+        let executor_thread = std::thread::current().id();
+        let model_thread = limiter.run(|| std::thread::current().id()).await.unwrap();
+
+        assert_ne!(model_thread, executor_thread);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn model_work_waits_for_capacity_before_entering_the_blocking_pool() {
+        let limiter = NvtxTaskLimiter::new(1);
+        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+        let (release_first_tx, release_first_rx) = std::sync::mpsc::channel();
+        let first_limiter = limiter.clone();
+        let first = tokio::spawn(async move {
+            first_limiter
+                .run(move || {
+                    first_started_tx.send(()).unwrap();
+                    release_first_rx.recv().unwrap();
+                })
+                .await
+                .unwrap();
+        });
+        first_started_rx.await.unwrap();
+
+        let (second_started_tx, mut second_started_rx) = tokio::sync::oneshot::channel();
+        let second = tokio::spawn(async move {
+            limiter
+                .run(move || second_started_tx.send(()).unwrap())
+                .await
+                .unwrap();
+        });
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            second_started_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+
+        release_first_tx.send(()).unwrap();
+        first.await.unwrap();
+        second_started_rx.await.unwrap();
+        second.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn model_and_query_relative_catalogs_are_cached_end_to_end() {
+        let present = Uuid::from_u128(1);
+        let loads = Arc::new(AtomicUsize::new(0));
+        let importer_loads = Arc::clone(&loads);
+        let app = routes(Box::new(move |context_id| {
+            importer_loads.fetch_add(1, Ordering::SeqCst);
+            Ok((context_id == present).then(|| range_events(context_id)))
+        }));
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(catalog_uri(present, QUERY_START))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let catalog: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(catalog["trace_start"], 0.0);
+        assert_eq!(catalog["trace_end"], 1.0);
+        assert!(catalog.get("query_start").is_none());
+
+        let alternate_origin = QUERY_START + 500_000_000;
+        let alternate = app
+            .clone()
+            .oneshot(
+                Request::get(catalog_uri(present, alternate_origin))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(alternate.into_body(), usize::MAX).await.unwrap();
+        let alternate: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(alternate["trace_start"], -0.5);
+        assert_eq!(alternate["trace_end"], 0.5);
+
+        let request = NvtxViewportRequest {
+            viewport: nvtx_ui::NvtxViewportWindow {
+                start: 0.0,
+                end: 1.0,
+            },
+            selections: vec![nvtx_ui::NvtxDomainSelection {
+                domain_id: 4,
+                category_ids: vec![],
+                include_uncategorized: true,
+            }],
+        };
+        let response = app
+            .oneshot(
+                Request::post(viewport_uri(present))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let viewport: NvtxViewportResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(viewport.statistics[0].total_duration, 1.0);
+        assert_eq!(
+            loads.load(Ordering::SeqCst),
+            1,
+            "one reconstruction per context"
+        );
+    }
+
+    #[tokio::test]
+    async fn absent_and_empty_streams_are_distinct() {
+        let empty = Uuid::from_u128(2);
+        let absent = Uuid::from_u128(3);
+        let app = routes(Box::new(move |context_id| {
+            Ok((context_id == empty).then(Vec::new))
+        }));
+
+        let empty_response = app
+            .clone()
+            .oneshot(
+                Request::get(catalog_uri(empty, QUERY_START))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(empty_response.status(), StatusCode::OK);
+
+        let absent_response = app
+            .oneshot(
+                Request::get(catalog_uri(absent, QUERY_START))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(absent_response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn absent_stream_is_retried_and_cached_after_it_becomes_available() {
+        let context_id = Uuid::from_u128(9);
+        let available = Arc::new(AtomicBool::new(false));
+        let loads = Arc::new(AtomicUsize::new(0));
+        let importer_available = Arc::clone(&available);
+        let importer_loads = Arc::clone(&loads);
+        let app = routes(Box::new(move |requested_context_id| {
+            importer_loads.fetch_add(1, Ordering::SeqCst);
+            Ok(
+                (requested_context_id == context_id && importer_available.load(Ordering::SeqCst))
+                    .then(|| range_events(requested_context_id)),
+            )
+        }));
+
+        let missing = app
+            .clone()
+            .oneshot(
+                Request::get(catalog_uri(context_id, QUERY_START))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+        available.store(true, Ordering::SeqCst);
+        for _ in 0..2 {
+            let present = app
+                .clone()
+                .oneshot(
+                    Request::get(catalog_uri(context_id, QUERY_START))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(present.status(), StatusCode::OK);
+        }
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn filesystem_importer_recognizes_an_empty_present_stream() {
+        let root = tempdir().unwrap();
+        let context_id = Uuid::from_u128(8);
+        std::fs::create_dir_all(
+            root.path()
+                .join(context_id.to_string())
+                .join(<NvtxEventEntity as EntityEvent>::NAME),
+        )
+        .unwrap();
+
+        let imported = import_context_events(root.path(), context_id).unwrap();
+        assert!(imported.is_some_and(|events| events.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn invalid_selector_is_a_bounded_bad_request() {
+        let present = Uuid::from_u128(4);
+        let app = routes(Box::new(move |context_id| {
+            Ok((context_id == present).then(|| range_events(context_id)))
+        }));
+        let request = NvtxViewportRequest {
+            viewport: nvtx_ui::NvtxViewportWindow {
+                start: 0.0,
+                end: 1.0,
+            },
+            selections: vec![nvtx_ui::NvtxDomainSelection {
+                domain_id: 4,
+                category_ids: vec![],
+                include_uncategorized: false,
+            }],
+        };
+        let response = app
+            .oneshot(
+                Request::post(viewport_uri(present))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn malformed_paths_and_oversized_requests_are_rejected() {
+        let present = Uuid::from_u128(5);
+        let app = routes(Box::new(move |context_id| {
+            Ok((context_id == present).then(|| range_events(context_id)))
+        }));
+
+        let invalid_uuid = app
+            .clone()
+            .oneshot(
+                Request::get(catalog_uri("not-a-uuid", QUERY_START))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid_uuid.status(), StatusCode::BAD_REQUEST);
+
+        let missing_origin = app
+            .clone()
+            .oneshot(
+                Request::get(format!("/api/nvtx/contexts/{present}/catalog"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing_origin.status(), StatusCode::BAD_REQUEST);
+
+        let oversized = app
+            .oneshot(
+                Request::post(viewport_uri(present))
+                    .header("content-type", "application/json")
+                    .body(Body::from(vec![b' '; MAX_BODY_BYTES + 1]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(oversized.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn importer_failures_are_redacted_and_isolated_by_context() {
+        let failing = Uuid::from_u128(6);
+        let present = Uuid::from_u128(7);
+        let app = routes(Box::new(move |context_id| {
+            if context_id == failing {
+                Err(NvtxImporterError::new(
+                    "/secret/capture/path could not be read",
+                ))
+            } else {
+                Ok((context_id == present).then(|| range_events(context_id)))
+            }
+        }));
+
+        let failed = app
+            .clone()
+            .oneshot(
+                Request::get(catalog_uri(failing, QUERY_START))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(failed.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let failed_body = to_bytes(failed.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&failed_body[..], b"NVTX data could not be loaded");
+
+        let healthy = app
+            .oneshot(
+                Request::get(catalog_uri(present, QUERY_START))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(healthy.status(), StatusCode::OK);
+    }
+}

--- a/ui/packages/@quent/client/src/api.ts
+++ b/ui/packages/@quent/client/src/api.ts
@@ -3,6 +3,7 @@
 
 import { parseJsonWithBigInt } from '@quent/utils';
 import { getApiBaseUrl } from './config';
+import { canonicalizeNvtxRequest } from './nvtxCanonical';
 import type {
   QueryBundle,
   QueryGroup,
@@ -20,10 +21,14 @@ import type {
   TimelineConfig,
   EntityListRequest,
   EntityListResponse,
+  EngineContexts,
+  NvtxCatalog,
+  NvtxViewportRequest,
+  NvtxViewportResponse,
 } from '@quent/utils';
 
 interface ApiFetchOptions {
-  params?: Record<string, string | number | boolean>;
+  params?: Record<string, string | number | bigint | boolean>;
   fetchOptions?: RequestInit;
 }
 
@@ -84,6 +89,59 @@ export async function fetchQueryBundle(
 
 export async function fetchListEngines(): Promise<Engine[]> {
   return apiFetch<Engine[]>('/engines', { params: { with_metadata: true } });
+}
+
+export async function fetchEngineContexts(engineId: string): Promise<EngineContexts> {
+  return apiFetch<EngineContexts>(`/engines/${engineId}/contexts`);
+}
+
+/** Fetch stable NVTX metadata, resolving a 404 to optional absence. */
+export async function fetchNvtxCatalog(
+  contextId: string,
+  queryStartUnixNs: bigint
+): Promise<NvtxCatalog | null> {
+  const response = await apiFetchResponse(`/nvtx/contexts/${contextId}/catalog`, {
+    params: { query_start: queryStartUnixNs },
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`API Error: ${response.status} ${response.statusText}`);
+  }
+  return parseJsonWithBigInt<NvtxCatalog>(await response.text());
+}
+
+export async function fetchNvtxViewport(
+  contextId: string,
+  queryStartUnixNs: bigint,
+  request: NvtxViewportRequest
+): Promise<NvtxViewportResponse> {
+  const canonical = canonicalizeNvtxRequest(request);
+  const response = await apiFetchResponse(`/nvtx/contexts/${contextId}/viewport`, {
+    params: { query_start: queryStartUnixNs },
+    fetchOptions: {
+      method: 'POST',
+      body: JSON.stringify(canonical),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`API Error: ${response.status} ${response.statusText}`);
+  }
+  return normalizeNvtxViewport(parseJsonWithBigInt<NvtxViewportResponse>(await response.text()));
+}
+
+function asBigInt(value: bigint | number): bigint {
+  return typeof value === 'bigint' ? value : BigInt(value);
+}
+
+function normalizeNvtxViewport(viewport: NvtxViewportResponse): NvtxViewportResponse {
+  return {
+    ...viewport,
+    statistics: viewport.statistics.map(statistics => ({
+      ...statistics,
+      count: asBigInt(statistics.count),
+      observed_count: asBigInt(statistics.observed_count),
+    })),
+  };
 }
 
 export async function fetchListCoordinators(engineId: string): Promise<QueryGroup[]> {

--- a/ui/packages/@quent/client/src/index.ts
+++ b/ui/packages/@quent/client/src/index.ts
@@ -15,6 +15,9 @@ export {
   fetchBulkTimelines,
   fetchDataFlow,
   fetchEntityList,
+  fetchEngineContexts,
+  fetchNvtxCatalog,
+  fetchNvtxViewport,
 } from './api';
 
 // queryOptions factories
@@ -26,6 +29,13 @@ export { singleTimelineQueryOptions } from './timeline';
 export { bulkTimelineQueryOptions } from './bulkTimelines';
 export { dataFlowQueryOptions } from './dataFlow';
 export { entityListInfiniteQueryOptions, entityListQueryOptions } from './entityList';
+export {
+  canonicalizeNvtxRequest,
+  canonicalizeNvtxSelections,
+  engineContextsQueryOptions,
+  nvtxCatalogQueryOptions,
+  nvtxViewportQueryOptions,
+} from './nvtx';
 
 // Hooks
 export { useQueryBundle } from './queryBundle';
@@ -35,3 +45,4 @@ export { useQueries } from './queries';
 export { useTimeline } from './timeline';
 export { useDataFlow } from './dataFlow';
 export { useEntityList, useInfiniteEntityList } from './entityList';
+export { useEngineContexts, useNvtxCatalog, useNvtxViewport } from './nvtx';

--- a/ui/packages/@quent/client/src/nvtx.test.ts
+++ b/ui/packages/@quent/client/src/nvtx.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { NvtxViewportRequest } from '@quent/utils';
+import { fetchNvtxCatalog, fetchNvtxViewport } from './api';
+import { canonicalizeNvtxRequest, nvtxCatalogQueryOptions, nvtxViewportQueryOptions } from './nvtx';
+
+function stubFetch(response: Response) {
+  const fetchMock = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+const QUERY_START_UNIX_NS = 1_800_000_000_000_000_001n;
+
+const request: NvtxViewportRequest = {
+  viewport: { start: -0.25, end: 1.5 },
+  selections: [
+    { domain_id: '9', category_ids: [7, 3, 7], include_uncategorized: false },
+    { domain_id: '2', category_ids: [], include_uncategorized: true },
+  ],
+};
+
+describe('NVTX client', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('treats catalog 404 as optional absence and fetches catalogs once', async () => {
+    const fetchMock = stubFetch(new Response(null, { status: 404, statusText: 'Not Found' }));
+    await expect(fetchNvtxCatalog('context-1', QUERY_START_UNIX_NS)).resolves.toBeNull();
+    expect(fetchMock.mock.calls[0]?.[0]).toContain(
+      `/api/nvtx/contexts/context-1/catalog?query_start=${QUERY_START_UNIX_NS}`
+    );
+    expect(nvtxCatalogQueryOptions('context-1', QUERY_START_UNIX_NS).staleTime).toBe(Infinity);
+  });
+
+  it('propagates non-404 catalog failures', async () => {
+    stubFetch(new Response(null, { status: 500, statusText: 'Internal Server Error' }));
+    await expect(fetchNvtxCatalog('context-1', QUERY_START_UNIX_NS)).rejects.toThrow(
+      'API Error: 500 Internal Server Error'
+    );
+  });
+
+  it('uses the same canonical selector order for body and query key', async () => {
+    const fetchMock = stubFetch(
+      new Response('{"viewport":{"start":-0.25,"end":1.5},"domains":[],"statistics":[]}', {
+        status: 200,
+      })
+    );
+    const canonical = canonicalizeNvtxRequest(request);
+    expect(canonical.selections.map(selection => selection.domain_id)).toEqual(['2', '9']);
+    expect(canonical.selections[1].category_ids).toEqual([3, 7]);
+
+    await fetchNvtxViewport('context-1', QUERY_START_UNIX_NS, request);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      `/api/nvtx/contexts/context-1/viewport?query_start=${QUERY_START_UNIX_NS}`
+    );
+    expect(init.body).toBe(
+      '{"viewport":{"start":-0.25,"end":1.5},"selections":[{"domain_id":"2","category_ids":[],"include_uncategorized":true},{"domain_id":"9","category_ids":[3,7],"include_uncategorized":false}]}'
+    );
+
+    const options = nvtxViewportQueryOptions('context-1', QUERY_START_UNIX_NS, request);
+    expect(options.queryKey).toEqual([
+      'nvtxViewport',
+      'context-1',
+      QUERY_START_UNIX_NS.toString(10),
+      -0.25,
+      1.5,
+      [
+        ['2', [], true],
+        ['9', [3, 7], false],
+      ],
+    ]);
+    expect(options.placeholderData).toBeTypeOf('function');
+  });
+
+  it('preserves relative seconds and decimal-string identifiers from the catalog', async () => {
+    stubFetch(
+      new Response(
+        '{"trace_start":-0.5,"trace_end":2,"domains":[{"domain_id":"3","name":"d","color":"#000000","threads":[],"categories":[],"has_uncategorized":false}],"anomalies":{"orphan_range_ends":"0","orphan_range_pops":"0","orphan_resource_destroys":"0","reused_range_ids":"0","reused_resource_handles":"0","total":"0","is_faithful":true}}',
+        { status: 200 }
+      )
+    );
+    const catalog = await fetchNvtxCatalog('context-1', QUERY_START_UNIX_NS);
+    expect(catalog?.trace_start).toBe(-0.5);
+    expect(catalog?.domains[0].domain_id).toBe('3');
+    expect(catalog?.anomalies.total).toBe('0');
+  });
+
+  it('normalizes even safe u64 statistic counts to bigint', async () => {
+    stubFetch(
+      new Response(
+        '{"viewport":{"start":-0.25,"end":1.5},"domains":[],"statistics":[{"message":"work","domain_id":"3","domain_name":"d","category_id":null,"category_name":null,"count":1,"observed_count":1,"total_duration":1.25,"avg_duration":1.25,"min_duration":1.25,"max_duration":1.25,"saturated":false}]}',
+        { status: 200 }
+      )
+    );
+    const viewport = await fetchNvtxViewport('context-1', QUERY_START_UNIX_NS, request);
+    expect(viewport.statistics[0]?.count).toBe(1n);
+    expect(viewport.statistics[0]?.observed_count).toBe(1n);
+    expect(viewport.statistics[0]?.total_duration).toBe(1.25);
+  });
+});

--- a/ui/packages/@quent/client/src/nvtx.ts
+++ b/ui/packages/@quent/client/src/nvtx.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { keepPreviousData, queryOptions, useQuery } from '@tanstack/react-query';
+import type { NvtxViewportRequest } from '@quent/utils';
+import { fetchEngineContexts, fetchNvtxCatalog, fetchNvtxViewport } from './api';
+import { DEFAULT_STALE_TIME } from './constants';
+import { canonicalizeNvtxRequest } from './nvtxCanonical';
+export { canonicalizeNvtxRequest, canonicalizeNvtxSelections } from './nvtxCanonical';
+
+export const engineContextsQueryOptions = (engineId: string) =>
+  queryOptions({
+    queryKey: ['engineContexts', engineId],
+    queryFn: () => fetchEngineContexts(engineId),
+    staleTime: DEFAULT_STALE_TIME,
+  });
+
+export const nvtxCatalogQueryOptions = (contextId: string, queryStartUnixNs: bigint) => {
+  const queryStartKey = queryStartUnixNs.toString(10);
+  return queryOptions({
+    queryKey: ['nvtxCatalog', contextId, queryStartKey],
+    queryFn: () => fetchNvtxCatalog(contextId, queryStartUnixNs),
+    staleTime: Infinity,
+  });
+};
+
+export const nvtxViewportQueryOptions = (
+  contextId: string,
+  queryStartUnixNs: bigint,
+  request: NvtxViewportRequest,
+  options?: { enabled?: boolean; staleTime?: number }
+) => {
+  const canonical = canonicalizeNvtxRequest(request);
+  const queryStartKey = queryStartUnixNs.toString(10);
+  const selectionKey = canonical.selections.map(selection => [
+    selection.domain_id,
+    selection.category_ids,
+    selection.include_uncategorized,
+  ]);
+  return queryOptions({
+    queryKey: [
+      'nvtxViewport',
+      contextId,
+      queryStartKey,
+      canonical.viewport.start,
+      canonical.viewport.end,
+      selectionKey,
+    ],
+    queryFn: () => fetchNvtxViewport(contextId, queryStartUnixNs, canonical),
+    enabled: options?.enabled ?? true,
+    staleTime: options?.staleTime ?? DEFAULT_STALE_TIME,
+    placeholderData: keepPreviousData,
+  });
+};
+
+export const useEngineContexts = (engineId: string) =>
+  useQuery(engineContextsQueryOptions(engineId));
+
+export const useNvtxCatalog = (contextId: string, queryStartUnixNs: bigint) =>
+  useQuery(nvtxCatalogQueryOptions(contextId, queryStartUnixNs));
+
+export const useNvtxViewport = (
+  contextId: string,
+  queryStartUnixNs: bigint,
+  request: NvtxViewportRequest,
+  options?: { enabled?: boolean; staleTime?: number }
+) => useQuery(nvtxViewportQueryOptions(contextId, queryStartUnixNs, request, options));

--- a/ui/packages/@quent/client/src/nvtxCanonical.ts
+++ b/ui/packages/@quent/client/src/nvtxCanonical.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { NvtxDomainSelection, NvtxViewportRequest } from '@quent/utils';
+
+export function canonicalizeNvtxSelections(
+  selections: readonly NvtxDomainSelection[]
+): NvtxDomainSelection[] {
+  const seen = new Set<string>();
+  const canonical = selections.map(selection => {
+    const domainKey = BigInt(selection.domain_id).toString(10);
+    if (seen.has(domainKey)) throw new Error(`duplicate NVTX domain ${domainKey}`);
+    seen.add(domainKey);
+    const category_ids = [...new Set(selection.category_ids)].sort((left, right) => left - right);
+    if (category_ids.length === 0 && !selection.include_uncategorized) {
+      throw new Error(`NVTX domain ${domainKey} selects no categories`);
+    }
+    return { ...selection, domain_id: domainKey, category_ids };
+  });
+  canonical.sort((left, right) =>
+    BigInt(left.domain_id) < BigInt(right.domain_id)
+      ? -1
+      : BigInt(left.domain_id) > BigInt(right.domain_id)
+        ? 1
+        : 0
+  );
+  return canonical;
+}
+
+export function canonicalizeNvtxRequest(request: NvtxViewportRequest): NvtxViewportRequest {
+  const { start, end } = request.viewport;
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) {
+    throw new Error('NVTX viewport bounds must be finite and ordered');
+  }
+  return {
+    viewport: { start, end },
+    selections: canonicalizeNvtxSelections(request.selections),
+  };
+}

--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -173,6 +173,15 @@ export {
 } from './timeline/types';
 export type { TimelineMark, TimelineSeries, TimelineSeriesEntry } from './timeline/types';
 export { ResourceTimeline } from './timeline/ResourceTimeline';
+export { NvtxLaneChart } from './nvtx/NvtxLaneChart';
+export type { NvtxLaneChartProps } from './nvtx/NvtxLaneChart';
+export { formatNvtxDuration, nvtxRelativeSecondsToMs } from './nvtx/NvtxLaneChart.utils';
+export { NvtxTimelineControls } from './nvtx/NvtxTimelineControls';
+export type {
+  NvtxCatalogControlEntry,
+  NvtxStatisticsControlEntry,
+  NvtxTimelineControlsProps,
+} from './nvtx/NvtxTimelineControls';
 
 // ─── DAG components ───────────────────────────────────────────────────────────
 export { DAGChart } from './dag/DAGChart';

--- a/ui/packages/@quent/components/src/lib/useTimelineWheelNavigation.test.ts
+++ b/ui/packages/@quent/components/src/lib/useTimelineWheelNavigation.test.ts
@@ -85,28 +85,39 @@ describe('useTimelineWheelNavigation', () => {
     );
   });
 
-  it('allows shifted vertical wheel input to reach ECharts', () => {
+  it('zooms on shifted vertical wheel input even when an overlay sits above the chart', () => {
     const chart = createChart({ start: 25, end: 75 });
     const wheelTarget = document.createElement('div');
     wheelTarget.appendChild(chart.dom);
+    const overlay = document.createElement('button');
+    wheelTarget.appendChild(overlay);
     const echartsWheel = vi.fn();
     chart.dom.addEventListener('wheel', echartsWheel);
     const { result } = renderHook(() => useTimelineWheelNavigation(10));
     act(() => result.current(chart.instance, wheelTarget));
 
-    act(() => {
-      chart.dom.dispatchEvent(
-        new WheelEvent('wheel', {
-          deltaY: 100,
-          shiftKey: true,
-          bubbles: true,
-          cancelable: true,
-        })
-      );
+    const event = new WheelEvent('wheel', {
+      deltaY: -100,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+      clientX: CHART_WIDTH / 2,
     });
+    act(() => overlay.dispatchEvent(event));
 
-    expect(echartsWheel).toHaveBeenCalledOnce();
-    expect(chart.dispatchAction).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    expect(echartsWheel).not.toHaveBeenCalled();
+    expect(chart.dispatchAction).toHaveBeenCalledOnce();
+    expect(chart.dispatchAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'dataZoom',
+        dataZoomIndex: 0,
+        start: expect.any(Number),
+        end: expect.any(Number),
+      })
+    );
+    const action = chart.dispatchAction.mock.calls[0][0];
+    expect(action.end - action.start).toBeLessThan(50);
   });
 
   it('leaves vertical wheel input to native scrolling', () => {
@@ -158,8 +169,9 @@ describe('useTimelineWheelNavigation', () => {
     });
     act(() => chart.dom.dispatchEvent(zoomOut));
 
-    expect(zoomOut.defaultPrevented).toBe(false);
-    expect(parentWheel).toHaveBeenCalledOnce();
+    expect(zoomOut.defaultPrevented).toBe(true);
+    expect(parentWheel).not.toHaveBeenCalled();
+    expect(chart.dispatchAction).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/ui/packages/@quent/components/src/lib/useTimelineWheelNavigation.ts
+++ b/ui/packages/@quent/components/src/lib/useTimelineWheelNavigation.ts
@@ -7,6 +7,7 @@ import type { DataZoomComponentOption } from 'echarts/components';
 import { TIMELINE_SPACING } from '../timeline/types';
 
 const ZOOM_LIMIT_FLOAT_TOLERANCE = 1.01;
+const WHEEL_ZOOM_FACTOR = 1.1;
 
 function getDataZoomState(instance: EChartsType): DataZoomComponentOption | undefined {
   const dataZoom = (instance.getOption() as EChartsOption).dataZoom;
@@ -39,10 +40,42 @@ export function useTimelineWheelNavigation(minZoomSpanPct: number) {
           event.deltaX !== 0 && Math.abs(event.deltaX) > Math.abs(event.deltaY);
 
         if (event.shiftKey && !isHorizontalScroll) {
-          if (event.deltaY < 0 && isAtZoomLimit()) {
-            event.preventDefault();
-            event.stopPropagation();
-          }
+          if (instance.isDisposed?.()) return;
+          const dataZoom = getDataZoomState(instance);
+          if (!dataZoom) return;
+
+          event.preventDefault();
+          event.stopPropagation();
+
+          const currentStart = dataZoom.start ?? 0;
+          const currentEnd = dataZoom.end ?? 100;
+          const currentSpan = currentEnd - currentStart;
+          const zoomingIn = event.deltaY < 0;
+          const unclampedNextSpan = zoomingIn
+            ? currentSpan / WHEEL_ZOOM_FACTOR
+            : currentSpan * WHEEL_ZOOM_FACTOR;
+          const nextSpan = Math.max(minZoomSpanPctRef.current, Math.min(100, unclampedNextSpan));
+
+          if (zoomingIn && isAtZoomLimit()) return;
+
+          const rect = instance.getDom().getBoundingClientRect();
+          const usableWidth = Math.max(
+            1,
+            rect.width - TIMELINE_SPACING.left - TIMELINE_SPACING.right
+          );
+          const localX =
+            event.clientX > 0 ? event.clientX - rect.left - TIMELINE_SPACING.left : usableWidth / 2;
+          const anchorPct = Math.max(0, Math.min(1, localX / usableWidth));
+          const anchorValue = currentStart + currentSpan * anchorPct;
+          const unclampedStart = anchorValue - nextSpan * anchorPct;
+          const newStart = Math.max(0, Math.min(100 - nextSpan, unclampedStart));
+
+          instance.dispatchAction({
+            type: 'dataZoom',
+            dataZoomIndex: 0,
+            start: newStart,
+            end: newStart + nextSpan,
+          });
           return;
         }
 

--- a/ui/packages/@quent/components/src/nvtx/NvtxLaneChart.test.tsx
+++ b/ui/packages/@quent/components/src/nvtx/NvtxLaneChart.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { NvtxLane } from '@quent/utils';
+import { NvtxLaneChart } from './NvtxLaneChart';
+import { formatNvtxDuration, nvtxRelativeSecondsToMs } from './NvtxLaneChart.utils';
+
+vi.mock('@quent/hooks', () => ({ useZoomRange: () => ({ start: 0, end: 1 }) }));
+vi.mock('../gantt-chart/GanttChart', () => ({
+  GanttChart: () => <div data-testid="gantt" />,
+}));
+
+const lane: NvtxLane = {
+  id: 'lane',
+  label: 'thread 7',
+  identity: { kind: 'thread', thread_id: 7, depth: 0 },
+  marks: [],
+  ranges: [
+    {
+      message: '<script>work</script>',
+      domain_id: '1',
+      domain_name: 'Runtime',
+      category_id: null,
+      category_name: null,
+      color: '#2563eb',
+      kind: 'push_pop',
+      thread_id: 7,
+      thread_name: 'worker',
+      observed_start: 0.00000001,
+      observed_end: null,
+      display_start: 0.00000001,
+      display_end: 0.10000001,
+      observed_duration: null,
+      incomplete: true,
+    },
+  ],
+};
+
+describe('NvtxLaneChart', () => {
+  it('converts and formats relative-second contract values', () => {
+    expect(nvtxRelativeSecondsToMs(0.00000001)).toBe(0.00001);
+    expect(formatNvtxDuration(0.00125)).toBe('1.25ms');
+  });
+
+  it('keeps the keyboard tooltip and exposes the message without injecting HTML', () => {
+    render(<NvtxLaneChart lanes={[lane]} durationSeconds={1} isDark={false} />);
+    const target = screen.getByRole('button', { name: /script.*incomplete/i });
+    expect(target).toHaveAttribute('aria-label', '<script>work</script>, incomplete');
+    fireEvent.focus(target);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('<script>work</script>');
+    expect(tooltip).toHaveTextContent('incomplete');
+    expect(tooltip).toHaveTextContent('open at trace boundary');
+    expect(tooltip).toHaveTextContent('worker');
+    expect(document.querySelector('script')).toBeNull();
+  });
+});

--- a/ui/packages/@quent/components/src/nvtx/NvtxLaneChart.tsx
+++ b/ui/packages/@quent/components/src/nvtx/NvtxLaneChart.tsx
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useZoomRange } from '@quent/hooks';
+import type { NvtxLane, NvtxMarkItem, NvtxRangeItem } from '@quent/utils';
+import { GanttChart, type GanttRenderItem } from '../gantt-chart/GanttChart';
+import { clipRectByRect } from '../gantt-chart/utils';
+import { formatNvtxDuration, nvtxRelativeSecondsToMs } from './NvtxLaneChart.utils';
+
+type NvtxDatum = {
+  value: [number, number, number];
+  type: 'range' | 'mark';
+  laneIndex: number;
+  itemIndex: number;
+  depth: number;
+};
+
+type ActiveItem =
+  | { type: 'range'; item: NvtxRangeItem; x: number; y: number }
+  | { type: 'mark'; item: NvtxMarkItem; x: number; y: number };
+
+function NvtxItemTooltip({ active }: { active: ActiveItem }) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState({ left: active.x + 12, top: active.y + 12 });
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const rect = host.getBoundingClientRect();
+    const margin = 4;
+    const offset = 12;
+    let left = active.x + offset;
+    let top = active.y + offset;
+    if (left + rect.width + margin > window.innerWidth) {
+      left = Math.max(margin, active.x - rect.width - offset);
+    }
+    if (top + rect.height + margin > window.innerHeight) {
+      top = Math.max(margin, active.y - rect.height - offset);
+    }
+    setPosition({ left, top });
+  }, [active]);
+
+  const common = active.item;
+  return createPortal(
+    <div
+      ref={hostRef}
+      role="tooltip"
+      className="fixed z-[1000] max-h-[calc(100vh-8px)] max-w-80 overflow-y-auto rounded border border-border bg-popover px-2 py-2 text-[11px] leading-tight text-foreground shadow-md pointer-events-none"
+      style={position}
+    >
+      <div className="text-base font-semibold leading-tight break-words mb-1">{common.message}</div>
+      {active.type === 'range' ? (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1">
+          <dt className="text-muted-foreground">duration</dt>
+          <dd>
+            {active.item.incomplete
+              ? 'incomplete'
+              : active.item.observed_duration === null
+                ? 'unavailable'
+                : formatNvtxDuration(active.item.observed_duration)}
+          </dd>
+          <dt className="text-muted-foreground">start</dt>
+          <dd className="font-mono whitespace-nowrap">
+            {formatNvtxDuration(active.item.observed_start)} relative to query
+          </dd>
+          <dt className="text-muted-foreground">end</dt>
+          <dd className="font-mono whitespace-nowrap">
+            {active.item.observed_end === null
+              ? 'open at trace boundary'
+              : `${formatNvtxDuration(active.item.observed_end)} relative to query`}
+          </dd>
+          <dt className="text-muted-foreground">kind</dt>
+          <dd>{active.item.kind === 'push_pop' ? 'push/pop range' : 'start/end range'}</dd>
+          {active.item.thread_name !== null && (
+            <>
+              <dt className="text-muted-foreground">thread</dt>
+              <dd className="break-words">{active.item.thread_name}</dd>
+            </>
+          )}
+          <dt className="text-muted-foreground">domain</dt>
+          <dd className="break-words">{active.item.domain_name}</dd>
+          <dt className="text-muted-foreground">category</dt>
+          <dd className="break-words">{active.item.category_name ?? 'Uncategorized'}</dd>
+        </dl>
+      ) : (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1">
+          <dt className="text-muted-foreground">timestamp</dt>
+          <dd className="font-mono whitespace-nowrap">
+            {formatNvtxDuration(active.item.timestamp)} relative to query
+          </dd>
+          <dt className="text-muted-foreground">domain</dt>
+          <dd className="break-words">{active.item.domain_name}</dd>
+          <dt className="text-muted-foreground">category</dt>
+          <dd className="break-words">{active.item.category_name ?? 'Uncategorized'}</dd>
+        </dl>
+      )}
+    </div>,
+    document.body
+  );
+}
+
+export interface NvtxLaneChartProps {
+  lanes: NvtxLane[];
+  durationSeconds: number;
+  isDark: boolean;
+}
+
+export function NvtxLaneChart({ lanes, durationSeconds, isDark }: NvtxLaneChartProps) {
+  const zoomRange = useZoomRange();
+  const [active, setActive] = useState<ActiveItem | null>(null);
+  const threadLanes = useMemo(() => lanes.filter(lane => lane.identity.kind === 'thread'), [lanes]);
+  const maxDepth = useMemo(
+    () =>
+      threadLanes.reduce(
+        (max, lane) => Math.max(max, lane.identity.kind === 'thread' ? lane.identity.depth : 0),
+        0
+      ),
+    [threadLanes]
+  );
+  const laneBandCount = Math.max(maxDepth + 1, 1);
+  const laneHeight = 18;
+  const laneGap = 0;
+  const verticalInset = 0;
+  const contentHeight = laneBandCount * laneHeight + Math.max(0, laneBandCount - 1) * laneGap;
+  const chartHeight = contentHeight;
+
+  const groupedRanges = useMemo(
+    () =>
+      lanes.map((lane, laneIndex) => ({
+        lane,
+        laneIndex,
+        depth: lane.identity.kind === 'thread' ? lane.identity.depth : 0,
+        ranges: lane.ranges.map(range => ({
+          range,
+          startMs: nvtxRelativeSecondsToMs(range.display_start),
+          endMs: nvtxRelativeSecondsToMs(range.display_end),
+        })),
+        marks: lane.marks.map(mark => ({
+          mark,
+          timestampMs: nvtxRelativeSecondsToMs(mark.timestamp),
+        })),
+      })),
+    [lanes]
+  );
+
+  const data = useMemo<NvtxDatum[]>(
+    () => [
+      ...groupedRanges.flatMap(({ ranges, laneIndex, depth }) =>
+        ranges.map(({ startMs, endMs }, itemIndex) => ({
+          value: [startMs, endMs, depth] as [number, number, number],
+          type: 'range' as const,
+          laneIndex,
+          itemIndex,
+          depth,
+        }))
+      ),
+      ...groupedRanges.flatMap(({ marks, laneIndex, depth }) =>
+        marks.map(({ timestampMs }, itemIndex) => ({
+          value: [timestampMs, timestampMs, depth] as [number, number, number],
+          type: 'mark' as const,
+          laneIndex,
+          itemIndex,
+          depth,
+        }))
+      ),
+    ],
+    [groupedRanges]
+  );
+
+  const renderItem: GanttRenderItem = useCallback(
+    (params, api) => {
+      const datum = data[params.dataIndex];
+      if (!datum) return null;
+      const startMs = api.value(0) as number;
+      const endMs = api.value(1) as number;
+      const startPoint = api.coord([startMs, datum.depth]);
+      const endPoint = api.coord([endMs, datum.depth]);
+      const coord = params.coordSys as { x?: number; y?: number; width?: number; height?: number };
+      const clipBound =
+        typeof coord.width === 'number' && typeof coord.height === 'number'
+          ? { x: coord.x ?? 0, y: coord.y ?? 0, width: coord.width, height: coord.height }
+          : null;
+
+      if (datum.type === 'mark') {
+        const mark = groupedRanges[datum.laneIndex]?.marks[datum.itemIndex]?.mark;
+        if (!mark) return null;
+        const x = startPoint[0];
+        return {
+          type: 'group' as const,
+          children: [
+            {
+              type: 'line' as const,
+              shape: {
+                x1: x,
+                y1: startPoint[1] - laneHeight / 2,
+                x2: x,
+                y2: startPoint[1] + laneHeight / 2,
+              },
+              style: { stroke: mark.color, lineWidth: 2 },
+            },
+            {
+              type: 'polygon' as const,
+              shape: {
+                points: [
+                  [x, startPoint[1] - laneHeight / 2],
+                  [x - 4, startPoint[1] - laneHeight / 2 + 6],
+                  [x + 4, startPoint[1] - laneHeight / 2 + 6],
+                ],
+              },
+              style: { fill: mark.color },
+            },
+          ],
+        };
+      }
+
+      const range = groupedRanges[datum.laneIndex]?.ranges[datum.itemIndex]?.range;
+      if (!range) return null;
+      const pixelWidth = endPoint[0] - startPoint[0];
+      const renderedWidth = Math.max(2, pixelWidth);
+      const rectShape = {
+        x: pixelWidth < 2 ? startPoint[0] - renderedWidth / 2 : startPoint[0],
+        y: startPoint[1] - laneHeight / 2,
+        width: renderedWidth,
+        height: laneHeight,
+      };
+      const clipped = clipBound ? clipRectByRect(rectShape, clipBound) : rectShape;
+      if (!clipped) return null;
+      const rect = {
+        type: 'rect' as const,
+        shape: { ...clipped, r: 2 },
+        style: {
+          fill: range.color,
+          stroke: range.color,
+          lineWidth: 1,
+          opacity: range.incomplete ? 0.45 : 0.8,
+        },
+      };
+      const edge = clipped.x + clipped.width;
+      const openEdge = {
+        type: 'line' as const,
+        shape: { x1: edge, y1: clipped.y, x2: edge, y2: clipped.y + clipped.height },
+        style: { stroke: range.color, lineWidth: 2, lineDash: [3, 2], opacity: 0.9 },
+      };
+      const label = range.message.trim();
+      const text =
+        clipped.width >= 36 && label.length > 0
+          ? {
+              type: 'text' as const,
+              style: {
+                x: clipped.x + 6,
+                y: clipped.y + clipped.height / 2,
+                text: label,
+                fill: 'rgba(255,255,255,0.95)',
+                fontSize: 11,
+                fontWeight: 500,
+                textVerticalAlign: 'middle' as const,
+                textAlign: 'left' as const,
+                width: Math.max(clipped.width - 12, 0),
+                overflow: 'truncate' as const,
+              },
+              silent: true,
+            }
+          : null;
+      return {
+        type: 'group' as const,
+        children: [rect, ...(range.incomplete ? [openEdge] : []), ...(text ? [text] : [])],
+      };
+    },
+    [data, groupedRanges, laneHeight]
+  );
+
+  const zoomStartMs = zoomRange.start * 1_000;
+  const zoomEndMs = zoomRange.end * 1_000;
+  const zoomSpanMs = Math.max((zoomRange.end - zoomRange.start) * 1_000, 0.000001);
+  const overlayStyle = (startMs: number, endMs: number, isMark: boolean) => {
+    if (endMs < zoomStartMs || startMs > zoomEndMs) return { display: 'none' };
+    const visibleStart = Math.max(startMs, zoomStartMs);
+    const visibleEnd = Math.min(endMs, zoomEndMs);
+    const left = ((visibleStart - zoomStartMs) / zoomSpanMs) * 100;
+    const width = ((Math.max(visibleEnd, visibleStart) - visibleStart) / zoomSpanMs) * 100;
+    if (isMark) return { left: `calc(${left}% - 6px)`, width: 12 };
+    if (width < 0.15) return { left: `calc(${left}% - 1px)`, width: 2 };
+    return { left: `${left}%`, width: `${width}%` };
+  };
+
+  const showAtElement = (
+    type: ActiveItem['type'],
+    item: NvtxRangeItem | NvtxMarkItem,
+    element: HTMLElement
+  ) => {
+    const rect = element.getBoundingClientRect();
+    const position = { x: rect.right, y: rect.top };
+    setActive(
+      type === 'range'
+        ? { type, item: item as NvtxRangeItem, ...position }
+        : { type, item: item as NvtxMarkItem, ...position }
+    );
+  };
+
+  return (
+    <div className="relative h-full min-h-11 overflow-hidden">
+      <GanttChart
+        data={data}
+        gridSpacing={{ left: 0, right: 8, top: 0, bottom: 0 }}
+        durationSeconds={durationSeconds}
+        height={chartHeight}
+        maxHeight={chartHeight}
+        rowHeight={laneHeight}
+        isDark={isDark}
+        seriesName="nvtx-item"
+        renderItem={renderItem}
+        emptyMessage="No NVTX ranges in this view"
+        cursor="pointer"
+      />
+      <div
+        className="absolute inset-0 right-2 pointer-events-none"
+        aria-label={`${lanes[0]?.label ?? 'NVTX'} NVTX items`}
+      >
+        {groupedRanges
+          .flatMap(({ ranges, depth }) => ranges.map(entry => ({ ...entry, depth })))
+          .map(({ range, startMs, endMs, depth }, index) => (
+            <button
+              key={`range-${index}`}
+              type="button"
+              className="absolute opacity-0 pointer-events-auto focus:opacity-100 focus:outline-2 focus:outline-primary rounded-sm"
+              style={{
+                ...overlayStyle(startMs, endMs, false),
+                top: verticalInset + depth * (laneHeight + laneGap),
+                height: laneHeight,
+              }}
+              aria-label={`${range.message}, ${range.incomplete ? 'incomplete' : 'NVTX range'}`}
+              onPointerEnter={event => showAtElement('range', range, event.currentTarget)}
+              onPointerLeave={() => setActive(null)}
+              onFocus={event => showAtElement('range', range, event.currentTarget)}
+              onBlur={() => setActive(null)}
+              onKeyDown={event => event.key === 'Escape' && setActive(null)}
+            />
+          ))}
+        {groupedRanges
+          .flatMap(({ marks, depth }) => marks.map(entry => ({ ...entry, depth })))
+          .map(({ mark, timestampMs, depth }, index) => (
+            <button
+              key={`mark-${index}`}
+              type="button"
+              className="absolute opacity-0 pointer-events-auto focus:opacity-100 focus:outline-2 focus:outline-primary rounded-sm"
+              style={{
+                ...overlayStyle(timestampMs, timestampMs, true),
+                top: verticalInset + depth * (laneHeight + laneGap),
+                height: laneHeight,
+              }}
+              aria-label={`${mark.message}, NVTX mark`}
+              onPointerEnter={event => showAtElement('mark', mark, event.currentTarget)}
+              onPointerLeave={() => setActive(null)}
+              onFocus={event => showAtElement('mark', mark, event.currentTarget)}
+              onBlur={() => setActive(null)}
+              onKeyDown={event => event.key === 'Escape' && setActive(null)}
+            />
+          ))}
+      </div>
+      {active && <NvtxItemTooltip active={active} />}
+    </div>
+  );
+}

--- a/ui/packages/@quent/components/src/nvtx/NvtxLaneChart.utils.ts
+++ b/ui/packages/@quent/components/src/nvtx/NvtxLaneChart.utils.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { formatDuration } from '@quent/utils';
+
+/** Convert query-relative seconds from the NVTX API to the millisecond chart axis. */
+export function nvtxRelativeSecondsToMs(seconds: number): number {
+  return seconds * 1_000;
+}
+
+/** Format a duration supplied by the NVTX API in seconds. */
+export function formatNvtxDuration(seconds: number): string {
+  return formatDuration(nvtxRelativeSecondsToMs(seconds));
+}

--- a/ui/packages/@quent/components/src/nvtx/NvtxTimelineControls.test.tsx
+++ b/ui/packages/@quent/components/src/nvtx/NvtxTimelineControls.test.tsx
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NvtxTimelineControls } from './NvtxTimelineControls';
+
+describe('NvtxTimelineControls', () => {
+  it('renders hierarchical filters and independently toggles Uncategorized', async () => {
+    const onSelectionChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <NvtxTimelineControls
+        catalogs={[
+          {
+            contextId: 'context-1',
+            label: 'context context-',
+            catalog: {
+              trace_start: 0,
+              trace_end: 10,
+              anomalies: {
+                orphan_range_ends: '0',
+                orphan_range_pops: '0',
+                orphan_resource_destroys: '0',
+                reused_range_ids: '0',
+                reused_resource_handles: '0',
+                total: '0',
+                is_faithful: true,
+              },
+              domains: [
+                {
+                  domain_id: '9',
+                  name: 'Runtime domain with a long display name',
+                  color: '#2563eb',
+                  threads: [],
+                  categories: [{ category_id: 3, name: 'Compute' }],
+                  has_uncategorized: true,
+                },
+              ],
+            },
+          },
+        ]}
+        selections={{
+          'context-1': [{ domain_id: '9', category_ids: [3], include_uncategorized: true }],
+        }}
+        statistics={[
+          {
+            contextId: 'context-1',
+            label: 'context context-',
+            statistics: [],
+          },
+        ]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /filter nvtx lanes/i }));
+    expect(screen.getByText('Runtime domain with a long display name')).toBeInTheDocument();
+    await user.click(screen.getByText('Runtime domain with a long display name'));
+    await user.click(screen.getByRole('checkbox', { name: 'Uncategorized' }));
+    expect(onSelectionChange).toHaveBeenCalledWith('context-1', [
+      { domain_id: '9', category_ids: [3], include_uncategorized: false },
+    ]);
+  });
+
+  it('renders bigint counts and relative-second durations', async () => {
+    const user = userEvent.setup();
+    render(
+      <NvtxTimelineControls
+        catalogs={[]}
+        selections={{}}
+        statistics={[
+          {
+            contextId: 'context-1',
+            label: 'context context-',
+            statistics: [
+              {
+                message: 'long work',
+                domain_id: '9',
+                domain_name: 'Runtime',
+                category_id: null,
+                category_name: null,
+                count: 2n,
+                observed_count: 1n,
+                total_duration: 1.25,
+                avg_duration: 1.25,
+                min_duration: 0.001,
+                max_duration: 1.25,
+                saturated: false,
+              },
+            ],
+          },
+        ]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'NVTX statistics' }));
+    expect(screen.getAllByText('1.25s')).toHaveLength(3);
+    expect(screen.getByText('1.00ms')).toBeInTheDocument();
+    expect(screen.getByText(/includes incomplete observations/i)).toBeInTheDocument();
+  });
+});

--- a/ui/packages/@quent/components/src/nvtx/NvtxTimelineControls.tsx
+++ b/ui/packages/@quent/components/src/nvtx/NvtxTimelineControls.tsx
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BarChart3, ListFilter } from 'lucide-react';
+import type { NvtxCatalog, NvtxDomainSelection, NvtxRangeStatistics } from '@quent/utils';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { formatNvtxDuration } from './NvtxLaneChart.utils';
+
+export interface NvtxCatalogControlEntry {
+  contextId: string;
+  label: string;
+  catalog: NvtxCatalog;
+}
+
+export interface NvtxStatisticsControlEntry {
+  contextId: string;
+  label: string;
+  statistics: NvtxRangeStatistics[];
+}
+
+export interface NvtxTimelineControlsProps {
+  catalogs: NvtxCatalogControlEntry[];
+  selections: Readonly<Record<string, NvtxDomainSelection[]>>;
+  statistics: NvtxStatisticsControlEntry[];
+  onSelectionChange: (contextId: string, selections: NvtxDomainSelection[]) => void;
+}
+
+export function NvtxTimelineControls({
+  catalogs,
+  selections,
+  statistics,
+  onSelectionChange,
+}: NvtxTimelineControlsProps) {
+  const selectedCount = Object.values(selections).reduce(
+    (total, domains) =>
+      total +
+      domains.reduce(
+        (domainTotal, domain) =>
+          domainTotal + domain.category_ids.length + (domain.include_uncategorized ? 1 : 0),
+        0
+      ),
+    0
+  );
+
+  const toggleDomain = (entry: NvtxCatalogControlEntry, domainId: string) => {
+    const current = selections[entry.contextId] ?? [];
+    const selectionDomainId = domainId;
+    const existing = current.find(selection => selection.domain_id === selectionDomainId);
+    if (existing) {
+      onSelectionChange(
+        entry.contextId,
+        current.filter(selection => selection.domain_id !== selectionDomainId)
+      );
+      return;
+    }
+    const domain = entry.catalog.domains.find(candidate => candidate.domain_id === domainId)!;
+    onSelectionChange(entry.contextId, [
+      ...current,
+      {
+        domain_id: selectionDomainId,
+        category_ids: domain.categories.map(category => category.category_id),
+        include_uncategorized: domain.has_uncategorized,
+      },
+    ]);
+  };
+
+  const toggleCategory = (
+    entry: NvtxCatalogControlEntry,
+    domainId: string,
+    categoryId: number | null
+  ) => {
+    const current = selections[entry.contextId] ?? [];
+    const selectionDomainId = domainId;
+    const existing = current.find(selection => selection.domain_id === selectionDomainId);
+    const categoryIds = new Set(existing?.category_ids ?? []);
+    let includeUncategorized = existing?.include_uncategorized ?? false;
+    if (categoryId === null) includeUncategorized = !includeUncategorized;
+    else if (categoryIds.has(categoryId)) categoryIds.delete(categoryId);
+    else categoryIds.add(categoryId);
+    const replacement: NvtxDomainSelection = {
+      domain_id: selectionDomainId,
+      category_ids: [...categoryIds],
+      include_uncategorized: includeUncategorized,
+    };
+    const withoutDomain = current.filter(selection => selection.domain_id !== selectionDomainId);
+    onSelectionChange(
+      entry.contextId,
+      replacement.category_ids.length > 0 || replacement.include_uncategorized
+        ? [...withoutDomain, replacement]
+        : withoutDomain
+    );
+  };
+
+  return (
+    <>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex min-h-8 items-center gap-1 rounded-sm px-1.5 hover:bg-accent hover:text-accent-foreground focus-visible:outline-2 focus-visible:outline-primary"
+            aria-label={`Filter NVTX lanes, ${selectedCount} options selected`}
+          >
+            <ListFilter className="h-3.5 w-3.5" />
+            <span>Filter NVTX lanes</span>
+            <span className="rounded bg-primary/15 px-1 text-primary">{selectedCount}</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-80 max-h-96 overflow-y-auto p-4 text-sm" align="end">
+          {catalogs.map(entry => (
+            <fieldset key={entry.contextId} className="mb-4 last:mb-0">
+              {catalogs.length > 1 && (
+                <legend
+                  className="mb-2 max-w-full truncate text-xs font-semibold"
+                  title={entry.label}
+                >
+                  {entry.label}
+                </legend>
+              )}
+              {entry.catalog.domains
+                .filter(domain => domain.categories.length > 0 || domain.has_uncategorized)
+                .map(domain => {
+                  const selection = (selections[entry.contextId] ?? []).find(
+                    candidate => candidate.domain_id === domain.domain_id
+                  );
+                  return (
+                    <details key={domain.domain_id.toString()} className="mb-2 last:mb-0">
+                      <summary className="flex min-h-8 cursor-pointer list-none items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={selection !== undefined}
+                          onClick={event => event.stopPropagation()}
+                          onChange={() => toggleDomain(entry, domain.domain_id)}
+                          aria-label={`${domain.name} domain`}
+                          className="h-3.5 w-3.5 accent-primary"
+                        />
+                        <span
+                          className="h-2.5 w-2.5 rounded-full shrink-0"
+                          style={{ backgroundColor: domain.color }}
+                        />
+                        <span className="truncate" title={domain.name}>
+                          {domain.name}
+                        </span>
+                      </summary>
+                      <div className="ml-6 border-l border-border pl-2">
+                        {domain.categories.map(category => (
+                          <label
+                            key={category.category_id}
+                            className="flex min-h-8 items-center gap-2 cursor-pointer"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={
+                                selection?.category_ids.includes(category.category_id) ?? false
+                              }
+                              onChange={() =>
+                                toggleCategory(entry, domain.domain_id, category.category_id)
+                              }
+                              className="h-3.5 w-3.5 accent-primary"
+                            />
+                            <span className="truncate" title={category.name}>
+                              {category.name}
+                            </span>
+                          </label>
+                        ))}
+                        {domain.has_uncategorized && (
+                          <label className="flex min-h-8 items-center gap-2 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={selection?.include_uncategorized ?? false}
+                              onChange={() => toggleCategory(entry, domain.domain_id, null)}
+                              className="h-3.5 w-3.5 accent-primary"
+                            />
+                            <span>Uncategorized</span>
+                          </label>
+                        )}
+                      </div>
+                    </details>
+                  );
+                })}
+            </fieldset>
+          ))}
+        </PopoverContent>
+      </Popover>
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex min-h-8 items-center gap-1 rounded-sm px-1.5 hover:bg-accent hover:text-accent-foreground focus-visible:outline-2 focus-visible:outline-primary"
+          >
+            <BarChart3 className="h-3.5 w-3.5" />
+            <span>NVTX statistics</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-96 max-h-96 overflow-y-auto p-4" align="end">
+          {statistics.every(entry => entry.statistics.length === 0) ? (
+            <p className="text-sm text-muted-foreground">No NVTX ranges in this view</p>
+          ) : (
+            statistics.map(entry => (
+              <section key={entry.contextId} className="mb-4 last:mb-0">
+                {statistics.length > 1 && (
+                  <h3 className="mb-2 truncate text-base font-semibold" title={entry.label}>
+                    {entry.label}
+                  </h3>
+                )}
+                <div className="space-y-2">
+                  {entry.statistics.map((item, index) => (
+                    <div
+                      key={`${item.domain_id.toString()}-${item.category_id ?? 'none'}-${item.message}-${index}`}
+                      className="rounded bg-secondary/40 p-2 text-xs"
+                    >
+                      <div className="font-semibold break-words text-sm">{item.message}</div>
+                      <div className="text-muted-foreground break-words">
+                        {item.domain_name} · {item.category_name ?? 'Uncategorized'}
+                      </div>
+                      <dl className="mt-1 grid grid-cols-2 gap-x-2 gap-y-1">
+                        <dt>ranges</dt>
+                        <dd className="text-right font-mono">{item.count.toString()}</dd>
+                        <dt>observed</dt>
+                        <dd className="text-right font-mono">{item.observed_count.toString()}</dd>
+                        <dt>total visible</dt>
+                        <dd className="text-right font-mono">
+                          {formatNvtxDuration(item.total_duration)}
+                        </dd>
+                        <dt>average</dt>
+                        <dd className="text-right font-mono">
+                          {item.observed_count === 0n ? '—' : formatNvtxDuration(item.avg_duration)}
+                        </dd>
+                        <dt>minimum</dt>
+                        <dd className="text-right font-mono">
+                          {item.min_duration === null ? '—' : formatNvtxDuration(item.min_duration)}
+                        </dd>
+                        <dt>maximum</dt>
+                        <dd className="text-right font-mono">
+                          {item.max_duration === null ? '—' : formatNvtxDuration(item.max_duration)}
+                        </dd>
+                      </dl>
+                      {item.observed_count !== item.count && (
+                        <p className="mt-1 text-muted-foreground">
+                          Includes incomplete observations; duration metrics cover closed ranges
+                          only.
+                        </p>
+                      )}
+                      {item.saturated && (
+                        <p className="mt-1 text-muted-foreground">
+                          Duration totals reached the maximum representable value.
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))
+          )}
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+}

--- a/ui/packages/@quent/components/src/timeline/TimelineToolbar.tsx
+++ b/ui/packages/@quent/components/src/timeline/TimelineToolbar.tsx
@@ -2,11 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Maximize2 } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useSetZoomRange, useSetDebouncedZoomRange } from '@quent/hooks';
 import { QueryToolbar } from './QueryToolbar';
 
-/** Toolbar for the timeline view: shows the active operator filter and zoom reset. */
-export function TimelineToolbar({ durationSeconds }: { durationSeconds: number }) {
+/** Toolbar for the timeline view: shows the active operator filter, zoom reset, and extensions. */
+export function TimelineToolbar({
+  durationSeconds,
+  children,
+}: {
+  durationSeconds: number;
+  children?: ReactNode;
+}) {
   const setZoomRange = useSetZoomRange();
   const setDebouncedZoomRange = useSetDebouncedZoomRange();
 
@@ -26,6 +33,8 @@ export function TimelineToolbar({ durationSeconds }: { durationSeconds: number }
         <Maximize2 className="h-3 w-3" />
         <span>Reset zoom</span>
       </button>
+      {children && <div className="h-3 w-px bg-border" />}
+      {children}
     </QueryToolbar>
   );
 }

--- a/ui/packages/@quent/utils/src/types/index.ts
+++ b/ui/packages/@quent/utils/src/types/index.ts
@@ -15,6 +15,7 @@ export type { DataFlowTimelineBinned } from '../../../../../generated/ts-binding
 export type { DimensionKeyDecl } from '../../../../../generated/ts-bindings/DimensionKeyDecl';
 export type { Edge } from '../../../../../generated/ts-bindings/Edge';
 export type { Engine } from '../../../../../generated/ts-bindings/Engine';
+export type { EngineContexts } from '../../../../../generated/ts-bindings/EngineContexts';
 export type { EngineImplementationAttributes } from '../../../../../generated/ts-bindings/EngineImplementationAttributes';
 export type { EntityFilter } from '../../../../../generated/ts-bindings/EntityFilter';
 export type { EntityListEntry } from '../../../../../generated/ts-bindings/EntityListEntry';
@@ -69,3 +70,19 @@ export type { TimelineRequest } from '../../../../../generated/ts-bindings/Timel
 export type { TimeWindow } from '../../../../../generated/ts-bindings/TimeWindow';
 export type { DynamicValue } from '../../../../../generated/ts-bindings/DynamicValue';
 export type { Worker } from '../../../../../generated/ts-bindings/Worker';
+export type { NvtxCatalog } from '../../../../../generated/ts-bindings/NvtxCatalog';
+export type { NvtxCatalogAnomalies } from '../../../../../generated/ts-bindings/NvtxCatalogAnomalies';
+export type { NvtxCatalogCategory } from '../../../../../generated/ts-bindings/NvtxCatalogCategory';
+export type { NvtxCatalogDomain } from '../../../../../generated/ts-bindings/NvtxCatalogDomain';
+export type { NvtxCatalogThread } from '../../../../../generated/ts-bindings/NvtxCatalogThread';
+export type { NvtxDomainLaneGroup } from '../../../../../generated/ts-bindings/NvtxDomainLaneGroup';
+export type { NvtxDomainSelection } from '../../../../../generated/ts-bindings/NvtxDomainSelection';
+export type { NvtxLane } from '../../../../../generated/ts-bindings/NvtxLane';
+export type { NvtxLaneIdentity } from '../../../../../generated/ts-bindings/NvtxLaneIdentity';
+export type { NvtxMarkItem } from '../../../../../generated/ts-bindings/NvtxMarkItem';
+export type { NvtxRangeItem } from '../../../../../generated/ts-bindings/NvtxRangeItem';
+export type { NvtxRangeKind } from '../../../../../generated/ts-bindings/NvtxRangeKind';
+export type { NvtxRangeStatistics } from '../../../../../generated/ts-bindings/NvtxRangeStatistics';
+export type { NvtxViewportRequest } from '../../../../../generated/ts-bindings/NvtxViewportRequest';
+export type { NvtxViewportResponse } from '../../../../../generated/ts-bindings/NvtxViewportResponse';
+export type { NvtxViewportWindow } from '../../../../../generated/ts-bindings/NvtxViewportWindow';

--- a/ui/src/components/QueryResourceTree.test.tsx
+++ b/ui/src/components/QueryResourceTree.test.tsx
@@ -4,12 +4,20 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { waitFor, act } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { renderWithQuery } from '@/test/test-utils';
+import { server } from '@/test/mocks/server';
 import { Provider as JotaiProvider, createStore } from 'jotai';
 import { QueryResourceTree } from './QueryResourceTree';
 import { applyBulkTimelineResponse, timelineCacheKey } from '@quent/hooks';
 import { timelineDataMapAtom } from '@quent/hooks/testing';
-import type { SingleTimelineResponse, QueryBundle, EntityRef } from '@quent/utils';
+import type {
+  SingleTimelineResponse,
+  QueryBundle,
+  EntityRef,
+  NvtxCatalog,
+  NvtxViewportResponse,
+} from '@quent/utils';
 
 // ---------------------------------------------------------------------------
 // Mock heavy/visual dependencies so tests run without a real browser/canvas
@@ -36,6 +44,21 @@ vi.mock('@/contexts/ThemeContext', () => ({
 
 // Capture the timelineData prop passed to TimelineController on every render
 let capturedTimelineData: SingleTimelineResponse | null | undefined = undefined;
+interface CapturedTreeItem {
+  id: string;
+  children?: CapturedTreeItem[];
+}
+
+let capturedTreeData: CapturedTreeItem[] = [];
+
+function findCapturedItem(id: string, items = capturedTreeData): CapturedTreeItem | undefined {
+  for (const item of items) {
+    if (item.id === id) return item;
+    const child = item.children ? findCapturedItem(id, item.children) : undefined;
+    if (child) return child;
+  }
+  return undefined;
+}
 
 // Mock @quent/components: keep all actual exports but override heavy/visual ones
 vi.mock('@quent/components', async importOriginal => {
@@ -48,18 +71,23 @@ vi.mock('@quent/components', async importOriginal => {
     },
     TreeTable: ({
       columns,
+      data,
     }: {
       columns: Array<{ headerContent?: React.ReactNode; subHeaderContent?: React.ReactNode }>;
-    }) => (
-      <>
-        {columns.map((col, i) => (
-          <React.Fragment key={i}>
-            {col.headerContent}
-            {col.subHeaderContent}
-          </React.Fragment>
-        ))}
-      </>
-    ),
+      data: CapturedTreeItem[];
+    }) => {
+      capturedTreeData = data;
+      return (
+        <>
+          {columns.map((col, i) => (
+            <React.Fragment key={i}>
+              {col.headerContent}
+              {col.subHeaderContent}
+            </React.Fragment>
+          ))}
+        </>
+      );
+    },
     ResourceColumn: () => null,
     UsageColumn: () => null,
     TimelineToolbar: () => null,
@@ -69,7 +97,14 @@ vi.mock('@quent/components', async importOriginal => {
 import * as clientApi from '@quent/client';
 vi.mock('@quent/client', async importOriginal => {
   const actual = await importOriginal<typeof clientApi>();
-  return { ...actual, fetchSingleTimeline: vi.fn(), fetchBulkTimelines: vi.fn() };
+  return {
+    ...actual,
+    fetchSingleTimeline: vi.fn(),
+    fetchBulkTimelines: vi.fn(),
+    fetchEngineContexts: vi.fn(),
+    fetchNvtxCatalog: vi.fn(),
+    fetchNvtxViewport: vi.fn(),
+  };
 });
 
 // ---------------------------------------------------------------------------
@@ -82,14 +117,15 @@ const RESOURCE_ID = 'res-1';
 const RESOURCE_TYPE = 'GPU';
 
 /** Minimal QueryBundle that causes the root timeline query to be enabled. */
-const makeBundle = (): QueryBundle<EntityRef> =>
-  ({
+const makeBundle = (workerId?: string): QueryBundle<EntityRef> => {
+  const resource = { Resource: { Resource: RESOURCE_ID } };
+  return {
     query_id: 'test-query',
     entities: {
       engine: { id: 'engine-1' },
       query_group: { id: ROOT_GROUP_ID },
       query: { id: 'query-1' },
-      workers: {},
+      workers: workerId ? { [workerId]: { id: workerId } } : {},
       plans: {},
       operators: {},
       ports: {},
@@ -102,15 +138,18 @@ const makeBundle = (): QueryBundle<EntityRef> =>
     resource_tree: {
       ResourceGroup: {
         id: { QueryGroup: ROOT_GROUP_ID },
-        children: [{ Resource: { Resource: RESOURCE_ID } }],
+        children: workerId
+          ? [{ ResourceGroup: { id: { Worker: workerId }, children: [resource] } }]
+          : [resource],
       },
     },
-    plan_tree: { id: 'plan-1', worker: null, children: [] },
+    plan_tree: { id: 'plan-1', worker: workerId ?? null, children: [] },
     unique_operator_names: [],
     quantity_specs: {},
     start_time_unix_ns: 0n,
     duration_s: DURATION_S,
-  }) as unknown as QueryBundle<EntityRef>;
+  } as unknown as QueryBundle<EntityRef>;
+};
 
 const makeTimeline = (start: number, end: number): SingleTimelineResponse =>
   ({
@@ -121,6 +160,7 @@ const makeTimeline = (start: number, end: number): SingleTimelineResponse =>
 describe('QueryResourceTree — TimelineController always shows full-range data', () => {
   beforeEach(() => {
     capturedTimelineData = undefined;
+    capturedTreeData = [];
     vi.mocked(clientApi.fetchBulkTimelines).mockResolvedValue({ entries: {} } as never);
   });
 
@@ -195,5 +235,259 @@ describe('QueryResourceTree — TimelineController always shows full-range data'
     // TimelineController must still show the full-range data — not the atom value.
     expect(capturedTimelineData?.config.span.start).toBe(0);
     expect(capturedTimelineData?.config.span.end).toBe(DURATION_S);
+  });
+
+  it('nests each NVTX context beneath its owning worker resource', async () => {
+    vi.mocked(clientApi.fetchSingleTimeline).mockResolvedValue(makeTimeline(0, DURATION_S));
+    const catalog = {
+      trace_start: 0,
+      trace_end: 10,
+      anomalies: {
+        orphan_range_ends: '0',
+        orphan_range_pops: '0',
+        orphan_resource_destroys: '0',
+        reused_range_ids: '0',
+        reused_resource_handles: '0',
+        total: '0',
+        is_faithful: true,
+      },
+      domains: [
+        {
+          domain_id: '1',
+          name: 'Runtime',
+          color: '#2563eb',
+          threads: [],
+          categories: [],
+          has_uncategorized: true,
+        },
+      ],
+    } satisfies NvtxCatalog;
+    const nvtxViewport = {
+      viewport: { start: 0, end: 100 },
+      domains: [
+        {
+          domain_id: '1',
+          name: 'Runtime',
+          color: '#2563eb',
+          lanes: [
+            {
+              id: 'nvtx:1:marks',
+              label: 'Marks',
+              identity: { kind: 'marks' },
+              ranges: [],
+              marks: [],
+            },
+          ],
+        },
+      ],
+      statistics: [],
+    } satisfies NvtxViewportResponse;
+    server.use(
+      http.get('http://localhost:8000/api/engines/:engineId/contexts', ({ params }) =>
+        HttpResponse.json({
+          engine_id: params.engineId,
+          context_resources: {
+            'context-1': ['worker-1'],
+            'context-other': ['worker-2'],
+          },
+        })
+      ),
+      http.get('http://localhost:8000/api/nvtx/contexts/context-1/catalog', () =>
+        HttpResponse.text(
+          JSON.stringify(catalog, (_key, value) =>
+            typeof value === 'bigint' ? Number(value) : value
+          ),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      ),
+      http.post('http://localhost:8000/api/nvtx/contexts/context-1/viewport', () =>
+        HttpResponse.text(
+          JSON.stringify(nvtxViewport, (_key, value) =>
+            typeof value === 'bigint' ? Number(value) : value
+          ),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      )
+    );
+
+    renderWithQuery(
+      <JotaiProvider store={createStore()}>
+        <QueryResourceTree engineId="engine-1" queryBundle={makeBundle('worker-1')} />
+      </JotaiProvider>
+    );
+
+    await waitFor(() => expect(findCapturedItem('nvtx:context-1:root')).toBeDefined());
+    expect(capturedTreeData).toHaveLength(1);
+    expect(findCapturedItem('worker-1')?.children?.map(item => item.id)).toContain(
+      'nvtx:context-1:root'
+    );
+    expect(findCapturedItem('nvtx:context-other:root')).toBeUndefined();
+    await waitFor(() =>
+      expect(findCapturedItem('nvtx:context-1:root')?.children?.[0].id).toBe(
+        'nvtx:context-1:domain:1'
+      )
+    );
+  });
+
+  it('omits the NVTX group when every context has no NVTX stream', async () => {
+    vi.mocked(clientApi.fetchSingleTimeline).mockResolvedValue(makeTimeline(0, DURATION_S));
+    let catalogRequests = 0;
+    server.use(
+      http.get('http://localhost:8000/api/engines/:engineId/contexts', ({ params }) =>
+        HttpResponse.json({
+          engine_id: params.engineId,
+          context_resources: {
+            'context-1': ['engine-1'],
+            'context-2': ['engine-1'],
+          },
+        })
+      ),
+      http.get('http://localhost:8000/api/nvtx/contexts/:contextId/catalog', () => {
+        catalogRequests += 1;
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
+
+    renderWithQuery(
+      <JotaiProvider store={createStore()}>
+        <QueryResourceTree engineId="engine-1" queryBundle={makeBundle()} />
+      </JotaiProvider>
+    );
+
+    await waitFor(() => expect(catalogRequests).toBe(2));
+    await waitFor(() => expect(findCapturedItem('nvtx:context-1:root')).toBeUndefined());
+    expect(findCapturedItem('nvtx:context-2:root')).toBeUndefined();
+    expect(capturedTreeData[0].id).toBe(ROOT_GROUP_ID);
+  });
+
+  it('retains successful contexts when another NVTX catalog fails', async () => {
+    vi.mocked(clientApi.fetchSingleTimeline).mockResolvedValue(makeTimeline(0, DURATION_S));
+    server.use(
+      http.get('http://localhost:8000/api/engines/:engineId/contexts', ({ params }) =>
+        HttpResponse.json({
+          engine_id: params.engineId,
+          context_resources: {
+            'context-good': ['engine-1'],
+            'context-failed': ['engine-1'],
+          },
+        })
+      ),
+      http.get('http://localhost:8000/api/nvtx/contexts/context-good/catalog', () =>
+        HttpResponse.json({
+          trace_start: 0,
+          trace_end: 10,
+          anomalies: {
+            orphan_range_ends: '0',
+            orphan_range_pops: '0',
+            orphan_resource_destroys: '0',
+            reused_range_ids: '0',
+            reused_resource_handles: '0',
+            total: '0',
+            is_faithful: true,
+          },
+          domains: [
+            {
+              domain_id: '1',
+              name: 'Runtime',
+              color: '#2563eb',
+              threads: [],
+              categories: [],
+              has_uncategorized: true,
+            },
+          ],
+        })
+      ),
+      http.get('http://localhost:8000/api/nvtx/contexts/context-failed/catalog', () =>
+        HttpResponse.json({ message: 'internal' }, { status: 500 })
+      ),
+      http.post('http://localhost:8000/api/nvtx/contexts/context-good/viewport', () =>
+        HttpResponse.json({
+          viewport: { start: 0, end: 100 },
+          domains: [
+            {
+              domain_id: '1',
+              name: 'Runtime',
+              color: '#2563eb',
+              lanes: [
+                {
+                  id: 'nvtx:1:marks',
+                  label: 'Marks',
+                  identity: { kind: 'marks' },
+                  ranges: [],
+                  marks: [],
+                },
+              ],
+            },
+          ],
+          statistics: [],
+        })
+      )
+    );
+
+    renderWithQuery(
+      <JotaiProvider store={createStore()}>
+        <QueryResourceTree engineId="engine-1" queryBundle={makeBundle()} />
+      </JotaiProvider>
+    );
+
+    await waitFor(() => {
+      expect(findCapturedItem('nvtx:context-good:domain:1')).toBeDefined();
+      expect(findCapturedItem('nvtx:context-failed:catalog-error')).toBeDefined();
+    });
+    expect(capturedTreeData[0].id).toBe(ROOT_GROUP_ID);
+  });
+
+  it('shows the filtered-empty state only after an NVTX stream is available', async () => {
+    vi.mocked(clientApi.fetchSingleTimeline).mockResolvedValue(makeTimeline(0, DURATION_S));
+    server.use(
+      http.get('http://localhost:8000/api/engines/:engineId/contexts', ({ params }) =>
+        HttpResponse.json({
+          engine_id: params.engineId,
+          context_resources: { 'context-1': ['engine-1'] },
+        })
+      ),
+      http.get('http://localhost:8000/api/nvtx/contexts/context-1/catalog', () =>
+        HttpResponse.json({
+          trace_start: 0,
+          trace_end: 10,
+          anomalies: {
+            orphan_range_ends: '0',
+            orphan_range_pops: '0',
+            orphan_resource_destroys: '0',
+            reused_range_ids: '0',
+            reused_resource_handles: '0',
+            total: '0',
+            is_faithful: true,
+          },
+          domains: [
+            {
+              domain_id: '1',
+              name: 'Runtime',
+              color: '#2563eb',
+              threads: [],
+              categories: [],
+              has_uncategorized: true,
+            },
+          ],
+        })
+      ),
+      http.post('http://localhost:8000/api/nvtx/contexts/context-1/viewport', () =>
+        HttpResponse.json({
+          viewport: { start: 0, end: 100 },
+          domains: [],
+          statistics: [],
+        })
+      )
+    );
+
+    renderWithQuery(
+      <JotaiProvider store={createStore()}>
+        <QueryResourceTree engineId="engine-1" queryBundle={makeBundle()} />
+      </JotaiProvider>
+    );
+
+    await waitFor(() =>
+      expect(findCapturedItem('nvtx:context-1:root')?.children?.[0].id).toBe('nvtx:context-1:empty')
+    );
   });
 });

--- a/ui/src/components/QueryResourceTree.tsx
+++ b/ui/src/components/QueryResourceTree.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Column, TreeTable } from '@quent/components';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 import { useHighlightedItemIds, useBulkTimelines, useHydrateTimelineAtoms } from '@quent/hooks';
@@ -24,6 +24,12 @@ import {
   buildBulkParamsForItem,
   findItemById,
 } from '@quent/components';
+import { NvtxTreeLabel, NvtxTreeUsage } from '@/components/nvtx/NvtxTreeRows';
+import { useNvtxTimeline } from '@/components/nvtx/useNvtxTimeline';
+import type {
+  NvtxTimelinePlacement,
+  NvtxTimelineTreeItem,
+} from '@/components/nvtx/nvtxTimeline.types';
 import { useExpandedIds } from '@/hooks/useExpandedIds';
 import {
   selectedTypesAtom,
@@ -117,6 +123,26 @@ function injectLongEntitiesRows(item: TreeTableItem): TreeTableItem {
   return { ...item, children };
 }
 
+function collectTreeItemIds(item: TreeTableItem, ids = new Set<string>()): Set<string> {
+  ids.add(item.id);
+  item.children?.forEach(child => collectTreeItemIds(child, ids));
+  return ids;
+}
+
+/** Nest each context-wide NVTX group beneath the resource owned by that process. */
+function injectNvtxTimelineRows(
+  item: NvtxTimelineTreeItem,
+  placements: NvtxTimelinePlacement[]
+): NvtxTimelineTreeItem {
+  const children = item.children?.map(child => injectNvtxTimelineRows(child, placements)) ?? [];
+  const nvtxChildren = placements
+    .filter(placement => placement.parentId === item.id)
+    .map(placement => placement.item);
+  return children.length > 0 || nvtxChildren.length > 0
+    ? { ...item, children: [...children, ...nvtxChildren] }
+    : { ...item };
+}
+
 interface QueryResourceTreeProps {
   engineId: string;
   queryBundle: QueryBundle<EntityRef>;
@@ -147,6 +173,14 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
     () => transformResourceTree(entities, resourceTree),
     [resourceTree, entities]
   );
+  const resourceIds = useMemo(() => collectTreeItemIds(rootItem), [rootItem]);
+
+  const nvtx = useNvtxTimeline({
+    engineId,
+    queryStartUnixNs: BigInt(startTime),
+    resourceIds,
+    rootResourceId: rootItem.id,
+  });
 
   const highlightedItemIds = useHighlightedItemIds(rootItem);
 
@@ -165,6 +199,14 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
 
   const { expandedIds, handleExpandChange } = useExpandedIds(rootItem.id);
   const controlledExpandedIds = expandedIds;
+  const seededNvtxIds = useRef(new Set<string>());
+  useEffect(() => {
+    for (const itemId of nvtx.initiallyExpandedIds) {
+      if (seededNvtxIds.current.has(itemId)) continue;
+      seededNvtxIds.current.add(itemId);
+      handleExpandChange(itemId, true);
+    }
+  }, [handleExpandChange, nvtx.initiallyExpandedIds]);
 
   const { handleZoomChange, handleExpand } = useBulkTimelines({
     engineId,
@@ -182,7 +224,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
   const onExpandChange = useCallback(
     (itemId: string, isExpanded: boolean) => {
       handleExpandChange(itemId, isExpanded);
-      handleExpand(itemId, isExpanded);
+      if (!itemId.startsWith('nvtx:')) handleExpand(itemId, isExpanded);
     },
     [handleExpandChange, handleExpand]
   );
@@ -228,8 +270,15 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
   );
 
   const treeData = useMemo(
-    () => [injectLongEntitiesRows(injectOperatorTimelineRows(rootItem, workerIdsFromPlanTree))],
-    [rootItem, workerIdsFromPlanTree]
+    () => [
+      injectNvtxTimelineRows(
+        injectLongEntitiesRows(
+          injectOperatorTimelineRows(rootItem, workerIdsFromPlanTree)
+        ) as NvtxTimelineTreeItem,
+        nvtx.placements
+      ),
+    ],
+    [rootItem, workerIdsFromPlanTree, nvtx.placements]
   );
 
   /** Operator entries per worker id (for expandable gantt under each worker resource). */
@@ -253,7 +302,8 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
             Resource
           </div>
         ),
-        render: ({ item }: { item: TreeTableItem; level: number }) => {
+        render: ({ item }: { item: NvtxTimelineTreeItem; level: number }) => {
+          if (item.nvtx) return <NvtxTreeLabel item={item} />;
           switch (item.type) {
             case OPERATOR_TIMELINE_ROW_TYPE: {
               return <GanttRowLabel>Operators</GanttRowLabel>;
@@ -303,7 +353,10 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
           </div>
         ),
         subHeaderContent: <TimelineRuler isDark={isDark} />,
-        render: ({ item }: { item: TreeTableItem }) => {
+        render: ({ item }: { item: NvtxTimelineTreeItem }) => {
+          if (item.nvtx) {
+            return <NvtxTreeUsage item={item} durationSeconds={durationSeconds} isDark={isDark} />;
+          }
           switch (item.type) {
             case OPERATOR_TIMELINE_ROW_TYPE: {
               const workerId = workerIdFromOperatorTimelineRowId(item.id);
@@ -348,7 +401,7 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
           }
         },
       },
-    ] satisfies Column<TreeTableItem>[];
+    ] satisfies Column<NvtxTimelineTreeItem>[];
   }, [
     durationSeconds,
     fetchedRootTimeline,
@@ -368,9 +421,9 @@ function QueryResourceTreeContent({ queryBundle, engineId }: QueryResourceTreePr
 
   return (
     <div className="flex min-w-0 flex-col h-full w-full">
-      <TimelineToolbar durationSeconds={durationSeconds} />
+      <TimelineToolbar durationSeconds={durationSeconds}>{nvtx.controls}</TimelineToolbar>
       <div className="min-w-0 flex-1 min-h-0">
-        <TreeTable<TreeTableItem>
+        <TreeTable<NvtxTimelineTreeItem>
           data={treeData}
           columns={columns}
           initialSelectedItemId={rootItem.id}

--- a/ui/src/components/nvtx/NvtxTreeRows.tsx
+++ b/ui/src/components/nvtx/NvtxTreeRows.tsx
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DEFAULT_TIMELINE_HEIGHT, NvtxLaneChart, TimelineSkeleton } from '@quent/components';
+import type { NvtxTimelineTreeItem } from './nvtxTimeline.types';
+
+export function NvtxTreeLabel({ item }: { item: NvtxTimelineTreeItem }) {
+  const metadata = item.nvtx;
+  if (!metadata) return null;
+  switch (metadata.kind) {
+    case 'root':
+      return (
+        <span className="block truncate text-xs font-semibold" title={metadata.label}>
+          {metadata.label}
+        </span>
+      );
+    case 'domain':
+      return (
+        <span className="flex min-w-0 items-center gap-2 text-xs" title={metadata.label}>
+          <span
+            className="h-2.5 w-2.5 rounded-full shrink-0"
+            style={{ backgroundColor: metadata.color }}
+          />
+          <span className="truncate">{metadata.label}</span>
+        </span>
+      );
+    case 'lane':
+      return (
+        <span className="block truncate text-xs" title={metadata.label}>
+          {metadata.label}
+        </span>
+      );
+    case 'status':
+      return (
+        <span className="text-xs font-medium">
+          {metadata.state === 'empty' ? 'No NVTX ranges in this view' : 'NVTX'}
+        </span>
+      );
+  }
+}
+
+export function NvtxTreeUsage({
+  item,
+  durationSeconds,
+  isDark,
+}: {
+  item: NvtxTimelineTreeItem;
+  durationSeconds: number;
+  isDark: boolean;
+}) {
+  const metadata = item.nvtx;
+  if (!metadata) return null;
+  if (metadata.kind === 'lane') {
+    return (
+      <NvtxLaneChart lanes={metadata.lanes} durationSeconds={durationSeconds} isDark={isDark} />
+    );
+  }
+  if (metadata.kind !== 'status') return null;
+  if (metadata.state === 'loading') {
+    return (
+      <div style={{ height: DEFAULT_TIMELINE_HEIGHT }} aria-label="Loading NVTX lanes…">
+        <TimelineSkeleton />
+      </div>
+    );
+  }
+  return (
+    <div
+      className={`flex min-h-11 items-center gap-2 px-3 text-sm ${metadata.state === 'error' ? 'text-destructive' : 'text-muted-foreground'}`}
+    >
+      <span className="whitespace-normal">{metadata.label}</span>
+      {metadata.retry && (
+        <button
+          type="button"
+          className="rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-secondary focus-visible:outline-2 focus-visible:outline-primary"
+          onClick={metadata.retry}
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/nvtx/nvtxTimeline.types.ts
+++ b/ui/src/components/nvtx/nvtxTimeline.types.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+import type { TreeTableItem } from '@quent/components';
+import type { NvtxLane } from '@quent/utils';
+
+export const NVTX_ROOT_ROW_TYPE = 'nvtx-root';
+export const NVTX_DOMAIN_ROW_TYPE = 'nvtx-domain';
+export const NVTX_LANE_ROW_TYPE = 'nvtx-lane';
+export const NVTX_STATUS_ROW_TYPE = 'nvtx-status';
+
+export type NvtxMetadata =
+  | { kind: 'root'; label: string }
+  | { kind: 'domain'; label: string; color: string }
+  | { kind: 'lane'; label: string; lanes: NvtxLane[] }
+  | {
+      kind: 'status';
+      state: 'loading' | 'empty' | 'error';
+      label: string;
+      retry?: () => void;
+    };
+
+export type NvtxTimelineTreeItem = TreeTableItem & {
+  nvtx?: NvtxMetadata;
+  children?: NvtxTimelineTreeItem[];
+};
+
+export interface NvtxTimelinePlacement {
+  parentId: string;
+  item: NvtxTimelineTreeItem;
+}
+
+export interface NvtxTimelineAdapter {
+  placements: NvtxTimelinePlacement[];
+  initiallyExpandedIds: string[];
+  controls: ReactNode;
+}

--- a/ui/src/components/nvtx/nvtxTimeline.utils.ts
+++ b/ui/src/components/nvtx/nvtxTimeline.utils.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { NvtxViewportWindow, ZoomRange } from '@quent/utils';
+
+export function nvtxViewportFromZoom(zoomRange: ZoomRange): NvtxViewportWindow {
+  return {
+    start: zoomRange.start,
+    end: Math.max(zoomRange.start, zoomRange.end),
+  };
+}

--- a/ui/src/components/nvtx/useNvtxTimeline.test.ts
+++ b/ui/src/components/nvtx/useNvtxTimeline.test.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { nvtxViewportFromZoom } from './nvtxTimeline.utils';
+
+describe('nvtxViewportFromZoom', () => {
+  it('passes query-relative timeline seconds to the NVTX viewport contract', () => {
+    expect(nvtxViewportFromZoom({ start: -0.25, end: 1.5 })).toEqual({
+      start: -0.25,
+      end: 1.5,
+    });
+  });
+});

--- a/ui/src/components/nvtx/useNvtxTimeline.tsx
+++ b/ui/src/components/nvtx/useNvtxTimeline.tsx
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { Activity } from 'lucide-react';
+import {
+  engineContextsQueryOptions,
+  nvtxCatalogQueryOptions,
+  nvtxViewportQueryOptions,
+} from '@quent/client';
+import { useDebouncedZoomRange } from '@quent/hooks';
+import {
+  NvtxTimelineControls,
+  type NvtxCatalogControlEntry,
+  type NvtxStatisticsControlEntry,
+} from '@quent/components';
+import type {
+  EntityTypeValue,
+  NvtxCatalog,
+  NvtxLane,
+  NvtxDomainSelection,
+  NvtxViewportResponse,
+} from '@quent/utils';
+import { nvtxViewportFromZoom } from './nvtxTimeline.utils';
+import {
+  NVTX_DOMAIN_ROW_TYPE,
+  NVTX_LANE_ROW_TYPE,
+  NVTX_ROOT_ROW_TYPE,
+  NVTX_STATUS_ROW_TYPE,
+  type NvtxTimelineAdapter,
+  type NvtxTimelinePlacement,
+  type NvtxTimelineTreeItem,
+} from './nvtxTimeline.types';
+
+const EMPTY_ENTITY = {} as EntityTypeValue;
+
+function selectAll(catalog: NvtxCatalog): NvtxDomainSelection[] {
+  return catalog.domains.flatMap(domain => {
+    const categoryIds = domain.categories.map(category => category.category_id);
+    if (categoryIds.length === 0 && !domain.has_uncategorized) return [];
+    return [
+      {
+        domain_id: domain.domain_id,
+        category_ids: categoryIds,
+        include_uncategorized: domain.has_uncategorized,
+      },
+    ];
+  });
+}
+
+function contextLabel(contextId: string): string {
+  return `context ${contextId.slice(0, 8)}`;
+}
+
+function statusItem(
+  id: string,
+  state: 'loading' | 'empty' | 'error',
+  label: string,
+  retry?: () => void
+): NvtxTimelineTreeItem {
+  return {
+    id,
+    type: NVTX_STATUS_ROW_TYPE,
+    entity: EMPTY_ENTITY,
+    nvtx: { kind: 'status', state, label, retry },
+  };
+}
+
+function responseDomainItems(
+  contextId: string,
+  response: NvtxViewportResponse,
+  includeContextLabel: boolean
+): NvtxTimelineTreeItem[] {
+  return response.domains.map(domain => {
+    const groupedLanes = new Map<string, NvtxLane[]>();
+    for (const lane of domain.lanes) {
+      let groupKey: string = lane.identity.kind;
+      if (lane.identity.kind === 'thread') {
+        groupKey = `thread:${lane.identity.thread_id}`;
+      }
+      const group = groupedLanes.get(groupKey);
+      if (group) group.push(lane);
+      else groupedLanes.set(groupKey, [lane]);
+    }
+    const children = Array.from(groupedLanes.values()).map(lanes => {
+      lanes.sort((left, right) => {
+        const leftDepth = left.identity.kind === 'thread' ? left.identity.depth : 0;
+        const rightDepth = right.identity.kind === 'thread' ? right.identity.depth : 0;
+        return leftDepth - rightDepth;
+      });
+      const primaryLane = lanes[0]!;
+      return {
+        id: `nvtx:${contextId}:lane:${primaryLane.id}`,
+        type: NVTX_LANE_ROW_TYPE,
+        entity: EMPTY_ENTITY,
+        nvtx: {
+          kind: 'lane',
+          label: primaryLane.label,
+          lanes,
+        },
+      } satisfies NvtxTimelineTreeItem;
+    });
+    return {
+      id: `nvtx:${contextId}:domain:${domain.domain_id.toString()}`,
+      type: NVTX_DOMAIN_ROW_TYPE,
+      entity: EMPTY_ENTITY,
+      nvtx: {
+        kind: 'domain',
+        label: includeContextLabel ? `${domain.name} · ${contextLabel(contextId)}` : domain.name,
+        color: domain.color,
+      },
+      children,
+    } satisfies NvtxTimelineTreeItem;
+  });
+}
+
+export function useNvtxTimeline({
+  engineId,
+  queryStartUnixNs,
+  resourceIds,
+  rootResourceId,
+}: {
+  engineId: string;
+  queryStartUnixNs: bigint;
+  resourceIds: ReadonlySet<string>;
+  rootResourceId: string;
+}): NvtxTimelineAdapter {
+  const zoomRange = useDebouncedZoomRange();
+  const contextsQuery = useQuery(engineContextsQueryOptions(engineId));
+  const contextResources = useMemo(
+    () => contextsQuery.data?.context_resources ?? {},
+    [contextsQuery.data?.context_resources]
+  );
+  const contextIds = useMemo(
+    () =>
+      Object.keys(contextResources).filter(contextId => {
+        const owners = contextResources[contextId] ?? [];
+        return (
+          owners.length === 0 ||
+          owners.includes(engineId) ||
+          owners.some(resourceId => resourceIds.has(resourceId))
+        );
+      }),
+    [contextResources, engineId, resourceIds]
+  );
+  const catalogQueries = useQueries({
+    queries: contextIds.map(contextId => nvtxCatalogQueryOptions(contextId, queryStartUnixNs)),
+  });
+  const [selections, setSelections] = useState<Record<string, NvtxDomainSelection[]>>({});
+  const [debouncedSelections, setDebouncedSelections] = useState<
+    Record<string, NvtxDomainSelection[]>
+  >({});
+
+  useEffect(() => {
+    setSelections(previous => {
+      const currentContextIds = new Set(contextIds);
+      let changed = Object.keys(previous).some(contextId => !currentContextIds.has(contextId));
+      const next: Record<string, NvtxDomainSelection[]> = {};
+      contextIds.forEach((contextId, index) => {
+        const catalog = catalogQueries[index]?.data;
+        if (previous[contextId] !== undefined) {
+          next[contextId] = previous[contextId];
+        } else if (catalog) {
+          next[contextId] = selectAll(catalog);
+          changed = true;
+        }
+      });
+      return changed ? next : previous;
+    });
+  }, [catalogQueries, contextIds]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedSelections(selections), 150);
+    return () => window.clearTimeout(timer);
+  }, [selections]);
+
+  const viewport = useMemo(() => nvtxViewportFromZoom(zoomRange), [zoomRange]);
+  const viewportQueries = useQueries({
+    queries: contextIds.map((contextId, index) => {
+      const catalog = catalogQueries[index]?.data;
+      const selection = debouncedSelections[contextId];
+      return nvtxViewportQueryOptions(
+        contextId,
+        queryStartUnixNs,
+        { viewport, selections: selection ?? [] },
+        { enabled: catalog != null && selection !== undefined }
+      );
+    }),
+  });
+
+  const setContextSelection = useCallback((contextId: string, next: NvtxDomainSelection[]) => {
+    setSelections(previous => ({ ...previous, [contextId]: next }));
+  }, []);
+
+  return useMemo(() => {
+    if (contextsQuery.isSuccess && contextIds.length === 0) {
+      return { placements: [], initiallyExpandedIds: [], controls: null };
+    }
+    const allCatalogsAbsent =
+      contextIds.length > 0 &&
+      catalogQueries.every(query => query.isSuccess && query.data === null);
+    if (allCatalogsAbsent) {
+      return { placements: [], initiallyExpandedIds: [], controls: null };
+    }
+
+    const placements: NvtxTimelinePlacement[] = [];
+    const initiallyExpandedIds: string[] = [];
+    const catalogControls: NvtxCatalogControlEntry[] = [];
+    const statisticsControls: NvtxStatisticsControlEntry[] = [];
+
+    const placeGroup = (contextId: string, children: NvtxTimelineTreeItem[]) => {
+      const matchingResources = (contextResources[contextId] ?? []).filter(resourceId =>
+        resourceIds.has(resourceId)
+      );
+      const parentId = matchingResources.length === 1 ? matchingResources[0]! : rootResourceId;
+      const group: NvtxTimelineTreeItem = {
+        id: `nvtx:${contextId}:root`,
+        type: NVTX_ROOT_ROW_TYPE,
+        entity: EMPTY_ENTITY,
+        icon: Activity,
+        nvtx: {
+          kind: 'root',
+          label: contextIds.length > 1 ? `NVTX · ${contextLabel(contextId)}` : 'NVTX',
+        },
+        children,
+      };
+      placements.push({ parentId, item: group });
+      initiallyExpandedIds.push(
+        group.id,
+        ...children.filter(item => item.nvtx?.kind === 'domain').map(item => item.id)
+      );
+    };
+
+    if (contextsQuery.isPending) {
+      placeGroup('contexts', [
+        statusItem('nvtx:loading-contexts', 'loading', 'Loading NVTX lanes…'),
+      ]);
+    } else if (contextsQuery.isError) {
+      placeGroup('contexts', [
+        statusItem(
+          'nvtx:error-contexts',
+          'error',
+          "Couldn't load NVTX contexts. Try again.",
+          () => {
+            void contextsQuery.refetch();
+          }
+        ),
+      ]);
+    }
+
+    contextIds.forEach((contextId, index) => {
+      const catalogQuery = catalogQueries[index];
+      const viewportQuery = viewportQueries[index];
+      const children: NvtxTimelineTreeItem[] = [];
+      if (!catalogQuery || catalogQuery.isPending) {
+        children.push(
+          statusItem(`nvtx:${contextId}:catalog-loading`, 'loading', 'Loading NVTX lanes…')
+        );
+        placeGroup(contextId, children);
+        return;
+      }
+      if (catalogQuery.isError) {
+        children.push(
+          statusItem(
+            `nvtx:${contextId}:catalog-error`,
+            'error',
+            `Couldn't load NVTX data for ${contextLabel(contextId)}. Try again.`,
+            () => void catalogQuery.refetch()
+          )
+        );
+        placeGroup(contextId, children);
+        return;
+      }
+      if (catalogQuery.data === null) return;
+      catalogControls.push({
+        contextId,
+        label: contextLabel(contextId),
+        catalog: catalogQuery.data,
+      });
+      if (!viewportQuery || (viewportQuery.isPending && viewportQuery.data === undefined)) {
+        children.push(
+          statusItem(`nvtx:${contextId}:viewport-loading`, 'loading', 'Loading NVTX lanes…')
+        );
+        placeGroup(contextId, children);
+        return;
+      }
+      if (viewportQuery.isError && viewportQuery.data === undefined) {
+        children.push(
+          statusItem(
+            `nvtx:${contextId}:viewport-error`,
+            'error',
+            `Couldn't load NVTX data for ${contextLabel(contextId)}. Try again.`,
+            () => void viewportQuery.refetch()
+          )
+        );
+        placeGroup(contextId, children);
+        return;
+      }
+      if (viewportQuery.data) {
+        const domainItems = responseDomainItems(contextId, viewportQuery.data, false);
+        const renderedItems = domainItems.reduce(
+          (total, domain) => total + (domain.children?.length ?? 0),
+          0
+        );
+        children.push(...domainItems);
+        statisticsControls.push({
+          contextId,
+          label: contextLabel(contextId),
+          statistics: viewportQuery.data.statistics,
+        });
+        if (viewportQuery.isError) {
+          children.push(
+            statusItem(
+              `nvtx:${contextId}:viewport-refetch-error`,
+              'error',
+              `Couldn't refresh NVTX data for ${contextLabel(contextId)}. Showing the previous view.`,
+              () => void viewportQuery.refetch()
+            )
+          );
+        }
+        const hasLoadingOrError = children.some(
+          item =>
+            item.nvtx?.kind === 'status' &&
+            (item.nvtx.state === 'loading' || item.nvtx.state === 'error')
+        );
+        if (renderedItems === 0 && !hasLoadingOrError) {
+          children.push(
+            statusItem(
+              `nvtx:${contextId}:empty`,
+              'empty',
+              'Adjust the time window or filters to see captured NVTX activity.'
+            )
+          );
+        }
+        placeGroup(contextId, children);
+      }
+    });
+
+    const controls =
+      catalogControls.length > 0 ? (
+        <NvtxTimelineControls
+          catalogs={catalogControls}
+          selections={selections}
+          statistics={statisticsControls}
+          onSelectionChange={setContextSelection}
+        />
+      ) : null;
+    return { placements, initiallyExpandedIds, controls };
+  }, [
+    catalogQueries,
+    contextIds,
+    contextResources,
+    contextsQuery,
+    resourceIds,
+    rootResourceId,
+    selections,
+    setContextSelection,
+    viewportQueries,
+  ]);
+}

--- a/ui/src/test/mocks/handlers.ts
+++ b/ui/src/test/mocks/handlers.ts
@@ -13,6 +13,14 @@ export const handlers = [
     return HttpResponse.json(['engine-1', 'engine-2', 'engine-3']);
   }),
 
+  // NVTX is optional; most component tests have no backing contexts.
+  http.get('http://localhost:8000/api/engines/:engineId/contexts', ({ params }) => {
+    return HttpResponse.json({
+      engine_id: params.engineId,
+      context_resources: {},
+    });
+  }),
+
   // Example: List coordinators for an engine
   http.get('/api/engines/:engineId/coordinators', ({ params }) => {
     const { engineId } = params;


### PR DESCRIPTION
## Summary

- render query-relative NVTX ranges and marks as timeline lanes
- add hierarchical domain and category filters plus viewport-scoped statistics
- place context-owned NVTX groups in the query resource tree while preserving the current long-entities UI
- extend timeline toolbar and wheel navigation behavior for the NVTX controls and lane rows

## Stack

- depends on #563 and #571
- this cumulative draft currently includes the server-routes and viewer/client waves
- it will be rebased as the preceding PRs merge

## Verification

- pixi run pnpm --dir ui typecheck
- pixi run pnpm --dir ui lint
- focused NVTX client, lane, controls, viewport, and resource-tree tests: 16 passed
- complete UI unit suite: 650 passed
