### PR TITLE
refactor(ui): animate playhead line when playing

### DIFF
--- a/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
+++ b/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
@@ -152,7 +152,7 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
       }
       return !playing;
     });
-  }, [bin, setPlayheadTimeS]);
+  }, [bin, setIsPlaying, setPlayheadTimeS]);
 
   // Stop playback when the overlay is disabled or the bin metadata goes away:
   // the component stays mounted while rendering null, so a live play interval
@@ -161,7 +161,7 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
     if (enabled && bin) return;
     setIsPlaying(false);
     setPlayheadLineTimeMs(null);
-  }, [enabled, bin, setPlayheadLineTimeMs]);
+  }, [enabled, bin, setIsPlaying, setPlayheadLineTimeMs]);
 
   // Advance one bin per tick while playing; stop at the window end.
   useEffect(() => {
@@ -175,7 +175,7 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
       if (next >= endS) setIsPlaying(false);
     }, PLAY_INTERVAL_MS);
     return () => window.clearInterval(id);
-  }, [isPlaying, bin, setPlayheadTimeS, setPlayheadLineTimeMs]);
+  }, [isPlaying, bin, setIsPlaying, setPlayheadTimeS, setPlayheadLineTimeMs]);
 
   useEffect(() => {
     if (!isPlaying) setPlayheadLineTimeMs(null);
@@ -228,7 +228,10 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
       >
         <div className="absolute top-1/2 -translate-y-1/2 h-1 w-full rounded-full bg-muted" />
         <div
-          className="absolute top-1/2 -translate-y-1/2 h-1 rounded-full bg-primary/40"
+          className={cn(
+            'absolute top-1/2 h-1 -translate-y-1/2 rounded-full bg-primary/40',
+            isPlaying && 'transition-[width] duration-100 ease-linear motion-reduce:transition-none'
+          )}
           style={{ width: `${positionPct}%` }}
         />
         <div
@@ -240,7 +243,10 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
           aria-valuenow={timeS}
           aria-valuetext={currentLabel}
           onKeyDown={handleKeyDown}
-          className="absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary bg-background shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={cn(
+            'absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary bg-background shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            isPlaying && 'transition-[left] duration-100 ease-linear motion-reduce:transition-none'
+          )}
           style={{ left: `${positionPct}%` }}
         />
       </div>

--- a/ui/packages/@quent/components/src/timeline/PlayheadLine.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/PlayheadLine.test.tsx
@@ -2,22 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { render } from '@testing-library/react';
+import type { EChartsInstance } from 'echarts-for-react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { usePlayheadLinePixel } from '../lib/usePlayheadLinePixel';
 import { PlayheadLine } from './PlayheadLine';
 
