### PR TITLE
feat(ui): entities deep link integration

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -105,6 +105,13 @@ stores generated event data in `ui/.e2e-data/`.
 In CI only, Playwright writes an HTML report and screenshots failures; the
 GitHub UI workflow uploads those files when the E2E job fails.
 
+### Deep Links
+
+The query timeline, operators, and entities tabs support versioned shareable
+view snapshots through the **Copy Link** action. See
+[Deep links](./docs/deep-links.md) for the stored state, compatibility policy,
+and command-line creation and decoding examples.
+
 ## API Integration
 
 The application includes stub API functions in `src/services/api.ts`. These
@@ -169,6 +176,7 @@ pnpm dlx shadcn@latest add dropdown-menu
 - `pnpm lint` - Run ESLint
 - `pnpm lint:fix` - Fix ESLint errors and format code
 - `pnpm format` - Format code with Prettier
+- `pnpm deep-link` - Create or decode versioned shareable links
 - `pnpm test:e2e` - Run Playwright end-to-end tests
 
 ## Development Tools

--- a/ui/docs/deep-links.md
+++ b/ui/docs/deep-links.md
@@ -16,13 +16,7 @@ shared view. Expanded row IDs may include stable synthetic IDs such as
   "route": {
     "engineId": "engine-a",
     "queryId": "query-a",
-    "tab": "operators"
-  },
-  "timeline": {
-    "zoomRange": {
-      "start": 12.5,
-      "end": 48.75
-    }
+    "tab": "entities"
   },
   "selection": {
     "planId": "plan-a",
@@ -50,6 +44,18 @@ shared view. Expanded row IDs may include stable synthetic IDs such as
     "visibleStats": ["duration_s", "spill_bytes"],
     "aggregation": "sum",
     "sort": [{ "id": "spill_bytes", "desc": true }]
+  },
+  "entities": {
+    "operatorId": "operator-a",
+    "entityType": "task",
+    "resourceId": "resource-a",
+    "minUsageS": 0.25,
+    "window": {
+      "start": 12.5,
+      "end": 48.75
+    },
+    "sortDir": "Asc",
+    "pageSize": 100
   }
 }
 ```
@@ -59,15 +65,16 @@ query, and active tab remain readable in the route and are repeated in the
 payload so mismatched or transplanted state can be rejected:
 
 ```text
-/profile/engine/ENGINE/query/QUERY/timeline?s=v2.COMPRESSED_STATE
+/profile/engine/ENGINE/query/QUERY/entities?s=v3.COMPRESSED_STATE
 ```
 
 Incoming state is treated as untrusted data and validated with the same Zod
 schema used by the UI and command-line tool. Limits are established on string
 and array lengths (see `deepLink.schema.ts`), and the complete absolute URL is
 limited to 2,048 characters. Existing `v1` viewport/resource links remain
-decodable. The v1 `expandedResourceIds` name is retained for compatibility and
-may also contain synthetic row IDs.
+decodable, as do `v2` timeline/operator snapshots. The v1
+`expandedResourceIds` name is retained for compatibility and may also contain
+synthetic row IDs.
 
 Default DAG, resource, data-flow, and table controls are omitted. Hover,
 playback, open popovers, and other transient state are not shared.
@@ -75,6 +82,12 @@ playback, open popovers, and other transient state are not shared.
 Resource filters store the name/label search and the selected resource and FSM
 types. Active fields are combined with AND. `showOthers` restores the complete
 tree and highlights matching rows; otherwise only matching rows are shown.
+
+Entity snapshots preserve the controls that define and order the result set:
+the selected operators, entity and resource filters, minimum usage, time window,
+sort direction, and non-default page size. The current results page and open
+entity detail are omitted because they can become stale as query results change.
+Entity links do not require or store a timeline viewport.
 
 ## Agent commands
 
@@ -95,7 +108,7 @@ pixi run pnpm --dir ui deep-link create \
 
 Add `--base http://localhost:5173` to emit an absolute URL. A JSON state file
 may be supplied instead. The command injects the route from `--engine`,
-`--query`, and `--tab`, so the state file may contain the remaining v2 fields:
+`--query`, and `--tab`, so the state file may contain the remaining v3 fields:
 
 ```sh
 pixi run pnpm --dir ui deep-link create \
@@ -104,6 +117,9 @@ pixi run pnpm --dir ui deep-link create \
   --tab timeline \
   --state state.json
 ```
+
+Use `--tab entities` with a state file containing an `entities` object to
+create an entity snapshot.
 
 Decode a generated link:
 

--- a/ui/docs/deep-links.md
+++ b/ui/docs/deep-links.md
@@ -46,7 +46,6 @@ shared view. Expanded row IDs may include stable synthetic IDs such as
     "sort": [{ "id": "spill_bytes", "desc": true }]
   },
   "entities": {
-    "operatorId": "operator-a",
     "entityType": "task",
     "resourceId": "resource-a",
     "minUsageS": 0.25,
@@ -55,7 +54,9 @@ shared view. Expanded row IDs may include stable synthetic IDs such as
       "end": 48.75
     },
     "sortDir": "Asc",
-    "pageSize": 100
+    "pageSize": 100,
+    "page": 2,
+    "selectedEntityId": "entity-a"
   }
 }
 ```
@@ -85,8 +86,8 @@ tree and highlights matching rows; otherwise only matching rows are shown.
 
 Entity snapshots preserve the controls that define and order the result set:
 the selected operators, entity and resource filters, minimum usage, time window,
-sort direction, and non-default page size. The current results page and open
-entity detail are omitted because they can become stale as query results change.
+sort direction, non-default page size, current results page, and selected entity
+ID. Selection is restored after the matching page loads.
 Entity links do not require or store a timeline viewport.
 
 ## Agent commands

--- a/ui/scripts/deep-link.ts
+++ b/ui/scripts/deep-link.ts
@@ -9,15 +9,15 @@ import {
   DEEP_LINK_SEARCH_KEY,
 } from '../src/features/deep-link/deepLink.codec';
 import {
-  DeepLinkStateV2Schema,
-  type DeepLinkStateV2,
+  DeepLinkStateV3Schema,
+  type DeepLinkStateV3,
   type DeepLinkTab,
 } from '../src/features/deep-link/deepLink.schema';
 import { mergeResourceFilter } from '../src/features/deep-link/deepLink.cli';
 
 const usage = `Usage:
   pnpm deep-link create --engine ID --query ID --tab timeline --start S --end S [--resource-search TEXT] [--resource-types TYPES] [--fsm-types TYPES] [--show-others] [--base URL]
