### PR TITLE
chore: group Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,60 @@
 version: 2
 
-multi-ecosystem-groups:
-  quent-dependencies:
-    schedule:
-      interval: "weekly"
-
 updates:
-  - cooldown:
+  - commit-message:
+      prefix: "chore(deps)"
+    cooldown:
       default-days: 14
     directory: "/"
-    multi-ecosystem-group: "quent-dependencies"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5
     package-ecosystem: "github-actions"
-    patterns:
-      - "*"
-  - cooldown:
+    schedule:
+      interval: "weekly"
+  - commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    cooldown:
       default-days: 14
     directories:
       - "/ui"
       - "/ui/examples/quent-pivot-table-panel"
       - "/crates/schema/ts"
-    multi-ecosystem-group: "quent-dependencies"
+    groups:
+      npm:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5
     package-ecosystem: "npm"
-    patterns:
-      - "*"
-  - cooldown:
+    schedule:
+      interval: "weekly"
+  - commit-message:
+      prefix: "chore(deps)"
+    cooldown:
       default-days: 14
     directories:
       - "/"
       - "/crates/instrumentation-build/example"
-    multi-ecosystem-group: "quent-dependencies"
+    groups:
+      cargo:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5
     package-ecosystem: "cargo"
-    patterns:
-      - "*"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,37 @@
 version: 2
+
+multi-ecosystem-groups:
+  quent-dependencies:
+    schedule:
+      interval: "weekly"
+
 updates:
   - cooldown:
       default-days: 14
     directory: "/"
+    multi-ecosystem-group: "quent-dependencies"
     open-pull-requests-limit: 5
     package-ecosystem: "github-actions"
-    schedule:
-      interval: "weekly"
+    patterns:
+      - "*"
   - cooldown:
       default-days: 14
     directories:
       - "/ui"
       - "/ui/examples/quent-pivot-table-panel"
       - "/crates/schema/ts"
+    multi-ecosystem-group: "quent-dependencies"
     open-pull-requests-limit: 5
     package-ecosystem: "npm"
-    schedule:
-      interval: "weekly"
+    patterns:
+      - "*"
   - cooldown:
       default-days: 14
-    directories: 
+    directories:
       - "/"
       - "/crates/instrumentation-build/example"
+    multi-ecosystem-group: "quent-dependencies"
     open-pull-requests-limit: 5
     package-ecosystem: "cargo"
-    schedule:
-      interval: "weekly"
+    patterns:
+      - "*"


### PR DESCRIPTION
# Description

Group Dependabot **minor and patch** version updates per ecosystem, so each of GitHub Actions, npm, and Cargo opens a single weekly pull request instead of one per dependency.

Major updates are deliberately left out of the groups and continue to open individually, so a breaking bump is always reviewed on its own and one bad update cannot block the rest of the ecosystem.

## Related Issues

N/A

## Testing

- Parsed `.github/dependabot.yml` and confirmed each of the three ecosystem entries defines a group scoped to `version-updates` with `update-types: [minor, patch]` and an explicit commit message prefix
- Ran `git diff --check`