### PR TITLE
refactor: better smoke test

### DIFF
--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -1,14 +1,66 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
-test('loads the query profiler page', async ({ page }) => {
-  await page.goto('/');
+const ENGINE_ID = '00000000-0000-0000-0000-000000000001';
+const QUERY_ID = '00000000-0000-0000-0000-000000000004';
+const QUERY_PATH = `/profile/engine/${ENGINE_ID}/query/${QUERY_ID}`;
+
+interface CapturedErrors {
+  ui: string[];
+  backend: string[];
+}
+
+function isBackendRequest(url: string): boolean {
+  const pathname = new URL(url).pathname;
+  return pathname === '/api' || pathname.startsWith('/api/');
+}
+
+function captureErrors(page: Page): CapturedErrors {
+  const errors: CapturedErrors = { ui: [], backend: [] };
+
+  page.on('pageerror', error => errors.ui.push(`Uncaught exception: ${error.message}`));
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      errors.ui.push(`Console error: ${message.text()}`);
+    }
+  });
+  page.on('response', response => {
+    if (isBackendRequest(response.url()) && !response.ok()) {
+      errors.backend.push(
+        `${response.request().method()} ${response.url()} returned ${response.status()}`
+      );
+    }
+  });
+  page.on('requestfailed', request => {
+    if (isBackendRequest(request.url())) {
+      errors.backend.push(
+        `${request.method()} ${request.url()} failed: ${request.failure()?.errorText ?? 'unknown error'}`
+      );
+    }
+  });
+
+  return errors;
+}
+
+async function expectNoErrors(page: Page, errors: CapturedErrors) {
+  await expect(page.getByRole('heading', { name: 'Something went wrong' })).toHaveCount(0);
+  expect(errors.ui, 'Expected no UI errors').toEqual([]);
+  expect(errors.backend, 'Expected no backend HTTP errors').toEqual([]);
+}
+
+test('smoke tests the query profiler routes', async ({ page }) => {
+  const errors = captureErrors(page);
+  const response = await page.goto('/');
+
+  expect(response?.ok()).toBe(true);
 
   await expect(page).toHaveTitle('Quent UI');
   await expect(page.getByRole('heading', { name: 'Query Profiler' })).toBeVisible();
   await expect(page.getByText('Select an engine, coordinator, and query')).toBeVisible();
+  await page.waitForLoadState('networkidle');
+  await expectNoErrors(page, errors);
 
   await page.getByRole('combobox').first().click();
   await expect(page.getByRole('option', { name: 'test-engine' })).toBeVisible();
@@ -20,4 +72,41 @@ test('loads the query profiler page', async ({ page }) => {
 
   await page.getByRole('combobox').nth(2).click();
   await expect(page.getByRole('option', { name: 'test-query' })).toBeVisible();
+  await page.getByRole('option', { name: 'test-query' }).click();
+
+  await expect(page).toHaveURL(new RegExp(`${QUERY_PATH}/timeline$`));
+  await expect(page.getByText('Resource', { exact: true }).first()).toBeVisible();
+  await page.waitForLoadState('networkidle');
+  await expectNoErrors(page, errors);
+
+  const routes = [
+    {
+      name: 'timeline',
+      path: `${QUERY_PATH}/timeline`,
+      ready: () => page.getByText('Resource', { exact: true }).first(),
+    },
+    {
+      name: 'operators',
+      path: `${QUERY_PATH}/operators`,
+      ready: () =>
+        page.getByText(/Select a plan on the left to view operators|Worker \/ Plan/).first(),
+    },
+    {
+      name: 'entities',
+      path: `${QUERY_PATH}/entities`,
+      ready: () => page.getByRole('columnheader', { name: 'Instance' }),
+    },
+  ];
+
+  for (const route of routes) {
+    await test.step(`loads the ${route.name} route directly`, async () => {
+      const routeResponse = await page.goto(route.path);
+
+      expect(routeResponse?.ok()).toBe(true);
+      await expect(page).toHaveURL(new RegExp(`${route.path}$`));
+      await expect(route.ready()).toBeVisible();
+      await page.waitForLoadState('networkidle');
+      await expectNoErrors(page, errors);
+    });
+  }
 });

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -34,7 +34,7 @@ test('smoke tests the query profiler routes', async ({ page }) => {
   await page.getByRole('option', { name: 'test-query' }).click();
 
   await expect(page).toHaveURL(new RegExp(`${QUERY_PATH}/timeline$`));
-  await expect(page.getByText('Resource', { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole('tree').getByText('test-engine', { exact: true })).toBeVisible();
   await page.waitForLoadState('networkidle');
   await expectNoErrors(page, errors, allowedMissingNvtxCatalogErrors);
 
@@ -42,7 +42,7 @@ test('smoke tests the query profiler routes', async ({ page }) => {
     {
       name: 'timeline',
       path: `${QUERY_PATH}/timeline`,
-      ready: () => page.getByText('Resource', { exact: true }).first(),
+      ready: () => page.getByRole('tree').getByText('test-engine', { exact: true }),
     },
     {
       name: 'operators',

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -1,57 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import { allowedMissingNvtxCatalogErrors } from './utils/allowed-errors';
+import { captureErrors, expectNoErrors } from './utils/error-capture';
 
 const ENGINE_ID = '00000000-0000-0000-0000-000000000001';
 const QUERY_ID = '00000000-0000-0000-0000-000000000004';
 const QUERY_PATH = `/profile/engine/${ENGINE_ID}/query/${QUERY_ID}`;
 
-interface CapturedErrors {
-  ui: string[];
-  backend: string[];
-}
-
-function isBackendRequest(url: string): boolean {
-  const pathname = new URL(url).pathname;
-  return pathname === '/api' || pathname.startsWith('/api/');
-}
-
-function captureErrors(page: Page): CapturedErrors {
-  const errors: CapturedErrors = { ui: [], backend: [] };
-
-  page.on('pageerror', error => errors.ui.push(`Uncaught exception: ${error.message}`));
-  page.on('console', message => {
-    if (message.type() === 'error') {
-      errors.ui.push(`Console error: ${message.text()}`);
-    }
-  });
-  page.on('response', response => {
-    if (isBackendRequest(response.url()) && !response.ok()) {
-      errors.backend.push(
-        `${response.request().method()} ${response.url()} returned ${response.status()}`
-      );
-    }
-  });
-  page.on('requestfailed', request => {
-    if (isBackendRequest(request.url())) {
-      errors.backend.push(
-        `${request.method()} ${request.url()} failed: ${request.failure()?.errorText ?? 'unknown error'}`
-      );
-    }
-  });
-
-  return errors;
-}
-
-async function expectNoErrors(page: Page, errors: CapturedErrors) {
-  await expect(page.getByRole('heading', { name: 'Something went wrong' })).toHaveCount(0);
-  expect(errors.ui, 'Expected no UI errors').toEqual([]);
-  expect(errors.backend, 'Expected no backend HTTP errors').toEqual([]);
-}
-
 test('smoke tests the query profiler routes', async ({ page }) => {
-  const errors = captureErrors(page);
+  const errors = await captureErrors(page);
   const response = await page.goto('/');
 
   expect(response?.ok()).toBe(true);
@@ -60,7 +19,7 @@ test('smoke tests the query profiler routes', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Query Profiler' })).toBeVisible();
   await expect(page.getByText('Select an engine, coordinator, and query')).toBeVisible();
   await page.waitForLoadState('networkidle');
-  await expectNoErrors(page, errors);
+  await expectNoErrors(page, errors, allowedMissingNvtxCatalogErrors);
 
   await page.getByRole('combobox').first().click();
   await expect(page.getByRole('option', { name: 'test-engine' })).toBeVisible();
@@ -77,7 +36,7 @@ test('smoke tests the query profiler routes', async ({ page }) => {
   await expect(page).toHaveURL(new RegExp(`${QUERY_PATH}/timeline$`));
   await expect(page.getByText('Resource', { exact: true }).first()).toBeVisible();
   await page.waitForLoadState('networkidle');
-  await expectNoErrors(page, errors);
+  await expectNoErrors(page, errors, allowedMissingNvtxCatalogErrors);
 
   const routes = [
     {
@@ -106,7 +65,7 @@ test('smoke tests the query profiler routes', async ({ page }) => {
       await expect(page).toHaveURL(new RegExp(`${route.path}$`));
       await expect(route.ready()).toBeVisible();
       await page.waitForLoadState('networkidle');
-      await expectNoErrors(page, errors);
+      await expectNoErrors(page, errors, allowedMissingNvtxCatalogErrors);
     });
   }
 });

--- a/ui/e2e/utils/allowed-errors.ts
+++ b/ui/e2e/utils/allowed-errors.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AllowedErrors, BackendError, UiError } from './error-capture';
+
+function isMissingNvtxCatalog(error: BackendError): boolean {
+  const pathname = new URL(error.url).pathname;
+  return (
+    error.method === 'GET' &&
+    error.status === 404 &&
+    /^\/api\/nvtx\/contexts\/[^/]+\/catalog$/.test(pathname)
+  );
+}
+
+function isMissingNvtxCatalogUiError(error: UiError): boolean {
+  if (!/404|not found/i.test(error.message)) {
+    return false;
+  }
+  return [error.url, error.message].some(value => {
+    if (!value) {
+      return false;
+    }
+    return /\/api\/nvtx\/contexts\/[^/\s?]+\/catalog(?:[?\s]|$)/.test(value);
+  });
+}
+
+export const allowedMissingNvtxCatalogErrors: AllowedErrors = {
+  ui: isMissingNvtxCatalogUiError,
+  backend: isMissingNvtxCatalog,
+};

--- a/ui/e2e/utils/error-capture.ts
+++ b/ui/e2e/utils/error-capture.ts
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Page } from '@playwright/test';
+
+export interface BackendError {
+  method: string;
+  url: string;
+  status?: number;
+  failure?: string;
+}
+
+export interface UiError {
+  source: 'page' | 'console' | 'dom';
+  message: string;
+  url?: string;
+}
+
+export interface CapturedErrors {
+  ui: UiError[];
+  backend: BackendError[];
+}
+
+export interface AllowedErrors {
+  ui?: (error: UiError) => boolean;
+  backend?: (error: BackendError) => boolean;
+}
+
+function isBackendRequest(url: string): boolean {
+  const pathname = new URL(url).pathname;
+  return pathname === '/api' || pathname.startsWith('/api/');
+}
+
+function formatBackendError(error: BackendError): string {
+  if (error.status !== undefined) {
+    return `${error.method} ${error.url} returned ${error.status}`;
+  }
+  return `${error.method} ${error.url} failed: ${error.failure ?? 'unknown error'}`;
+}
+
+export async function captureErrors(page: Page): Promise<CapturedErrors> {
+  const errors: CapturedErrors = { ui: [], backend: [] };
+
+  await page.exposeFunction('__quentCaptureDomError', (error: Omit<UiError, 'source'>) => {
+    errors.ui.push({ source: 'dom', ...error });
+  });
+  await page.addInitScript(() => {
+    const reported = new WeakMap<Element, string>();
+    const captureDomErrors = () => {
+      for (const heading of document.querySelectorAll('h2')) {
+        if (heading.textContent?.trim() !== 'Something went wrong') {
+          continue;
+        }
+        const message =
+          heading.nextElementSibling?.textContent?.trim() || heading.textContent.trim();
+        const fingerprint = `${window.location.href}\n${message}`;
+        if (reported.get(heading) === fingerprint) {
+          continue;
+        }
+        reported.set(heading, fingerprint);
+        void (
+          window as typeof window & {
+            __quentCaptureDomError: (error: { message: string; url: string }) => Promise<void>;
+          }
+        ).__quentCaptureDomError({ message, url: window.location.href });
+      }
+    };
+
+    new MutationObserver(captureDomErrors).observe(document, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    window.addEventListener('DOMContentLoaded', captureDomErrors, { once: true });
+  });
+
+  page.on('pageerror', error =>
+    errors.ui.push({ source: 'page', message: error.message, url: page.url() })
+  );
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      errors.ui.push({
+        source: 'console',
+        message: message.text(),
+        url: message.location().url || undefined,
+      });
+    }
+  });
+  page.on('response', response => {
+    if (isBackendRequest(response.url()) && !response.ok()) {
+      errors.backend.push({
+        method: response.request().method(),
+        url: response.url(),
+        status: response.status(),
+      });
+    }
+  });
+  page.on('requestfailed', request => {
+    if (isBackendRequest(request.url())) {
+      errors.backend.push({
+        method: request.method(),
+        url: request.url(),
+        failure: request.failure()?.errorText,
+      });
+    }
+  });
+
+  return errors;
+}
+
+export async function expectNoErrors(
+  page: Page,
+  errors: CapturedErrors,
+  allowed: AllowedErrors = {}
+) {
+  const visibleDomErrors = await page
+    .getByRole('heading', { name: 'Something went wrong' })
+    .evaluateAll(headings =>
+      headings.map(heading => ({
+        source: 'dom' as const,
+        message:
+          heading.nextElementSibling?.textContent?.trim() || heading.textContent?.trim() || '',
+        url: window.location.href,
+      }))
+    );
+  for (const error of visibleDomErrors) {
+    if (
+      !errors.ui.some(
+        captured =>
+          captured.source === error.source &&
+          captured.message === error.message &&
+          captured.url === error.url
+      )
+    ) {
+      errors.ui.push(error);
+    }
+  }
+
+  expect(
+    errors.ui.filter(error => !allowed.ui?.(error)),
+    'Expected no unexpected UI errors'
+  ).toEqual([]);
+  expect(
+    errors.backend.filter(error => !allowed.backend?.(error)).map(formatBackendError),
+    'Expected no unexpected backend HTTP errors'
+  ).toEqual([]);
+}


### PR DESCRIPTION
# Description
Adds a little more oomph to the existing smoke test. This navigates to each of our top level routes and makes sure there are no errors.

## Related Issues
N/A

## Testing
e2e tests pass CI

Initiative motivated by failure when upgrading the `vite` package. To go the extra mile, upgrade vite to `"vite": "^8.0.0"` and try re-running the smoke tests, expecting failure.

## Screenshots
N/A