-  pnpm deep-link create --engine ID --query ID --tab timeline --state FILE [--resource-search TEXT] [--resource-types TYPES] [--fsm-types TYPES] [--show-others] [--base URL]
+  pnpm deep-link create --engine ID --query ID --tab TAB --state FILE [--resource-search TEXT] [--resource-types TYPES] [--fsm-types TYPES] [--show-others] [--base URL]
   pnpm deep-link decode URL`;
 
 function fail(message: string): never {
@@ -39,7 +39,7 @@ function parseList(value: string | boolean | undefined): string[] | undefined {
 
 async function readState(
   values: Record<string, string | boolean | undefined>,
-  route: DeepLinkStateV2['route']
+  route: DeepLinkStateV3['route']
 ) {
   let input: unknown;
   if (typeof values.state === 'string') {
@@ -73,7 +73,7 @@ async function readState(
     ...(values['show-others'] === true ? { showOthers: true } : {}),
   };
   const candidateWithFilter = mergeResourceFilter(candidate, resourceFilter);
-  const parsed = DeepLinkStateV2Schema.safeParse(candidateWithFilter);
+  const parsed = DeepLinkStateV3Schema.safeParse(candidateWithFilter);
   if (!parsed.success) {
     fail(`Invalid state: ${parsed.error.message}`);
   }
@@ -81,8 +81,8 @@ async function readState(
 }
 
 function parseTab(tab: string): DeepLinkTab {
-  if (tab !== 'timeline' && tab !== 'operators') {
-    fail('The --tab option must be "timeline" or "operators".');
+  if (tab !== 'timeline' && tab !== 'operators' && tab !== 'entities') {
+    fail('The --tab option must be "timeline", "operators", or "entities".');
   }
   return tab;
 }

--- a/ui/src/atoms/entitiesTable.ts
+++ b/ui/src/atoms/entitiesTable.ts
@@ -18,10 +18,12 @@ export interface EntitiesTableState {
   filters: EntityFilters | null;
   page: number;
   selected: FiniteStateMachine | null;
+  selectedEntityId: string | null;
 }
 
 export const entitiesTableStateAtom = atom<EntitiesTableState>({
   filters: null,
   page: 0,
   selected: null,
+  selectedEntityId: null,
 });

--- a/ui/src/atoms/entitiesTable.ts
+++ b/ui/src/atoms/entitiesTable.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { atom } from 'jotai';
+import type { FiniteStateMachine, SortDir } from '@quent/utils';
+
+export interface EntityFilters {
+  entityType: string | null;
+  resourceId: string | null;
+  minUsageS: string;
+  windowStart: string;
+  windowEnd: string;
+  sortDir: SortDir;
+  pageSize: number | null;
+}
+
+export interface EntitiesTableState {
+  filters: EntityFilters | null;
+  page: number;
+  selected: FiniteStateMachine | null;
+}
+
+export const entitiesTableStateAtom = atom<EntitiesTableState>({
+  filters: null,
+  page: 0,
+  selected: null,
+});

--- a/ui/src/components/entities-table/EntitiesTable.test.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.test.tsx
@@ -4,6 +4,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createStore, Provider } from 'jotai';
+import { StrictMode } from 'react';
 import {
   useOperatorSelection,
   useOperatorSelectionActions,
@@ -494,7 +495,7 @@ describe('EntitiesTable', () => {
       filters: {
         entityType: 'Task',
         resourceId: 'resource-1',
-        minUsageS: '0.5',
+        minUsageS: '0.2',
         windowStart: '1',
         windowEnd: '8',
         sortDir: 'Asc',
@@ -502,10 +503,14 @@ describe('EntitiesTable', () => {
       },
       page: 0,
       selected: null,
+      selectedEntityId: 'entity-1',
     });
-    renderTable(<EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />, {
-      store,
-    });
+    renderTable(
+      <StrictMode>
+        <EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />
+      </StrictMode>,
+      { store }
+    );
 
     const params = useEntities.mock.lastCall?.[0];
     expect(params.request.entry).toMatchObject({
@@ -513,12 +518,13 @@ describe('EntitiesTable', () => {
       filter: {
         scope: { Resource: { resource_id: 'resource-1' } },
         entity_type_name: 'Task',
-        min_usage_s: 0.5,
+        min_usage_s: 0.2,
       },
       sort: { key: 'UsageDuration', dir: 'Asc' },
       page: { max: 100, page: 0 },
       application: { operator_ids: [] },
     });
+    expect(screen.getByText('running')).toBeInTheDocument();
   });
 
   it('writes entity control changes to the Jotai table state', () => {

--- a/ui/src/components/entities-table/EntitiesTable.test.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '@quent/hooks';
 import { DAGNodeInfoPanel } from '@quent/components';
 import type { EntityRef, Operator, QueryBundle } from '@quent/utils';
+import { entitiesTableStateAtom } from '@/atoms/entitiesTable';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { EntitiesTable } from './EntitiesTable';
 
@@ -18,8 +19,8 @@ function renderTable(
   ui: React.ReactElement,
   options: { store?: ReturnType<typeof createStore> } = {}
 ) {
-  const { store } = options;
-  const content = store ? <Provider store={store}>{ui}</Provider> : ui;
+  const store = options.store ?? createStore();
+  const content = <Provider store={store}>{ui}</Provider>;
   return render(<ThemeProvider>{content}</ThemeProvider>);
 }
 
@@ -429,6 +430,7 @@ describe('EntitiesTable', () => {
   });
 
   it('clamps min usage filter when the longest-entity bound narrows after loading', () => {
+    const store = createStore();
     useEntityList.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -438,7 +440,8 @@ describe('EntitiesTable', () => {
     });
 
     const { rerender } = renderTable(
-      <EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />
+      <EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />,
+      { store }
     );
 
     fireEvent.change(screen.getByLabelText('Min usage (s)'), { target: { value: '8' } });
@@ -456,7 +459,9 @@ describe('EntitiesTable', () => {
 
     rerender(
       <ThemeProvider>
-        <EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />
+        <Provider store={store}>
+          <EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />
+        </Provider>
       </ThemeProvider>
     );
     act(() => vi.advanceTimersByTime(300));
@@ -481,5 +486,49 @@ describe('EntitiesTable', () => {
     const params = useEntities.mock.lastCall?.[0];
     expect(params.request.entry.application.operator_ids).toEqual(['operator-1']);
     expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent('Operator One');
+  });
+
+  it('reads entity controls from the Jotai table state', () => {
+    const store = createStore();
+    store.set(entitiesTableStateAtom, {
+      filters: {
+        entityType: 'Task',
+        resourceId: 'resource-1',
+        minUsageS: '0.5',
+        windowStart: '1',
+        windowEnd: '8',
+        sortDir: 'Asc',
+        pageSize: 100,
+      },
+      page: 0,
+      selected: null,
+    });
+    renderTable(<EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />, {
+      store,
+    });
+
+    const params = useEntities.mock.lastCall?.[0];
+    expect(params.request.entry).toMatchObject({
+      window: { start: 1, end: 8 },
+      filter: {
+        scope: { Resource: { resource_id: 'resource-1' } },
+        entity_type_name: 'Task',
+        min_usage_s: 0.5,
+      },
+      sort: { key: 'UsageDuration', dir: 'Asc' },
+      page: { max: 100, page: 0 },
+      application: { operator_ids: [] },
+    });
+  });
+
+  it('writes entity control changes to the Jotai table state', () => {
+    const store = createStore();
+    renderTable(<EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />, {
+      store,
+    });
+
+    fireEvent.change(screen.getByLabelText('Min usage (s)'), { target: { value: '0.75' } });
+
+    expect(store.get(entitiesTableStateAtom).filters?.minUsageS).toBe('0.75');
   });
 });

--- a/ui/src/components/entities-table/EntitiesTable.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.tsx
@@ -30,7 +30,6 @@ export function EntitiesTable(props: EntitiesTableProps) {
     () => createFsmTypeColorFn(table.query.fsmTypes, isDark ? THEME_DARK : THEME_LIGHT),
     [table.query.fsmTypes, isDark]
   );
-
   return (
     <div className="flex flex-col h-full">
       <QueryToolbar />

--- a/ui/src/components/entities-table/types.ts
+++ b/ui/src/components/entities-table/types.ts
@@ -1,17 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { FiniteStateMachine, SortDir } from '@quent/utils';
+import type { FiniteStateMachine } from '@quent/utils';
 
-export interface EntityFilters {
-  entityType: string | null;
-  resourceId: string | null;
-  minUsageS: string;
-  windowStart: string;
-  windowEnd: string;
-  sortDir: SortDir;
-  pageSize: number | null;
-}
+export type { EntityFilters } from '@/atoms/entitiesTable';
 
 export interface EntityTableRow {
   fsm: FiniteStateMachine;

--- a/ui/src/components/entities-table/useEntityTable.ts
+++ b/ui/src/components/entities-table/useEntityTable.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type SetStateAction } from 'react';
+import { useAtom } from 'jotai';
 import { useEntities, useEntityList } from '@quent/client';
 import {
   useOperatorSelection,
@@ -17,6 +18,7 @@ import {
   type QueryBundle,
   type SortDir,
 } from '@quent/utils';
+import { entitiesTableStateAtom } from '@/atoms/entitiesTable';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import type { EntityFilters } from './types';
 import {
@@ -47,6 +49,9 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
   const updateOperatorSelection = useOperatorSelectionActions();
   const operators = useMemo(() => Object.values(entities.operators), [entities.operators]);
   const defaults = useMemo(() => defaultEntityFilters(durationS), [durationS]);
+  const [tableState, setTableState] = useAtom(entitiesTableStateAtom);
+  const filters = tableState.filters ?? defaults;
+  const { page, selected } = tableState;
   // The "Min usage (s)" slider is bounded by the query duration, which is often far longer than
   // when entities actually occur. Use the longest-running entity's usage duration as a tighter,
   // more useful max so the slider isn't mostly dead space.
@@ -59,25 +64,39 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
     maxItems: 1,
   });
   const maxUsageS = longestEntityQuery.data?.items[0]?.usage_duration_s ?? durationS;
-  const [filters, setFilters] = useState<EntityFilters>(() => defaultEntityFilters(durationS));
-  const [page, setPage] = useState(0);
-  const [selected, setSelected] = useState<FiniteStateMachine | null>(null);
+  const setPage = useCallback(
+    (value: SetStateAction<number>) => {
+      setTableState(previous => ({
+        ...previous,
+        page: typeof value === 'function' ? value(previous.page) : value,
+      }));
+    },
+    [setTableState]
+  );
+  const setSelected = useCallback(
+    (value: SetStateAction<FiniteStateMachine | null>) => {
+      setTableState(previous => ({
+        ...previous,
+        selected: typeof value === 'function' ? value(previous.selected) : value,
+      }));
+    },
+    [setTableState]
+  );
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
-  // maxUsageS starts at durationS (a loose upper bound) and narrows once longestEntityQuery
-  // resolves. If a previously entered minUsageS now exceeds the narrower bound, clamp it so
-  // effectiveFilters/buildEntityRequest stay consistent with what SliderField displays. Reads
-  // filters via a ref (rather than a dependency) so this only reacts to maxUsageS narrowing,
-  // not every filter change.
+  // Clamp only when the fetched usage bound narrows.
   useEffect(() => {
     const currentMinUsageS = parseOptionalNumber(filtersRef.current.minUsageS);
     if (currentMinUsageS === null || currentMinUsageS <= maxUsageS) {
       return;
     }
-    setFilters(previous => ({ ...previous, minUsageS: String(maxUsageS) }));
-    setPage(0);
-    setSelected(null);
-  }, [maxUsageS]);
+    setTableState(previous => ({
+      ...previous,
+      filters: { ...(previous.filters ?? defaults), minUsageS: String(maxUsageS) },
+      page: 0,
+      selected: null,
+    }));
+  }, [defaults, maxUsageS, setTableState]);
   const operatorLabel = useCallback(
     (id: string) => {
       const operator = entities.operators[id];
@@ -90,23 +109,30 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
   useEffect(() => {
     setPage(0);
     setSelected(null);
-  }, [operatorIds]);
+  }, [operatorIds, setPage, setSelected]);
 
   const updateFilters = useCallback(
     (patch: Partial<EntityFilters>, options?: { preserveSelection?: boolean }) => {
-      setFilters(previous => ({ ...previous, ...patch }));
-      setPage(0);
-      if (!options?.preserveSelection) {
-        setSelected(null);
-      }
+      setTableState(previous => ({
+        ...previous,
+        filters: { ...(previous.filters ?? defaults), ...patch },
+        page: 0,
+        selected: options?.preserveSelection ? previous.selected : null,
+      }));
     },
-    []
+    [defaults, setTableState]
   );
 
-  const updateSortDir = useCallback((sortDir: SortDir) => {
-    setFilters(previous => ({ ...previous, sortDir }));
-    setPage(0);
-  }, []);
+  const updateSortDir = useCallback(
+    (sortDir: SortDir) => {
+      setTableState(previous => ({
+        ...previous,
+        filters: { ...(previous.filters ?? defaults), sortDir },
+        page: 0,
+      }));
+    },
+    [defaults, setTableState]
+  );
 
   const applyOperatorSelection = useCallback(
     (nextIds: Set<string>) => {
@@ -152,11 +178,14 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
   );
 
   const resetFilters = useCallback(() => {
-    setFilters(defaults);
     updateOperatorSelection({ type: 'clear' });
-    setPage(0);
-    setSelected(null);
-  }, [defaults, updateOperatorSelection]);
+    setTableState(previous => ({
+      ...previous,
+      filters: defaults,
+      page: 0,
+      selected: null,
+    }));
+  }, [defaults, setTableState, updateOperatorSelection]);
 
   const operatorOptions = useMemo<OptionMultiSelectOption[]>(
     () =>

--- a/ui/src/components/entities-table/useEntityTable.ts
+++ b/ui/src/components/entities-table/useEntityTable.ts
@@ -51,10 +51,8 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
   const defaults = useMemo(() => defaultEntityFilters(durationS), [durationS]);
   const [tableState, setTableState] = useAtom(entitiesTableStateAtom);
   const filters = tableState.filters ?? defaults;
-  const { page, selected } = tableState;
-  // The "Min usage (s)" slider is bounded by the query duration, which is often far longer than
-  // when entities actually occur. Use the longest-running entity's usage duration as a tighter,
-  // more useful max so the slider isn't mostly dead space.
+  const { page, selected, selectedEntityId } = tableState;
+  // Bound minimum usage by the longest entity, not the often much longer query.
   const longestEntityQuery = useEntityList({
     engineId,
     queryId,
@@ -75,10 +73,10 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
   );
   const setSelected = useCallback(
     (value: SetStateAction<FiniteStateMachine | null>) => {
-      setTableState(previous => ({
-        ...previous,
-        selected: typeof value === 'function' ? value(previous.selected) : value,
-      }));
+      setTableState(previous => {
+        const selected = typeof value === 'function' ? value(previous.selected) : value;
+        return { ...previous, selected, selectedEntityId: selected?.id ?? null };
+      });
     },
     [setTableState]
   );
@@ -95,6 +93,7 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
       filters: { ...(previous.filters ?? defaults), minUsageS: String(maxUsageS) },
       page: 0,
       selected: null,
+      selectedEntityId: null,
     }));
   }, [defaults, maxUsageS, setTableState]);
   const operatorLabel = useCallback(
@@ -104,12 +103,18 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
     },
     [entities.operators]
   );
+  const operatorIdsKey = [...operatorIds].sort().join('\0');
+  const previousOperatorIdsKey = useRef(operatorIdsKey);
   // Reset pagination/selection whenever the operator filter changes, regardless of whether
   // it came from this toolbar or another crossfiltered view (DAG, operator swimlanes, etc).
   useEffect(() => {
+    if (previousOperatorIdsKey.current === operatorIdsKey) {
+      return;
+    }
+    previousOperatorIdsKey.current = operatorIdsKey;
     setPage(0);
     setSelected(null);
-  }, [operatorIds, setPage, setSelected]);
+  }, [operatorIdsKey, setPage, setSelected]);
 
   const updateFilters = useCallback(
     (patch: Partial<EntityFilters>, options?: { preserveSelection?: boolean }) => {
@@ -118,6 +123,7 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
         filters: { ...(previous.filters ?? defaults), ...patch },
         page: 0,
         selected: options?.preserveSelection ? previous.selected : null,
+        selectedEntityId: options?.preserveSelection ? previous.selectedEntityId : null,
       }));
     },
     [defaults, setTableState]
@@ -143,7 +149,7 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
       setPage(0);
       setSelected(null);
     },
-    [operators, updateOperatorSelection]
+    [operators, setPage, setSelected, updateOperatorSelection]
   );
 
   const toggleOperator = useCallback(
@@ -164,7 +170,14 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
       setPage(0);
       setSelected(null);
     },
-    [operatorIds, operatorSelection.selections, operators, updateOperatorSelection]
+    [
+      operatorIds,
+      operatorSelection.selections,
+      operators,
+      setPage,
+      setSelected,
+      updateOperatorSelection,
+    ]
   );
 
   const selectAllOperators = useCallback(
@@ -184,6 +197,7 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
       filters: defaults,
       page: 0,
       selected: null,
+      selectedEntityId: null,
     }));
   }, [defaults, setTableState, updateOperatorSelection]);
 
@@ -252,6 +266,20 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
   const query = useEntities({ engineId, request }, { enabled: validationErrors.length === 0 });
   const requestPending = query.isFetching;
   const rows = useMemo(() => entityRows(query.data), [query.data]);
+  useEffect(() => {
+    if (!selectedEntityId || selected?.id === selectedEntityId) {
+      return;
+    }
+    const matchingEntity = rows.find(row => row.fsm.id === selectedEntityId)?.fsm;
+    if (!matchingEntity) {
+      return;
+    }
+    setTableState(previous =>
+      previous.selectedEntityId === selectedEntityId
+        ? { ...previous, selected: matchingEntity }
+        : previous
+    );
+  }, [rows, selected?.id, selectedEntityId, setTableState]);
   const pageSize = normalizePageSize(filters.pageSize);
   const total = query.data?.total ?? 0;
   const pageCount = Math.max(1, Math.ceil(total / pageSize));

--- a/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
+++ b/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
@@ -436,6 +436,8 @@ describe('DeepLinkBoundary', () => {
       window: { start: 10, end: 40 },
       sortDir: 'Asc' as const,
       pageSize: 100,
+      page: 2,
+      selectedEntityId: 'entity-a',
     };
     const encoded = encodeDeepLinkState({
       route: { engineId: 'e', queryId: 'q', tab: 'entities' },
@@ -466,8 +468,9 @@ describe('DeepLinkBoundary', () => {
           sortDir: 'Asc',
           pageSize: 100,
         },
-        page: 0,
+        page: 2,
         selected: null,
+        selectedEntityId: 'entity-a',
       })
     );
   });
@@ -644,6 +647,8 @@ describe('DeepLinkBoundary', () => {
       minUsageS: 0.5,
       window: { start: 10, end: 40 },
       sortDir: 'Asc' as const,
+      page: 3,
+      selectedEntityId: 'entity-a',
     };
     const tableState: EntitiesTableState = {
       filters: {
@@ -657,6 +662,7 @@ describe('DeepLinkBoundary', () => {
       },
       page: 3,
       selected: null,
+      selectedEntityId: 'entity-a',
     };
 
     render(

--- a/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
+++ b/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
@@ -15,6 +15,7 @@ import {
 import { NVTX_SECTION_ID, toast, Toaster } from '@quent/components';
 import type { Operator } from '@quent/utils';
 import { render, screen, waitFor, userEvent } from '@/test/test-utils';
+import { entitiesTableStateAtom, type EntitiesTableState } from '@/atoms/entitiesTable';
 import {
   expandedIdsAtom,
   resourceFilterAtom,
@@ -79,6 +80,11 @@ function ViewportProbe() {
 function IntakeStatusProbe() {
   const deepLink = useDeepLink();
   return <output data-testid="intake-status">{deepLink?.intakeStatus.kind}</output>;
+}
+
+function InitialEntitiesProbe() {
+  const state = useAtomValue(entitiesTableStateAtom);
+  return <output data-testid="initial-entities">{JSON.stringify(state)}</output>;
 }
 
 function ExpandedRowsProbe() {
@@ -167,6 +173,15 @@ function SeedResourceFilter({ filter }: { filter: ResourceFilter }) {
   useLayoutEffect(() => {
     setResourceFilter(filter);
   }, [filter, setResourceFilter]);
+  return null;
+}
+
+function SeedEntitiesState({ state }: { state: EntitiesTableState }) {
+  const setEntitiesState = useSetAtom(entitiesTableStateAtom);
+
+  useLayoutEffect(() => {
+    setEntitiesState(state);
+  }, [setEntitiesState, state]);
   return null;
 }
 
@@ -413,6 +428,50 @@ describe('DeepLinkBoundary', () => {
     expect(value.resources.resourceFilter).toEqual(EMPTY_RESOURCE_FILTER);
   });
 
+  it('exposes v3 entity state before rendering the entities route', () => {
+    const entities = {
+      entityType: 'task',
+      resourceId: 'resource-a',
+      minUsageS: 0.5,
+      window: { start: 10, end: 40 },
+      sortDir: 'Asc' as const,
+      pageSize: 100,
+    };
+    const encoded = encodeDeepLinkState({
+      route: { engineId: 'e', queryId: 'q', tab: 'entities' },
+      selection: { operatorNodeIds: ['operator-a'] },
+      entities,
+    });
+    expect(encoded.ok).toBe(true);
+    if (!encoded.ok) {
+      return;
+    }
+
+    render(
+      <JotaiProvider>
+        <DeepLinkBoundary {...BOUNDARY_PROPS} activeTab="entities" encodedState={encoded.value}>
+          <InitialEntitiesProbe />
+        </DeepLinkBoundary>
+      </JotaiProvider>
+    );
+
+    expect(screen.getByTestId('initial-entities')).toHaveTextContent(
+      JSON.stringify({
+        filters: {
+          entityType: 'task',
+          resourceId: 'resource-a',
+          minUsageS: '0.5',
+          windowStart: '10',
+          windowEnd: '40',
+          sortDir: 'Asc',
+          pageSize: 100,
+        },
+        page: 0,
+        selected: null,
+      })
+    );
+  });
+
   it('does not subscribe to render-time timeline hydration', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
@@ -513,7 +572,7 @@ describe('DeepLinkBoundary', () => {
     expect(decodeDeepLinkState(encoded!)).toEqual({
       ok: true,
       value: {
-        version: 'v2',
+        version: 'v3',
         data: {
           route: { engineId: 'e', queryId: 'q', tab: 'timeline' },
           timeline: { zoomRange: { start: 20, end: 60 } },
@@ -563,11 +622,66 @@ describe('DeepLinkBoundary', () => {
     expect(decodeDeepLinkState(encoded!)).toMatchObject({
       ok: true,
       value: {
-        version: 'v2',
+        version: 'v3',
         data: {
           resources: {
             resourceFilter: { search: 'resource', showOthers: true },
           },
+        },
+      },
+    });
+  });
+
+  it('copies entity filters without requiring timeline state', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    window.history.replaceState(null, '', '/profile/engine/e/query/q/entities');
+    const entities = {
+      entityType: 'task',
+      minUsageS: 0.5,
+      window: { start: 10, end: 40 },
+      sortDir: 'Asc' as const,
+    };
+    const tableState: EntitiesTableState = {
+      filters: {
+        entityType: 'task',
+        resourceId: null,
+        minUsageS: '0.5',
+        windowStart: '10',
+        windowEnd: '40',
+        sortDir: 'Asc',
+        pageSize: 50,
+      },
+      page: 3,
+      selected: null,
+    };
+
+    render(
+      <>
+        <div id={DEEP_LINK_NAV_SLOT_ID} />
+        <JotaiProvider>
+          <DeepLinkBoundary {...BOUNDARY_PROPS} activeTab="entities">
+            <SeedEntitiesState state={tableState} />
+            <CopyLinkButton />
+          </DeepLinkBoundary>
+        </JotaiProvider>
+      </>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy Link' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    const encoded = new URL(writeText.mock.calls[0][0] as string).searchParams.get('s');
+
+    expect(decodeDeepLinkState(encoded!)).toEqual({
+      ok: true,
+      value: {
+        version: 'v3',
+        data: {
+          route: { engineId: 'e', queryId: 'q', tab: 'entities' },
+          entities,
         },
       },
     });

--- a/ui/src/features/deep-link/DeepLinkBoundary.tsx
+++ b/ui/src/features/deep-link/DeepLinkBoundary.tsx
@@ -20,6 +20,11 @@ import {
 import { DAG_LAYOUT_DIRECTION, NODE_LABEL_FIELD, type Operator } from '@quent/utils';
 import { toast } from '@quent/components';
 import {
+  entitiesTableStateAtom,
+  type EntitiesTableState,
+  type EntityFilters,
+} from '@/atoms/entitiesTable';
+import {
   expandedIdsAtom,
   resourceFilterAtom,
   rootResourceTypeAtom,
@@ -35,6 +40,14 @@ import {
   OPERATOR_TABLE_INDEX_ORDER,
   OPERATOR_TABLE_PERSIST_KEY,
 } from '@/components/operator-table/types';
+import {
+  DEFAULT_PAGE_SIZE,
+  SORT_DESC,
+  defaultEntityFilters,
+  normalizePageSize,
+  parseOptionalNumber,
+  validateEntityFilters,
+} from '@/components/entities-table/utils';
 import { buildDeepLinkUrl, decodeDeepLinkState, DEEP_LINK_SEARCH_KEY } from './deepLink.codec';
 import {
   DeepLinkContext,
@@ -44,7 +57,12 @@ import {
 } from './deepLink.context';
 import { readDeepLinkFields, type DeepLinkFields } from './deepLink.fields';
 import { normalizeZoomRange, resolveCapturedZoomRange } from './deepLink.normalize';
-import { OperatorGroupSchema, type DeepLinkStateV2, type DeepLinkTab } from './deepLink.schema';
+import {
+  OperatorGroupSchema,
+  type DeepLinkEntitiesState,
+  type DeepLinkStateV3,
+  type DeepLinkTab,
+} from './deepLink.schema';
 
 interface DeepLinkBoundaryProps {
   children: ReactNode;
@@ -72,6 +90,63 @@ function hasKeys(value: object): boolean {
 
 function isOperatorGroup(value: string): value is (typeof OperatorGroupSchema.options)[number] {
   return OperatorGroupSchema.safeParse(value).success;
+}
+
+function hydrateEntitiesState(
+  state: DeepLinkEntitiesState,
+  durationSeconds: number
+): EntitiesTableState {
+  const filters: EntityFilters = {
+    ...defaultEntityFilters(durationSeconds),
+    entityType: state.entityType ?? null,
+    resourceId: state.resourceId ?? null,
+    minUsageS: state.minUsageS === undefined ? '' : String(state.minUsageS),
+    windowStart: state.window ? String(state.window.start) : '0',
+    windowEnd: state.window ? String(state.window.end) : String(durationSeconds),
+    sortDir: state.sortDir ?? SORT_DESC,
+    pageSize: state.pageSize ?? DEFAULT_PAGE_SIZE,
+  };
+
+  return {
+    filters,
+    page: 0,
+    selected: null,
+  };
+}
+
+function captureEntitiesState(
+  tableState: EntitiesTableState,
+  durationSeconds: number
+): DeepLinkEntitiesState | null {
+  const filters = tableState.filters ?? defaultEntityFilters(durationSeconds);
+  if (validateEntityFilters(filters).errors.length > 0) {
+    return null;
+  }
+
+  const state: DeepLinkEntitiesState = {};
+  if (filters.entityType) {
+    state.entityType = filters.entityType;
+  }
+  if (filters.resourceId) {
+    state.resourceId = filters.resourceId;
+  }
+  const minUsageS = parseOptionalNumber(filters.minUsageS);
+  if (minUsageS !== null) {
+    state.minUsageS = minUsageS;
+  }
+  const windowStart = parseOptionalNumber(filters.windowStart) ?? 0;
+  const windowEnd = parseOptionalNumber(filters.windowEnd) ?? durationSeconds;
+  if (windowStart !== 0 || windowEnd !== durationSeconds) {
+    state.window = { start: windowStart, end: windowEnd };
+  }
+  if (filters.sortDir !== SORT_DESC) {
+    state.sortDir = filters.sortDir;
+  }
+  const pageSize = normalizePageSize(filters.pageSize);
+  if (pageSize !== DEFAULT_PAGE_SIZE) {
+    state.pageSize = pageSize;
+  }
+  return state;
 }
 
 export function DeepLinkBoundary({
@@ -270,6 +345,12 @@ export function DeepLinkBoundary({
           : undefined,
         operatorTable: intake.fields.operatorTable,
       });
+      if (intake.fields.entities) {
+        store.set(
+          entitiesTableStateAtom,
+          hydrateEntitiesState(intake.fields.entities, durationSeconds)
+        );
+      }
     }
     if (encodedState) {
       const url = new URL(window.location.href);
@@ -282,6 +363,7 @@ export function DeepLinkBoundary({
     }
     setIsHydrated(true);
   }, [
+    durationSeconds,
     encodedState,
     intake.initialExpandedResourceIds,
     intake.initialZoomRange,
@@ -297,18 +379,28 @@ export function DeepLinkBoundary({
     if (!queryId || !activeTab) {
       return { ok: false, message: 'Select a query tab before copying a shared link.' };
     }
-    const capturedRange = resolveCapturedZoomRange(readZoomRange(), durationSeconds);
-    if (!capturedRange) {
+    const capturedRange =
+      activeTab === 'entities' ? null : resolveCapturedZoomRange(readZoomRange(), durationSeconds);
+    if (!capturedRange && activeTab !== 'entities') {
       return { ok: false, message: 'The timeline viewport is not available yet.' };
     }
-
     const sharedView = readSerializableViewState();
-    const state: DeepLinkStateV2 = {
-      route: { engineId, queryId, tab: activeTab },
-      timeline: { zoomRange: capturedRange },
-    };
+    const entitiesState =
+      activeTab === 'entities'
+        ? captureEntitiesState(store.get(entitiesTableStateAtom), durationSeconds)
+        : undefined;
+    if (activeTab === 'entities' && entitiesState === null) {
+      return { ok: false, message: 'Fix the entity filters before copying a shared link.' };
+    }
 
-    const selection: NonNullable<DeepLinkStateV2['selection']> = {};
+    const state: DeepLinkStateV3 = {
+      route: { engineId, queryId, tab: activeTab },
+    };
+    if (capturedRange) {
+      state.timeline = { zoomRange: capturedRange };
+    }
+
+    const selection: NonNullable<DeepLinkStateV3['selection']> = {};
     if (sharedView.selection.planId) {
       selection.planId = sharedView.selection.planId;
     }
@@ -319,7 +411,7 @@ export function DeepLinkBoundary({
       state.selection = selection;
     }
 
-    const resources: NonNullable<DeepLinkStateV2['resources']> = {};
+    const resources: NonNullable<DeepLinkStateV3['resources']> = {};
     const expandedRowIds = [...store.get(expandedIdsAtom)].sort();
     if (expandedRowIds.length > 0) {
       resources.expandedRowIds = expandedRowIds;
@@ -357,7 +449,7 @@ export function DeepLinkBoundary({
       state.resources = resources;
     }
 
-    const dag: NonNullable<DeepLinkStateV2['dag']> = {};
+    const dag: NonNullable<DeepLinkStateV3['dag']> = {};
     if (sharedView.dag.nodeColorField) {
       dag.nodeColorField = sharedView.dag.nodeColorField;
     }
@@ -383,7 +475,7 @@ export function DeepLinkBoundary({
       state.dag = dag;
     }
 
-    const dataFlow: NonNullable<DeepLinkStateV2['dataFlow']> = {};
+    const dataFlow: NonNullable<DeepLinkStateV3['dataFlow']> = {};
     if (!sharedView.dataFlow.enabled) {
       dataFlow.enabled = false;
     }
@@ -398,7 +490,8 @@ export function DeepLinkBoundary({
     }
     if (
       sharedView.dataFlow.playheadS !== null &&
-      Math.abs(sharedView.dataFlow.playheadS - capturedRange.start) > Number.EPSILON
+      (!capturedRange ||
+        Math.abs(sharedView.dataFlow.playheadS - capturedRange.start) > Number.EPSILON)
     ) {
       dataFlow.playheadS = sharedView.dataFlow.playheadS;
     }
@@ -406,7 +499,7 @@ export function DeepLinkBoundary({
       state.dataFlow = dataFlow;
     }
 
-    const table: NonNullable<DeepLinkStateV2['operatorTable']> = {};
+    const table: NonNullable<DeepLinkStateV3['operatorTable']> = {};
     const groupingOrder = sharedView.operatorTable.groupingOrder?.filter(isOperatorGroup);
     if (groupingOrder) {
       table.groupingOrder = groupingOrder;
@@ -431,6 +524,10 @@ export function DeepLinkBoundary({
     }
     if (hasKeys(table)) {
       state.operatorTable = table;
+    }
+
+    if (entitiesState && hasKeys(entitiesState)) {
+      state.entities = entitiesState;
     }
 
     const canonicalPageUrl = `${window.location.origin}${window.location.pathname}`;

--- a/ui/src/features/deep-link/DeepLinkBoundary.tsx
+++ b/ui/src/features/deep-link/DeepLinkBoundary.tsx
@@ -109,8 +109,9 @@ function hydrateEntitiesState(
 
   return {
     filters,
-    page: 0,
+    page: state.page ?? 0,
     selected: null,
+    selectedEntityId: state.selectedEntityId ?? null,
   };
 }
 
@@ -145,6 +146,13 @@ function captureEntitiesState(
   const pageSize = normalizePageSize(filters.pageSize);
   if (pageSize !== DEFAULT_PAGE_SIZE) {
     state.pageSize = pageSize;
+  }
+  if (tableState.page > 0) {
+    state.page = tableState.page;
+  }
+  const selectedEntityId = tableState.selectedEntityId ?? tableState.selected?.id;
+  if (selectedEntityId) {
+    state.selectedEntityId = selectedEntityId;
   }
   return state;
 }

--- a/ui/src/features/deep-link/deepLink.codec.test.ts
+++ b/ui/src/features/deep-link/deepLink.codec.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest';
+import { gzipSync, strToU8 } from 'fflate';
 import {
   buildDeepLinkUrl,
   CURRENT_DEEP_LINK_VERSION,
@@ -11,11 +12,12 @@ import {
   SUPPORTED_DEEP_LINK_VERSIONS,
 } from './deepLink.codec';
 import {
-  DeepLinkStateV2Schema,
   DeepLinkStateV1Schema,
+  DeepLinkStateV2Schema,
+  DeepLinkStateV3Schema,
   MAX_EXPANDED_RESOURCE_IDS,
   OperatorGroupSchema,
-  type DeepLinkStateV2,
+  type DeepLinkStateV3,
   validateDeepLinkSearch,
 } from './deepLink.schema';
 import { CONTINUOUS_PALETTES, DAG_LAYOUT_DIRECTION, NODE_LABEL_FIELD } from '@quent/utils';
@@ -26,11 +28,11 @@ const RESOURCE_A_ID = '01a025ff-ea8b-7881-9d31-72a275872c9d';
 const RESOURCE_B_ID = '01a025ff-ea8b-7881-9d31-72a275872c9e';
 const NVTX_SECTION_ID = '__nvtx__';
 
-const state: DeepLinkStateV2 = {
+const state: DeepLinkStateV3 = {
   route: {
     engineId: 'engine-a',
     queryId: 'query-a',
-    tab: 'operators',
+    tab: 'entities',
   },
   timeline: {
     zoomRange: {
@@ -77,6 +79,14 @@ const state: DeepLinkStateV2 = {
     aggregation: 'max',
     sort: [{ id: 'spill_bytes', desc: true }],
   },
+  entities: {
+    entityType: 'task',
+    resourceId: 'resource-a',
+    minUsageS: 0.25,
+    window: { start: 10, end: 45 },
+    sortDir: 'Asc',
+    pageSize: 100,
+  },
 };
 
 describe('deep-link codec', () => {
@@ -91,7 +101,7 @@ describe('deep-link codec', () => {
     }
     expect(decodeDeepLinkState(first.value)).toEqual({
       ok: true,
-      value: { version: 'v2', data: state },
+      value: { version: 'v3', data: state },
     });
   });
 
@@ -117,6 +127,28 @@ describe('deep-link codec', () => {
     expect(decodeDeepLinkState(encoded)).toEqual({
       ok: true,
       value: { version: 'v1', data: { zoomRange: { start: 0, end: 0.407 } } },
+    });
+  });
+
+  it('decodes legacy v2 links', () => {
+    const legacyState = DeepLinkStateV2Schema.parse({
+      route: { engineId: 'engine-a', queryId: 'query-a', tab: 'operators' },
+      timeline: { zoomRange: { start: 12.5, end: 48.75 } },
+      selection: { operatorNodeIds: ['operator-a'] },
+    });
+    const compressed = gzipSync(strToU8(JSON.stringify(legacyState)), { level: 9, mtime: 0 });
+    let binary = '';
+    for (const byte of compressed) {
+      binary += String.fromCharCode(byte);
+    }
+    const encoded = `v2.${btoa(binary)
+      .replace(/\+/gu, '-')
+      .replace(/\//gu, '_')
+      .replace(/=+$/u, '')}`;
+
+    expect(decodeDeepLinkState(encoded)).toEqual({
+      ok: true,
+      value: { version: 'v2', data: legacyState },
     });
   });
 
@@ -154,10 +186,10 @@ describe('deep-link search validation', () => {
 });
 
 describe('deep-link state validation', () => {
-  it('validates and canonicalizes comprehensive v2 state', () => {
-    expect(DeepLinkStateV2Schema.parse({ ...state, futureField: true })).toEqual(state);
+  it('validates and canonicalizes comprehensive v3 state', () => {
+    expect(DeepLinkStateV3Schema.parse({ ...state, futureField: true })).toEqual(state);
     expect(
-      DeepLinkStateV2Schema.parse({
+      DeepLinkStateV3Schema.parse({
         route: state.route,
         timeline: state.timeline,
         resources: {
@@ -166,13 +198,13 @@ describe('deep-link state validation', () => {
       }).resources?.expandedRowIds
     ).toEqual([RESOURCE_A_ID, RESOURCE_B_ID, NVTX_SECTION_ID]);
     expect(
-      DeepLinkStateV2Schema.safeParse({
+      DeepLinkStateV3Schema.safeParse({
         route: state.route,
         timeline: { zoomRange: { start: 20, end: 10 } },
       }).success
     ).toBe(false);
     expect(
-      DeepLinkStateV2Schema.safeParse({
+      DeepLinkStateV3Schema.safeParse({
         route: state.route,
         timeline: state.timeline,
         resources: {
@@ -184,12 +216,27 @@ describe('deep-link state validation', () => {
       }).success
     ).toBe(false);
     expect(
-      DeepLinkStateV2Schema.safeParse({
+      DeepLinkStateV3Schema.safeParse({
         route: state.route,
         timeline: state.timeline,
         resources: {
           resourceFilter: { search: 'x'.repeat(MAX_RESOURCE_FILTER_QUERY_LENGTH + 1) },
         },
+      }).success
+    ).toBe(false);
+    expect(
+      DeepLinkStateV3Schema.safeParse({
+        route: state.route,
+        entities: { window: { start: 20, end: 10 } },
+      }).success
+    ).toBe(false);
+  });
+
+  it('keeps the v2 schema unchanged', () => {
+    expect(
+      DeepLinkStateV2Schema.safeParse({
+        route: { engineId: 'engine-a', queryId: 'query-a', tab: 'entities' },
+        timeline: state.timeline,
       }).success
     ).toBe(false);
   });
@@ -225,19 +272,19 @@ describe('deep-link state validation', () => {
     const base = { route: state.route, timeline: state.timeline };
     for (const palette of Object.keys(CONTINUOUS_PALETTES)) {
       expect(
-        DeepLinkStateV2Schema.safeParse({
+        DeepLinkStateV3Schema.safeParse({
           ...base,
           dag: { nodeColorPalette: palette, edgeColorPalette: palette },
         }).success
       ).toBe(true);
     }
     for (const nodeLabelField of Object.values(NODE_LABEL_FIELD)) {
-      expect(DeepLinkStateV2Schema.safeParse({ ...base, dag: { nodeLabelField } }).success).toBe(
+      expect(DeepLinkStateV3Schema.safeParse({ ...base, dag: { nodeLabelField } }).success).toBe(
         true
       );
     }
     for (const layoutDirection of Object.values(DAG_LAYOUT_DIRECTION)) {
-      expect(DeepLinkStateV2Schema.safeParse({ ...base, dag: { layoutDirection } }).success).toBe(
+      expect(DeepLinkStateV3Schema.safeParse({ ...base, dag: { layoutDirection } }).success).toBe(
         true
       );
     }

--- a/ui/src/features/deep-link/deepLink.codec.test.ts
+++ b/ui/src/features/deep-link/deepLink.codec.test.ts
@@ -86,6 +86,8 @@ const state: DeepLinkStateV3 = {
     window: { start: 10, end: 45 },
     sortDir: 'Asc',
     pageSize: 100,
+    page: 2,
+    selectedEntityId: 'entity-a',
   },
 };
 

--- a/ui/src/features/deep-link/deepLink.codec.ts
+++ b/ui/src/features/deep-link/deepLink.codec.ts
@@ -8,12 +8,12 @@ import {
   type VersionedDeepLinkState,
 } from './deepLink.fields';
 import {
-  DeepLinkStateV2Schema,
+  DeepLinkStateV3Schema,
   MAX_ENCODED_STATE_LENGTH,
-  type DeepLinkStateV2,
+  type DeepLinkStateV3,
 } from './deepLink.schema';
 
-export const CURRENT_DEEP_LINK_VERSION: DeepLinkVersion = 'v2';
+export const CURRENT_DEEP_LINK_VERSION: DeepLinkVersion = 'v3';
 export const SUPPORTED_DEEP_LINK_VERSIONS = SUPPORTED_DEEP_LINK_SCHEMAS.map(entry => entry.version);
 export const DEEP_LINK_SEARCH_KEY = 's';
 export const MAX_DEEP_LINK_URL_LENGTH = 2048;
@@ -55,8 +55,8 @@ function base64UrlToBytes(value: string): Uint8Array | null {
   }
 }
 
-export function encodeDeepLinkState(state: DeepLinkStateV2): DeepLinkResult<string> {
-  const parsed = DeepLinkStateV2Schema.safeParse(state);
+export function encodeDeepLinkState(state: DeepLinkStateV3): DeepLinkResult<string> {
+  const parsed = DeepLinkStateV3Schema.safeParse(state);
   if (!parsed.success) {
     return failure('invalid-state', 'The current shared view state is invalid.');
   }
@@ -112,7 +112,7 @@ export function decodeDeepLinkState(encoded: string): DeepLinkResult<VersionedDe
 
 export function buildDeepLinkUrl(
   currentUrl: string,
-  state: DeepLinkStateV2
+  state: DeepLinkStateV3
 ): DeepLinkResult<string> {
   const encoded = encodeDeepLinkState(state);
   if (!encoded.ok) {

--- a/ui/src/features/deep-link/deepLink.fields.test.ts
+++ b/ui/src/features/deep-link/deepLink.fields.test.ts
@@ -8,7 +8,11 @@ import {
   readDeepLinkFields,
   type DeepLinkFields,
 } from './deepLink.fields';
-import { DeepLinkStateV1Schema, DeepLinkStateV2Schema } from './deepLink.schema';
+import {
+  DeepLinkStateV1Schema,
+  DeepLinkStateV2Schema,
+  DeepLinkStateV3Schema,
+} from './deepLink.schema';
 
 const absentFields = {
   route: undefined,
@@ -19,6 +23,7 @@ const absentFields = {
   dag: undefined,
   dataFlow: undefined,
   operatorTable: undefined,
+  entities: undefined,
 } satisfies DeepLinkFields;
 
 const v1State = DeepLinkStateV1Schema.parse({
@@ -31,6 +36,16 @@ const v2State = DeepLinkStateV2Schema.parse({
   timeline: { zoomRange: { start: 10, end: 40 } },
   resources: { expandedRowIds: ['resource-b', 'resource-a'] },
   selection: { planId: 'plan-a' },
+});
+
+const v3State = DeepLinkStateV3Schema.parse({
+  route: { engineId: 'engine-a', queryId: 'query-a', tab: 'entities' },
+  selection: { operatorNodeIds: ['operator-a'] },
+  entities: {
+    entityType: 'task',
+    window: { start: 12, end: 24 },
+    sortDir: 'Asc',
+  },
 });
 
 describe('deep-link field readers', () => {
@@ -60,6 +75,17 @@ describe('deep-link field readers', () => {
       expandedResourceIds: ['resource-a', 'resource-b'],
       selection: { planId: 'plan-a' },
       resources: v2State.resources,
+    });
+  });
+
+  it('reads v3 entity fields without requiring a timeline viewport', () => {
+    const decoded = { version: 'v3' as const, data: v3State };
+
+    expect(readDeepLinkFields(decoded)).toEqual({
+      ...absentFields,
+      route: v3State.route,
+      selection: v3State.selection,
+      entities: v3State.entities,
     });
   });
 

--- a/ui/src/features/deep-link/deepLink.fields.ts
+++ b/ui/src/features/deep-link/deepLink.fields.ts
@@ -6,20 +6,23 @@ import { z } from 'zod';
 import {
   DeepLinkStateV1Schema,
   DeepLinkStateV2Schema,
+  DeepLinkStateV3Schema,
   type DeepLinkStateV1,
   type DeepLinkStateV2,
+  type DeepLinkStateV3,
 } from './deepLink.schema';
 
 /** Canonical fields a decoded link may expose. Missing readers return `undefined`. */
 export type DeepLinkFields = {
-  route: DeepLinkStateV2['route'] | undefined;
+  route: DeepLinkStateV3['route'] | undefined;
   zoomRange: ZoomRange | undefined;
   expandedResourceIds: readonly string[] | undefined;
-  selection: DeepLinkStateV2['selection'];
-  resources: DeepLinkStateV2['resources'];
-  dag: DeepLinkStateV2['dag'];
-  dataFlow: DeepLinkStateV2['dataFlow'];
-  operatorTable: DeepLinkStateV2['operatorTable'];
+  selection: DeepLinkStateV3['selection'];
+  resources: DeepLinkStateV3['resources'];
+  dag: DeepLinkStateV3['dag'];
+  dataFlow: DeepLinkStateV3['dataFlow'];
+  operatorTable: DeepLinkStateV3['operatorTable'];
+  entities: DeepLinkStateV3['entities'];
 };
 
 export type DeepLinkFieldKey = keyof DeepLinkFields;
@@ -45,6 +48,7 @@ function readFields<TState>(readers: DeepLinkFieldReaders<TState>, state: TState
     dag: readers.dag?.(state),
     dataFlow: readers.dataFlow?.(state),
     operatorTable: readers.operatorTable?.(state),
+    entities: readers.entities?.(state),
   };
 }
 
@@ -87,10 +91,25 @@ export const SUPPORTED_DEEP_LINK_SCHEMAS = [
       operatorTable: state => state.operatorTable,
     },
   }),
+  defineDeepLinkVersion({
+    version: 'v3',
+    schema: DeepLinkStateV3Schema,
+    fields: {
+      route: state => state.route,
+      zoomRange: state => state.timeline?.zoomRange,
+      expandedResourceIds: state => state.resources?.expandedRowIds,
+      selection: state => state.selection,
+      resources: state => state.resources,
+      dag: state => state.dag,
+      dataFlow: state => state.dataFlow,
+      operatorTable: state => state.operatorTable,
+      entities: state => state.entities,
+    },
+  }),
 ] as const;
 
 export type DeepLinkVersion = (typeof SUPPORTED_DEEP_LINK_SCHEMAS)[number]['version'];
-export type DecodedDeepLinkState = DeepLinkStateV1 | DeepLinkStateV2;
+export type DecodedDeepLinkState = DeepLinkStateV1 | DeepLinkStateV2 | DeepLinkStateV3;
 
 export type VersionedDeepLinkState = {
   version: DeepLinkVersion;

--- a/ui/src/features/deep-link/deepLink.schema.ts
+++ b/ui/src/features/deep-link/deepLink.schema.ts
@@ -8,6 +8,7 @@ import {
   NODE_LABEL_FIELD,
   AGG_MODES,
 } from '@quent/utils';
+import { MAX_PAGE_SIZE } from '@/components/entities-table/utils';
 import { OPERATOR_TABLE_INDEX_ORDER } from '@/components/operator-table/types';
 import { MAX_RESOURCE_FILTER_QUERY_LENGTH } from '@/features/resource-filter/resourceFilter';
 
@@ -74,6 +75,16 @@ const RouteSchema = z
     tab: z.enum(['timeline', 'operators']),
   })
   .strip();
+
+const RouteV3Schema = z
+  .object({
+    engineId: IdSchema,
+    queryId: IdSchema,
+    tab: z.enum(['timeline', 'operators', 'entities']),
+  })
+  .strip();
+
+const TimelineSchema = z.object({ zoomRange: ZoomRangeSchema }).strip();
 
 const SelectionSchema = z
   .object({
@@ -189,10 +200,30 @@ const OperatorTableSchema = z
   })
   .strip();
 
+const EntityWindowSchema = z
+  .object({
+    start: z.number().finite().nonnegative(),
+    end: z.number().finite().nonnegative(),
+  })
+  .refine(window => window.end >= window.start, {
+    message: 'Entity window end must not precede its start',
+  });
+
+const EntitiesSchema = z
+  .object({
+    entityType: NameSchema.optional(),
+    resourceId: IdSchema.optional(),
+    minUsageS: z.number().finite().nonnegative().optional(),
+    window: EntityWindowSchema.optional(),
+    sortDir: z.enum(['Asc', 'Desc']).optional(),
+    pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).optional(),
+  })
+  .strip();
+
 export const DeepLinkStateV2Schema = z
   .object({
     route: RouteSchema,
-    timeline: z.object({ zoomRange: ZoomRangeSchema }).strip(),
+    timeline: TimelineSchema,
     selection: SelectionSchema.optional(),
     resources: ResourceTreeSchema.optional(),
     dag: DagControlsSchema.optional(),
@@ -202,8 +233,40 @@ export const DeepLinkStateV2Schema = z
   .strip();
 
 export type DeepLinkStateV2 = z.infer<typeof DeepLinkStateV2Schema>;
-export type DeepLinkState = DeepLinkStateV2;
-export type DeepLinkTab = DeepLinkStateV2['route']['tab'];
+
+export const DeepLinkStateV3Schema = z
+  .object({
+    route: RouteV3Schema,
+    timeline: TimelineSchema.optional(),
+    selection: SelectionSchema.optional(),
+    resources: ResourceTreeSchema.optional(),
+    dag: DagControlsSchema.optional(),
+    dataFlow: DataFlowSchema.optional(),
+    operatorTable: OperatorTableSchema.optional(),
+    entities: EntitiesSchema.optional(),
+  })
+  .strip()
+  .superRefine((state, context) => {
+    if (state.route.tab !== 'entities' && !state.timeline) {
+      context.addIssue({
+        code: 'custom',
+        path: ['timeline'],
+        message: 'Timeline state is required for timeline and operator links',
+      });
+    }
+    if (state.route.tab !== 'entities' && state.entities) {
+      context.addIssue({
+        code: 'custom',
+        path: ['entities'],
+        message: 'Entity state is only valid for entity links',
+      });
+    }
+  });
+
+export type DeepLinkStateV3 = z.infer<typeof DeepLinkStateV3Schema>;
+export type DeepLinkState = DeepLinkStateV3;
+export type DeepLinkTab = DeepLinkStateV3['route']['tab'];
+export type DeepLinkEntitiesState = NonNullable<DeepLinkStateV3['entities']>;
 
 export const DeepLinkSearchSchema = z
   .object({

--- a/ui/src/features/deep-link/deepLink.schema.ts
+++ b/ui/src/features/deep-link/deepLink.schema.ts
@@ -217,6 +217,8 @@ const EntitiesSchema = z
     window: EntityWindowSchema.optional(),
     sortDir: z.enum(['Asc', 'Desc']).optional(),
     pageSize: z.number().int().min(1).max(MAX_PAGE_SIZE).optional(),
+    page: z.number().int().nonnegative().max(1_000_000).optional(),
+    selectedEntityId: IdSchema.optional(),
   })
   .strip();
 

--- a/ui/src/routes/profile.engine.$engineId.tsx
+++ b/ui/src/routes/profile.engine.$engineId.tsx
@@ -83,7 +83,17 @@ function ProfileLayout() {
     from: '/profile/engine/$engineId/query/$queryId/operators',
     shouldThrow: false,
   });
-  const activeTab = timelineMatch ? 'timeline' : operatorsMatch ? 'operators' : undefined;
+  const entitiesMatch = useMatch({
+    from: '/profile/engine/$engineId/query/$queryId/entities',
+    shouldThrow: false,
+  });
+  const activeTab = timelineMatch
+    ? 'timeline'
+    : operatorsMatch
+      ? 'operators'
+      : entitiesMatch
+        ? 'entities'
+        : undefined;
   const hasQuery = queryId !== undefined;
   const isQueryReady = !hasQuery || queryMatch?.status === 'success';
   // Stripping a consumed `s` keeps the store; a different payload resets it.


### PR DESCRIPTION
# Description
This creates a new deep link schema (v3) that includes all of the /entities route state. 

## Related Issues
Fixes #636 

## Testing

New deep link state to test:
* Entities tab selected
* All filters from the entities toolbar (operator, type, resource, usage, window)
* Selected entity

Above and beyond: test deep link backwards compatibility
* Checkout `main`
* Filter timelines, zoom/pan to area, expand/collapse rows, etc
* Copy share link
* Checkout this branch
* Paste v2 link 
* Verify that state is still hydrated properly

<!--
Describe what you ran locally.

Rust changes:
- pixi run cargo fmt --all
- pixi run cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- pixi run cargo test --workspace --all-features --locked --all-targets

UI changes:
- cd ui
- pnpm ci:check
-->

## Screenshots

<!-- For UI changes, include screenshots or videos when possible. -->
