### PR TITLE
feat(ui): keep playhead line until playhead finishes

### DIFF
--- a/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
+++ b/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
@@ -110,15 +110,11 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
     [applyClientX]
   );
 
-  const handlePointerEnd = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-        event.currentTarget.releasePointerCapture(event.pointerId);
-      }
-      setPlayheadLineTimeMs(null);
-    },
-    [setPlayheadLineTimeMs]
-  );
+  const handlePointerEnd = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }, []);
 
   const stepBy = useCallback(
     (bins: number) => {
@@ -170,11 +166,14 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
         const current = playheadRef.current ?? bin.startS;
         if (current >= bin.endS) {
           setPlayheadTimeS(bin.startS);
+          setPlayheadLineTimeMs(bin.startS * 1000);
+        } else {
+          setPlayheadLineTimeMs(current * 1000);
         }
       }
       return !playing;
     });
-  }, [bin, setIsPlaying, setPlayheadTimeS]);
+  }, [bin, setIsPlaying, setPlayheadTimeS, setPlayheadLineTimeMs]);
 
   // Stop playback when the overlay is disabled or the bin metadata goes away:
   // the component stays mounted while rendering null, so a live play interval
@@ -187,7 +186,9 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
     setPlayheadLineTimeMs(null);
   }, [enabled, bin, setIsPlaying, setPlayheadLineTimeMs]);
 
-  // Advance one bin per tick while playing; stop at the window end.
+  // Advance one bin per tick while playing; stop at the window end. The line
+  // is only cleared here (playback finished), not on manual pause, so the
+  // last position stays visible until the user resumes, scrubs, or restarts.
   useEffect(() => {
     if (!isPlaying || !bin) {
       return;
@@ -197,19 +198,15 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
       const current = playheadRef.current ?? startS;
       const next = Math.min(current + binDurationS, endS);
       setPlayheadTimeS(next);
-      setPlayheadLineTimeMs(next * 1000);
       if (next >= endS) {
+        setPlayheadLineTimeMs(null);
         setIsPlaying(false);
+      } else {
+        setPlayheadLineTimeMs(next * 1000);
       }
     }, PLAY_INTERVAL_MS);
     return () => window.clearInterval(id);
   }, [isPlaying, bin, setIsPlaying, setPlayheadTimeS, setPlayheadLineTimeMs]);
-
-  useEffect(() => {
-    if (!isPlaying) {
-      setPlayheadLineTimeMs(null);
-    }
-  }, [isPlaying, setPlayheadLineTimeMs]);
 
   useEffect(() => {
     return () => {

--- a/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
+++ b/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
@@ -242,6 +242,7 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
       data-testid="dag-playhead"
     >
       <button
+        type="button"
         onClick={togglePlay}
         aria-label={isPlaying ? 'Pause data flow' : 'Play data flow'}
         title={isPlaying ? 'Pause' : 'Play'}
@@ -254,6 +255,7 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
         )}
       </button>
       <button
+        type="button"
         onClick={stopLine}
         disabled={!isPlaying && playheadLineTimeMs == null}
         aria-label="Stop and clear playhead line"

--- a/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
+++ b/ui/packages/@quent/components/src/dag/DagPlayhead.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useEffect, useRef } from 'react';
-import { Pause, Play } from 'lucide-react';
+import { Pause, Play, Square } from 'lucide-react';
 import { cn, formatDurationForWindow } from '@quent/utils';
 import {
   useDataFlowEnabled,
@@ -11,6 +11,7 @@ import {
   useSetDataFlowIsPlaying,
   usePlayheadTimeS,
   useSetPlayheadTimeS,
+  usePlayheadLineTimeMs,
   useSetPlayheadLineTimeMs,
 } from '@quent/hooks';
 
@@ -44,6 +45,7 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
   const setPlayheadTimeS = useSetPlayheadTimeS();
   const isPlaying = useDataFlowIsPlaying();
   const setIsPlaying = useSetDataFlowIsPlaying();
+  const playheadLineTimeMs = usePlayheadLineTimeMs();
   const setPlayheadLineTimeMs = useSetPlayheadLineTimeMs();
 
   const trackRef = useRef<HTMLDivElement>(null);
@@ -175,6 +177,11 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
     });
   }, [bin, setIsPlaying, setPlayheadTimeS, setPlayheadLineTimeMs]);
 
+  const stopLine = useCallback(() => {
+    setIsPlaying(false);
+    setPlayheadLineTimeMs(null);
+  }, [setIsPlaying, setPlayheadLineTimeMs]);
+
   // Stop playback when the overlay is disabled or the bin metadata goes away:
   // the component stays mounted while rendering null, so a live play interval
   // would otherwise keep advancing the playhead invisibly.
@@ -245,6 +252,15 @@ export function DagPlayhead({ className }: DagPlayheadProps) {
         ) : (
           <Play className="h-3 w-3 text-muted-foreground" />
         )}
+      </button>
+      <button
+        onClick={stopLine}
+        disabled={!isPlaying && playheadLineTimeMs == null}
+        aria-label="Stop and clear playhead line"
+        title="Stop"
+        className="rounded p-1 hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-30 disabled:pointer-events-none"
+      >
+        <Square className="h-3 w-3 text-muted-foreground" />
       </button>
       <span className="text-[10px] text-muted-foreground tabular-nums flex-shrink-0">
         {formatTimeLabel(bin.startS, windowS)}


### PR DESCRIPTION
# Description

Previously the playhead line would disappear when the user paused, but this could create difficulties for people wanting to pinpoint and do some analysis on that moment of time on the timelines. This retains the line so that when paused users can see where they paused. In case users want to clear the line, a stop button was added - this will stop the timer where it is and clear the line from the chart.

## Related Issues

Closes: #625 

## Testing

1. Start playhead, make sure line appears and scrolls as normal
2. Before it finishes, pause, and make sure the line still stays on the timelines
3. Let it finish, ensure line disappears once done
4. Start playhead again, hit the stop button part-way through - make sure the timer stops and line disappears
5. Drag slider to a specific point in time, make sure line appears
6. Hit stop, make sure line disappears

## Screenshots

https://github.com/user-attachments/assets/4eb2add8-477c-4c20-9f6f-a84468ef0439