-const mocks = vi.hoisted(() => ({ isPlaying: false }));
+const mocks = vi.hoisted(() => ({
+  isPlaying: false,
+  pixelX: 24 as number | null,
+}));
 
 vi.mock('@quent/hooks', () => ({
   useDataFlowIsPlaying: () => mocks.isPlaying,
 }));
 
 vi.mock('../lib/usePlayheadLinePixel', () => ({
-  usePlayheadLinePixel: () => 24,
+  usePlayheadLinePixel: vi.fn(() => mocks.pixelX),
 }));
 
 describe('PlayheadLine', () => {
   afterEach(() => {
     mocks.isPlaying = false;
+    mocks.pixelX = 24;
+    vi.mocked(usePlayheadLinePixel).mockClear();
+  });
+
+  it('renders nothing when the playhead has no pixel position', () => {
+    mocks.pixelX = null;
+    const { container } = render(<PlayheadLine instance={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('positions the overlay at the computed pixel, including zero', () => {
+    const { container, rerender } = render(<PlayheadLine instance={null} />);
+    expect(container.firstElementChild).toHaveStyle({ left: '24px' });
+
+    mocks.pixelX = 0;
+    rerender(<PlayheadLine instance={null} />);
+    expect(container.firstElementChild).toHaveStyle({ left: '0px' });
   });
 
   it('only transitions position during data-flow playback', () => {
@@ -30,7 +52,21 @@ describe('PlayheadLine', () => {
     expect(container.firstElementChild).toHaveClass(
       'transition-[left]',
       'duration-100',
-      'ease-linear'
+      'ease-linear',
+      'motion-reduce:transition-none'
     );
+
+    mocks.isPlaying = false;
+    rerender(<PlayheadLine instance={null} />);
+    expect(container.firstElementChild).not.toHaveClass('transition-[left]');
+  });
+
+  it('forwards the chart instance and x-axis index', () => {
+    const instance = {} as EChartsInstance;
+    const { rerender } = render(<PlayheadLine instance={instance} />);
+    expect(usePlayheadLinePixel).toHaveBeenCalledWith(instance, 0);
+
+    rerender(<PlayheadLine instance={instance} xAxisIndex={1} />);
+    expect(usePlayheadLinePixel).toHaveBeenCalledWith(instance, 1);
   });
 });

--- a/ui/packages/@quent/components/src/timeline/PlayheadLine.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/PlayheadLine.test.tsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlayheadLine } from './PlayheadLine';
+
+const mocks = vi.hoisted(() => ({ isPlaying: false }));
+
+vi.mock('@quent/hooks', () => ({
+  useDataFlowIsPlaying: () => mocks.isPlaying,
+}));
+
+vi.mock('../lib/usePlayheadLinePixel', () => ({
+  usePlayheadLinePixel: () => 24,
+}));
+
+describe('PlayheadLine', () => {
+  afterEach(() => {
+    mocks.isPlaying = false;
+  });
+
+  it('only transitions position during data-flow playback', () => {
+    const { container, rerender } = render(<PlayheadLine instance={null} />);
+    expect(container.firstElementChild).not.toHaveClass('transition-[left]');
+
+    mocks.isPlaying = true;
+    rerender(<PlayheadLine instance={null} />);
+
+    expect(container.firstElementChild).toHaveClass(
+      'transition-[left]',
+      'duration-100',
+      'ease-linear'
+    );
+  });
+});

--- a/ui/packages/@quent/components/src/timeline/PlayheadLine.tsx
+++ b/ui/packages/@quent/components/src/timeline/PlayheadLine.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { EChartsInstance } from 'echarts-for-react';
+import { useDataFlowIsPlaying } from '@quent/hooks';
+import { cn } from '@quent/utils';
 import { usePlayheadLinePixel } from '../lib/usePlayheadLinePixel';
 
 type PlayheadLineProps = {
@@ -12,12 +14,16 @@ type PlayheadLineProps = {
 /** Playhead overlay aligned to an ECharts x-axis. */
 export function PlayheadLine({ instance, xAxisIndex = 0 }: PlayheadLineProps) {
   const pixelX = usePlayheadLinePixel(instance, xAxisIndex);
+  const isPlaying = useDataFlowIsPlaying();
 
   if (pixelX == null) return null;
 
   return (
     <div
-      className="absolute top-0 bottom-0 w-px pointer-events-none z-[10] bg-primary/70"
+      className={cn(
+        'pointer-events-none absolute bottom-0 top-0 z-[10] w-px bg-primary/70',
+        isPlaying && 'transition-[left] duration-100 ease-linear motion-reduce:transition-none'
+      )}
       style={{ left: pixelX }}
     />
   );


### PR DESCRIPTION
# Description
Animates the playhead on the resource timeline view when data-flow is playing. Already looked smooth when dragging and don't want the delay in movement so only animate when playing.

## Related Issues
N/A

## Testing
* Click "play" on data-flow 
* Verify that data-flow playhead is moving v smoothly through the timelines
* Click and drag the data-flow slider handle
* Verify that there's no delay when dragging, or clicking to jump to a different spot on the slider

## Screenshots

https://github.com/user-attachments/assets/0a90e080-03fc-4846-b717-8ecbbb8cb1a8

