### PR TITLE
feat(ui): entities tab operator filtering, multiple operator selection, dropdown descriptions

### DIFF
--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -115,6 +115,7 @@ export { TreeTable } from './ui/tree-table';
 export type { Column, ColumnComponent, IconComponent } from './ui/tree-table';
 export { Badge, badgeVariants } from './ui/badge';
 export { OptionMultiSelect } from './ui/option-multi-select';
+export type { OptionMultiSelectOption } from './ui/option-multi-select';
 export {
   Table,
   TableHeader,

--- a/ui/packages/@quent/components/src/pivot-table/PivotTableToolbar.tsx
+++ b/ui/packages/@quent/components/src/pivot-table/PivotTableToolbar.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { cn, AGG_MODES } from '@quent/utils';
 import { useColumnDragDrop } from '@quent/hooks';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
@@ -41,6 +41,7 @@ export function PivotTableToolbar({
   onSelectAllStats,
   onSelectNoStats,
 }: PivotTableToolbarProps) {
+  const statOptions = useMemo(() => orderedStats.map(stat => ({ value: stat })), [orderedStats]);
   const commitDrop = useCallback(
     (fromKey: string, toKey: string, position: 'before' | 'after') => {
       if (fromKey === toKey) {
@@ -135,7 +136,7 @@ export function PivotTableToolbar({
       <OptionMultiSelect
         label="Columns"
         triggerText="Select Columns"
-        options={orderedStats}
+        options={statOptions}
         selectedOptionIds={selectedStats}
         onToggleOption={onToggleStat}
         onSelectAllOptions={onSelectAllStats}

--- a/ui/packages/@quent/components/src/pivot-table/PivotTableToolbar.tsx
+++ b/ui/packages/@quent/components/src/pivot-table/PivotTableToolbar.tsx
@@ -144,6 +144,7 @@ export function PivotTableToolbar({
         searchPlaceholder="Search columns…"
         emptyMessage="No columns found"
         noneSelectedText="None selected"
+        optionClassName="font-mono"
       />
     </>
   );

--- a/ui/packages/@quent/components/src/ui/option-multi-select.tsx
+++ b/ui/packages/@quent/components/src/ui/option-multi-select.tsx
@@ -33,8 +33,8 @@ interface OptionMultiSelectProps {
   showSelectedBadges?: boolean;
   className?: string;
   triggerClassName?: string;
-  /** Render option labels in a monospace font, e.g. for raw field/column identifiers. Defaults to true. */
-  monospaceLabels?: boolean;
+  /** className applied to each option's label and its selected badge. */
+  optionClassName?: string;
 }
 
 function optionLabel(option: OptionMultiSelectOption): string {
@@ -57,7 +57,7 @@ export function OptionMultiSelect({
   showSelectedBadges = true,
   className,
   triggerClassName,
-  monospaceLabels = true,
+  optionClassName,
 }: OptionMultiSelectProps) {
   const [search, setSearch] = useState('');
 
@@ -199,7 +199,7 @@ export function OptionMultiSelect({
                     {checked && <Check className="size-2.5" strokeWidth={3} />}
                   </span>
                   <span className="min-w-0 flex-1 text-left">
-                    <span className={cn('block truncate', monospaceLabels && 'font-mono')}>
+                    <span className={cn('block truncate', optionClassName)}>
                       {optionLabel(option)}
                     </span>
                     {option.description && (
@@ -229,7 +229,7 @@ export function OptionMultiSelect({
                   variant="outline"
                   className={cn(
                     'px-1.5 py-0 text-data bg-primary/10 border-primary/40 hover:bg-primary/15',
-                    monospaceLabels && 'font-mono'
+                    optionClassName
                   )}
                 >
                   <span className="truncate">{optionLabel(option)}</span>

--- a/ui/packages/@quent/components/src/ui/option-multi-select.tsx
+++ b/ui/packages/@quent/components/src/ui/option-multi-select.tsx
@@ -9,10 +9,19 @@ import { Button } from './button';
 import { Input } from './input';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 
+export interface OptionMultiSelectOption {
+  value: string;
+  label?: string;
+  description?: string;
+}
+
 interface OptionMultiSelectProps {
-  label: string;
+  /** Prefix label rendered before the trigger, e.g. "Columns:". Omit when the field already has an external label (e.g. via a wrapping <FieldWrapper>). */
+  label?: string;
+  /** Accessible label for the trigger button when the visible label is rendered externally. */
+  ariaLabel?: string;
   triggerText: string;
-  options: string[];
+  options: OptionMultiSelectOption[];
   selectedOptionIds: Set<string> | null;
   onToggleOption: (optionId: string) => void;
   onSelectAllOptions: () => void;
@@ -22,10 +31,19 @@ interface OptionMultiSelectProps {
   noneSelectedText?: string;
   maxVisibleBadges?: number;
   showSelectedBadges?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  /** Render option labels in a monospace font, e.g. for raw field/column identifiers. Defaults to true. */
+  monospaceLabels?: boolean;
+}
+
+function optionLabel(option: OptionMultiSelectOption): string {
+  return option.label ?? option.value;
 }
 
 export function OptionMultiSelect({
   label,
+  ariaLabel,
   triggerText,
   options,
   selectedOptionIds,
@@ -37,13 +55,20 @@ export function OptionMultiSelect({
   noneSelectedText = 'None selected',
   maxVisibleBadges = 6,
   showSelectedBadges = true,
+  className,
+  triggerClassName,
+  monospaceLabels = true,
 }: OptionMultiSelectProps) {
   const [search, setSearch] = useState('');
 
-  const isSelected = (option: string): boolean =>
-    selectedOptionIds ? selectedOptionIds.has(option) : true;
+  const isSelected = (value: string): boolean =>
+    selectedOptionIds ? selectedOptionIds.has(value) : true;
 
-  const selectedOptions = useMemo(() => options.filter(isSelected), [options, selectedOptionIds]);
+  const selectedOptions = useMemo(
+    () =>
+      options.filter(option => (selectedOptionIds ? selectedOptionIds.has(option.value) : true)),
+    [options, selectedOptionIds]
+  );
   const visibleSelectedOptions = selectedOptions.slice(0, maxVisibleBadges);
   const hiddenSelectedCount = Math.max(0, selectedOptions.length - visibleSelectedOptions.length);
 
@@ -52,12 +77,20 @@ export function OptionMultiSelect({
       return options;
     }
     const needle = search.toLowerCase();
-    return options.filter(option => option.toLowerCase().includes(needle));
+    return options.filter(option =>
+      `${optionLabel(option)} ${option.description ?? ''}`.toLowerCase().includes(needle)
+    );
   }, [options, search]);
 
   return (
-    <div className="flex items-center gap-1 px-3 py-1.5 border-t border-border/50">
-      <span className="text-xs text-muted-foreground shrink-0 mr-1">{label}:</span>
+    <div
+      className={cn(
+        'flex items-center gap-1',
+        label ? 'px-3 py-1.5 border-t border-border/50' : 'min-w-0',
+        className
+      )}
+    >
+      {label && <span className="text-xs text-muted-foreground shrink-0 mr-1">{label}:</span>}
       <Popover
         onOpenChange={open => {
           if (!open) {
@@ -70,13 +103,34 @@ export function OptionMultiSelect({
             variant="outline"
             size="sm"
             role="combobox"
-            className="h-7 min-w-36 justify-between gap-2 px-2 text-xs font-normal"
+            aria-label={ariaLabel ?? label}
+            className={cn(
+              'h-7 min-w-36 justify-between gap-2 px-2 text-xs font-normal',
+              triggerClassName
+            )}
           >
-            <span className="truncate">
+            <span className="flex-1 truncate text-left">
               {selectedOptions.length > 0
                 ? `${triggerText} (${selectedOptions.length})`
                 : triggerText}
             </span>
+            {selectedOptions.length > 0 && (
+              <span
+                role="button"
+                aria-label={`Clear ${ariaLabel ?? label ?? triggerText}`}
+                className="shrink-0 cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
+                onPointerDown={e => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+                onClick={e => {
+                  e.stopPropagation();
+                  onSelectNoOptions();
+                }}
+              >
+                <X className="size-3!" />
+              </span>
+            )}
             <ChevronDown className="text-muted-foreground shrink-0 opacity-70" />
           </Button>
         </PopoverTrigger>
@@ -87,6 +141,7 @@ export function OptionMultiSelect({
               type="search"
               className="h-7 pl-7 pr-2 text-xs md:text-xs"
               placeholder={searchPlaceholder}
+              aria-label={searchPlaceholder}
               value={search}
               onChange={e => setSearch(e.target.value)}
               autoFocus
@@ -114,17 +169,17 @@ export function OptionMultiSelect({
           </div>
           <div role="listbox" aria-multiselectable className="max-h-52 overflow-y-auto space-y-0.5">
             {filteredOptions.map(option => {
-              const checked = isSelected(option);
+              const checked = isSelected(option.value);
               return (
                 <button
-                  key={option}
+                  key={option.value}
                   type="button"
                   role="option"
                   aria-selected={checked}
                   data-state={checked ? 'checked' : 'unchecked'}
-                  onClick={() => onToggleOption(option)}
+                  onClick={() => onToggleOption(option.value)}
                   className={cn(
-                    'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1 text-xs font-mono outline-none',
+                    'relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm px-2 py-1 text-xs outline-none',
                     'transition-colors hover:bg-accent hover:text-accent-foreground',
                     'focus-visible:bg-accent focus-visible:text-accent-foreground'
                   )}
@@ -132,7 +187,7 @@ export function OptionMultiSelect({
                   <span
                     aria-hidden
                     className={cn(
-                      'flex size-3.5 shrink-0 items-center justify-center rounded-sm border transition-colors',
+                      'mt-0.5 flex size-3.5 shrink-0 items-center justify-center rounded-sm border transition-colors',
                       checked
                         ? 'bg-primary border-primary text-primary-foreground'
                         : 'border-input bg-background'
@@ -140,7 +195,16 @@ export function OptionMultiSelect({
                   >
                     {checked && <Check className="size-2.5" strokeWidth={3} />}
                   </span>
-                  <span className="truncate">{option}</span>
+                  <span className="min-w-0 flex-1 text-left">
+                    <span className={cn('block truncate', monospaceLabels && 'font-mono')}>
+                      {optionLabel(option)}
+                    </span>
+                    {option.description && (
+                      <span className="block truncate text-[10px] text-muted-foreground">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
                 </button>
               );
             })}
@@ -158,18 +222,21 @@ export function OptionMultiSelect({
             <div className="flex flex-wrap items-center gap-1">
               {visibleSelectedOptions.map(option => (
                 <Badge
-                  key={option}
+                  key={option.value}
                   variant="outline"
-                  className="px-1.5 py-0 font-mono text-data bg-primary/10 border-primary/40 hover:bg-primary/15"
+                  className={cn(
+                    'px-1.5 py-0 text-data bg-primary/10 border-primary/40 hover:bg-primary/15',
+                    monospaceLabels && 'font-mono'
+                  )}
                 >
-                  <span className="truncate">{option}</span>
+                  <span className="truncate">{optionLabel(option)}</span>
                   <button
                     type="button"
                     onClick={e => {
                       e.stopPropagation();
-                      onToggleOption(option);
+                      onToggleOption(option.value);
                     }}
-                    aria-label={`Remove ${option}`}
+                    aria-label={`Remove ${optionLabel(option)}`}
                     className="ml-0.5 rounded-sm opacity-70 hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer"
                   >
                     <X className="size-2.5" />

--- a/ui/packages/@quent/components/src/ui/option-multi-select.tsx
+++ b/ui/packages/@quent/components/src/ui/option-multi-select.tsx
@@ -182,7 +182,7 @@ export function OptionMultiSelect({
                   data-state={checked ? 'checked' : 'unchecked'}
                   onClick={() => onToggleOption(option.value)}
                   className={cn(
-                    'relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm px-2 py-1 text-xs outline-none',
+                    'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1 text-xs outline-none',
                     'transition-colors hover:bg-accent hover:text-accent-foreground',
                     'focus-visible:bg-accent focus-visible:text-accent-foreground'
                   )}

--- a/ui/packages/@quent/components/src/ui/option-multi-select.tsx
+++ b/ui/packages/@quent/components/src/ui/option-multi-select.tsx
@@ -82,6 +82,13 @@ export function OptionMultiSelect({
     );
   }, [options, search]);
 
+  const triggerLabel =
+    selectedOptions.length === 0
+      ? triggerText
+      : selectedOptions.length === 1
+        ? optionLabel(selectedOptions[0])
+        : `${selectedOptions.length} selected`;
+
   return (
     <div
       className={cn(
@@ -105,15 +112,11 @@ export function OptionMultiSelect({
             role="combobox"
             aria-label={ariaLabel ?? label}
             className={cn(
-              'h-7 min-w-36 justify-between gap-2 px-2 text-xs font-normal',
+              'h-7 min-w-36 justify-between gap-2 px-2 text-xs font-normal hover:bg-background hover:text-foreground',
               triggerClassName
             )}
           >
-            <span className="flex-1 truncate text-left">
-              {selectedOptions.length > 0
-                ? `${triggerText} (${selectedOptions.length})`
-                : triggerText}
-            </span>
+            <span className="flex-1 truncate text-left">{triggerLabel}</span>
             {selectedOptions.length > 0 && (
               <span
                 role="button"

--- a/ui/packages/@quent/components/src/ui/option-multi-select.tsx
+++ b/ui/packages/@quent/components/src/ui/option-multi-select.tsx
@@ -97,7 +97,7 @@ export function OptionMultiSelect({
         className
       )}
     >
-      {label && <span className="text-xs text-muted-foreground shrink-0 mr-1">{label}:</span>}
+      {label && <label className="text-xs text-muted-foreground shrink-0 mr-1">{label}:</label>}
       <Popover
         onOpenChange={open => {
           if (!open) {

--- a/ui/packages/@quent/components/src/ui/searchable-select.tsx
+++ b/ui/packages/@quent/components/src/ui/searchable-select.tsx
@@ -43,7 +43,9 @@ export function SearchableSelect({
       return options;
     }
     return options.filter(option =>
-      `${option.label ?? option.value} ${option.value}`.toLowerCase().includes(needle)
+      `${option.label ?? option.value} ${option.value} ${option.description ?? ''}`
+        .toLowerCase()
+        .includes(needle)
     );
   }, [options, search]);
 
@@ -120,6 +122,7 @@ export function SearchableSelect({
               <Option
                 key={option.value}
                 label={option.label ?? option.value}
+                description={option.description}
                 selected={option.value === value}
                 onSelect={() => select(option.value)}
               />
@@ -136,10 +139,12 @@ export function SearchableSelect({
 
 function Option({
   label,
+  description,
   selected,
   onSelect,
 }: {
   label: string;
+  description?: string;
   selected: boolean;
   onSelect: () => void;
 }) {
@@ -150,13 +155,18 @@ function Option({
       aria-selected={selected}
       onClick={onSelect}
       className={cn(
-        'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1 text-xs outline-none',
+        'relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm px-2 py-1 text-xs outline-none',
         'transition-colors hover:bg-accent hover:text-accent-foreground',
         'focus-visible:bg-accent focus-visible:text-accent-foreground'
       )}
     >
-      <Check className={cn('size-3.5 shrink-0', !selected && 'opacity-0')} />
-      <span className="truncate">{label}</span>
+      <Check className={cn('mt-0.5 size-3.5 shrink-0', !selected && 'opacity-0')} />
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block truncate">{label}</span>
+        {description && (
+          <span className="block truncate text-[10px] text-muted-foreground">{description}</span>
+        )}
+      </span>
     </button>
   );
 }

--- a/ui/packages/@quent/components/src/ui/searchable-select.tsx
+++ b/ui/packages/@quent/components/src/ui/searchable-select.tsx
@@ -79,13 +79,30 @@ export function SearchableSelect({
             aria-label={accessibleLabel}
             aria-expanded={open}
             className={cn(
-              'h-8 min-w-0 flex-1 justify-between gap-2 px-2 font-normal',
+              'h-8 min-w-0 flex-1 justify-between gap-2 px-2 font-normal hover:bg-background hover:text-foreground',
               triggerClassName
             )}
           >
-            <span className="truncate text-xs">
+            <span className="flex-1 truncate text-left text-xs">
               {selected?.label ?? selected?.value ?? placeholder}
             </span>
+            {value !== null && (
+              <span
+                role="button"
+                aria-label={`Clear ${accessibleLabel ?? 'selection'}`}
+                className="shrink-0 cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
+                onPointerDown={e => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+                onClick={e => {
+                  e.stopPropagation();
+                  select(null);
+                }}
+              >
+                <X className="size-3!" />
+              </span>
+            )}
             <ChevronDown className="size-3.5 shrink-0 opacity-70" />
           </Button>
         </PopoverTrigger>

--- a/ui/packages/@quent/components/src/ui/select-field.tsx
+++ b/ui/packages/@quent/components/src/ui/select-field.tsx
@@ -16,6 +16,8 @@ import { ScrollArea } from './scroll-area';
 export interface SelectFieldOption {
   value: string;
   label?: string;
+  /** Optional secondary text */
+  description?: string;
 }
 
 export interface SelectFieldProps {

--- a/ui/src/components/entities-table/EntitiesTable.test.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.test.tsx
@@ -173,7 +173,9 @@ describe('EntitiesTable', () => {
     renderTable(<EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={queryBundle} />);
 
     fireEvent.click(screen.getByRole('combobox', { name: 'Operator' }));
-    fireEvent.change(screen.getByLabelText('Search operator'), { target: { value: 'one' } });
+    fireEvent.change(screen.getByPlaceholderText('Search operators…'), {
+      target: { value: 'one' },
+    });
     fireEvent.click(screen.getByRole('option', { name: 'Operator One' }));
 
     expect(screen.getByText('1 active filter')).toBeInTheDocument();
@@ -182,6 +184,41 @@ describe('EntitiesTable', () => {
 
     const params = useEntities.mock.lastCall?.[0];
     expect(params.request.entry.application.operator_ids).toEqual([]);
+  });
+
+  it('supports selecting multiple operators from the dropdown', () => {
+    const multiOperatorQueryBundle = {
+      ...queryBundle,
+      entities: {
+        ...queryBundle.entities,
+        operators: {
+          ...queryBundle.entities.operators,
+          'operator-2': {
+            id: 'operator-2',
+            instance_name: 'Operator Two',
+            operator_type_name: 'Filter',
+          },
+        },
+      },
+    } as unknown as QueryBundle<EntityRef>;
+
+    renderTable(
+      <EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={multiOperatorQueryBundle} />
+    );
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Operator' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Operator One' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Operator Two' }));
+    act(() => vi.advanceTimersByTime(300));
+
+    const params = useEntities.mock.lastCall?.[0];
+    expect(params.request.entry.application.operator_ids).toEqual(
+      expect.arrayContaining(['operator-1', 'operator-2'])
+    );
+    expect(params.request.entry.application.operator_ids).toHaveLength(2);
+    expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent(
+      'All operators (2)'
+    );
   });
 
   it('shows empty state when the response contains no entities', () => {
@@ -244,6 +281,8 @@ describe('EntitiesTable', () => {
 
     const params = useEntities.mock.lastCall?.[0];
     expect(params.request.entry.application.operator_ids).toEqual(['operator-1']);
-    expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent('Operator One');
+    expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent(
+      'All operators (1)'
+    );
   });
 });

--- a/ui/src/components/entities-table/EntitiesTable.test.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.test.tsx
@@ -216,9 +216,7 @@ describe('EntitiesTable', () => {
       expect.arrayContaining(['operator-1', 'operator-2'])
     );
     expect(params.request.entry.application.operator_ids).toHaveLength(2);
-    expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent(
-      'All operators (2)'
-    );
+    expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent('2 selected');
   });
 
   it('shows empty state when the response contains no entities', () => {
@@ -281,8 +279,6 @@ describe('EntitiesTable', () => {
 
     const params = useEntities.mock.lastCall?.[0];
     expect(params.request.entry.application.operator_ids).toEqual(['operator-1']);
-    expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent(
-      'All operators (1)'
-    );
+    expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent('Operator One');
   });
 });

--- a/ui/src/components/entities-table/EntitiesTable.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.tsx
@@ -40,7 +40,7 @@ export function EntitiesTable(props: EntitiesTableProps) {
             filters={table.filters.values}
             durationS={table.filters.durationS}
             windowMaxS={table.filters.windowMaxS}
-            operatorId={table.filters.operatorId}
+            operatorIds={table.filters.operatorIds}
             operatorOptions={table.filters.operatorOptions}
             entityTypeOptions={table.filters.entityTypeOptions}
             resourceOptions={table.filters.resourceOptions}
@@ -48,7 +48,9 @@ export function EntitiesTable(props: EntitiesTableProps) {
             hasNonDefaultSettings={table.filters.hasNonDefaultSettings}
             validationErrors={table.filters.validationErrors}
             invalidFilterFields={table.filters.invalidFilterFields}
-            onOperatorChange={table.filters.updateOperator}
+            onToggleOperator={table.filters.toggleOperator}
+            onSelectAllOperators={table.filters.selectAllOperators}
+            onSelectNoOperators={table.filters.selectNoOperators}
             onFiltersChange={table.filters.update}
             onReset={table.filters.reset}
           />

--- a/ui/src/components/entities-table/EntitiesToolbar.tsx
+++ b/ui/src/components/entities-table/EntitiesToolbar.tsx
@@ -4,10 +4,12 @@
 import { RotateCcw } from 'lucide-react';
 import {
   Button,
+  OptionMultiSelect,
   RangeSliderField,
   SearchableSelect,
   SelectField,
   SliderField,
+  type OptionMultiSelectOption,
   type SelectFieldOption,
 } from '@quent/components';
 import { cn } from '@quent/utils';
@@ -20,15 +22,17 @@ interface EntitiesToolbarProps {
   filters: EntityFilters;
   durationS: number;
   windowMaxS: number;
-  operatorId: string | null;
-  operatorOptions: SelectFieldOption[];
+  operatorIds: ReadonlySet<string>;
+  operatorOptions: OptionMultiSelectOption[];
   entityTypeOptions: SelectFieldOption[];
   resourceOptions: SelectFieldOption[];
   activeFilterCount: number;
   hasNonDefaultSettings: boolean;
   validationErrors: string[];
   invalidFilterFields: Set<EntityNumberFilterField>;
-  onOperatorChange: (value: string | null) => void;
+  onToggleOperator: (value: string) => void;
+  onSelectAllOperators: () => void;
+  onSelectNoOperators: () => void;
   onFiltersChange: (
     patch: Partial<EntityFilters>,
     options?: { preserveSelection?: boolean }
@@ -40,7 +44,7 @@ export function EntitiesToolbar({
   filters,
   durationS,
   windowMaxS,
-  operatorId,
+  operatorIds,
   operatorOptions,
   entityTypeOptions,
   resourceOptions,
@@ -48,7 +52,9 @@ export function EntitiesToolbar({
   hasNonDefaultSettings,
   validationErrors,
   invalidFilterFields,
-  onOperatorChange,
+  onToggleOperator,
+  onSelectAllOperators,
+  onSelectNoOperators,
   onFiltersChange,
   onReset,
 }: EntitiesToolbarProps) {
@@ -60,12 +66,19 @@ export function EntitiesToolbar({
         {/* Filters */}
         <div className="flex flex-wrap items-end gap-x-3 gap-y-3">
           <FieldWrapper label="Operator" className="w-64">
-            <SearchableSelect
+            <OptionMultiSelect
               ariaLabel="Operator"
-              placeholder="All operators"
+              triggerText="All operators"
               options={operatorOptions}
-              value={operatorId}
-              onValueChange={onOperatorChange}
+              selectedOptionIds={new Set(operatorIds)}
+              onToggleOption={onToggleOperator}
+              onSelectAllOptions={onSelectAllOperators}
+              onSelectNoOptions={onSelectNoOperators}
+              searchPlaceholder="Search operators…"
+              emptyMessage="No operators found"
+              showSelectedBadges={false}
+              monospaceLabels={false}
+              triggerClassName="h-8 w-full"
             />
           </FieldWrapper>
           <FieldWrapper label="Type" className="w-36">

--- a/ui/src/components/entities-table/EntitiesToolbar.tsx
+++ b/ui/src/components/entities-table/EntitiesToolbar.tsx
@@ -77,7 +77,6 @@ export function EntitiesToolbar({
               searchPlaceholder="Search operators…"
               emptyMessage="No operators found"
               showSelectedBadges={false}
-              monospaceLabels={false}
               triggerClassName="h-8 w-full"
             />
           </FieldWrapper>

--- a/ui/src/components/entities-table/useEntityTable.ts
+++ b/ui/src/components/entities-table/useEntityTable.ts
@@ -21,6 +21,7 @@ import {
   hasNonDefaultEntitySettings,
   normalizePageSize,
   operatorLocationDescription,
+  resourceLocationDescription,
   selectedOperatorsLabel,
   validateEntityFilters,
 } from './utils';
@@ -156,9 +157,14 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
         .map(resource => ({
           value: resource.id,
           label: `${resource.instance_name} (${resource.type_name})`,
+          description: resourceLocationDescription(
+            resource,
+            entities.resource_groups,
+            entities.workers
+          ),
         }))
         .sort((a, b) => a.label.localeCompare(b.label)),
-    [entities.resources]
+    [entities.resources, entities.resource_groups, entities.workers]
   );
   const resourceLabel = useCallback(
     (id: string) => {

--- a/ui/src/components/entities-table/useEntityTable.ts
+++ b/ui/src/components/entities-table/useEntityTable.ts
@@ -16,6 +16,7 @@ import {
   fsmSpan,
   hasNonDefaultEntitySettings,
   normalizePageSize,
+  operatorLocationDescription,
   validateEntityFilters,
 } from './utils';
 
@@ -109,9 +110,10 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
         .map(operator => ({
           value: operator.id,
           label: operator.instance_name ?? operator.operator_type_name ?? operator.id,
+          description: operatorLocationDescription(operator, entities.plans, entities.workers),
         }))
         .sort((a, b) => a.label.localeCompare(b.label)),
-    [entities.operators]
+    [entities.operators, entities.plans, entities.workers]
   );
   const entityTypeOptions = useMemo<SelectFieldOption[]>(
     () =>

--- a/ui/src/components/entities-table/useEntityTable.ts
+++ b/ui/src/components/entities-table/useEntityTable.ts
@@ -3,8 +3,12 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useEntities, useEntityList } from '@quent/client';
-import { useSelectedNodeIds } from '@quent/hooks';
-import type { SelectFieldOption } from '@quent/components';
+import {
+  useSelectedNodeIds,
+  useSetSelectedNodeIds,
+  useSetSelectedOperatorLabel,
+} from '@quent/hooks';
+import type { OptionMultiSelectOption, SelectFieldOption } from '@quent/components';
 import type { EntityRef, FiniteStateMachine, QueryBundle, SortDir } from '@quent/utils';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import type { EntityFilters } from './types';
@@ -17,6 +21,7 @@ import {
   hasNonDefaultEntitySettings,
   normalizePageSize,
   operatorLocationDescription,
+  selectedOperatorsLabel,
   validateEntityFilters,
 } from './utils';
 
@@ -28,15 +33,11 @@ interface UseEntityTableParams {
   queryBundle: QueryBundle<EntityRef>;
 }
 
-interface ManualOperatorOverride {
-  dagOperatorId: string | null;
-  value: string | null;
-}
-
 export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTableParams) {
   const { entities, duration_s: durationS } = queryBundle;
-  const selectedNodeIds = useSelectedNodeIds();
-  const dagOperatorId = selectedNodeIds.values().next().value ?? null;
+  const operatorIds = useSelectedNodeIds();
+  const setSelectedNodeIds = useSetSelectedNodeIds();
+  const setSelectedOperatorLabel = useSetSelectedOperatorLabel();
   const defaults = useMemo(() => defaultEntityFilters(durationS), [durationS]);
   // The "Window (s)" slider is bounded by the query duration, which is often far longer than
   // when entities actually occur. Use the longest-running entity's end time as a tighter,
@@ -57,20 +58,22 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
     return Math.min(durationS, Math.max(0, fsmSpan(longestEntity).end));
   }, [longestEntityQuery.data, durationS]);
   const [filters, setFilters] = useState<EntityFilters>(() => defaultEntityFilters(durationS));
-  const [manualOperatorOverride, setManualOperatorOverride] =
-    useState<ManualOperatorOverride | null>(null);
   const [page, setPage] = useState(0);
   const [selected, setSelected] = useState<FiniteStateMachine | null>(null);
-  const operatorId =
-    manualOperatorOverride?.dagOperatorId === dagOperatorId
-      ? manualOperatorOverride.value
-      : dagOperatorId;
+  const operatorLabel = useCallback(
+    (id: string) => {
+      const operator = entities.operators[id];
+      return operator ? (operator.instance_name ?? operator.operator_type_name ?? id) : id;
+    },
+    [entities.operators]
+  );
 
+  // Reset pagination/selection whenever the operator filter changes, regardless of whether
+  // it came from this toolbar or another crossfiltered view (DAG, operator swimlanes, etc).
   useEffect(() => {
-    setManualOperatorOverride(null);
     setPage(0);
     setSelected(null);
-  }, [dagOperatorId]);
+  }, [operatorIds]);
 
   const updateFilters = useCallback(
     (patch: Partial<EntityFilters>, options?: { preserveSelection?: boolean }) => {
@@ -88,23 +91,48 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
     setPage(0);
   }, []);
 
-  const updateOperator = useCallback(
-    (value: string | null) => {
-      setManualOperatorOverride({ dagOperatorId, value });
+  const applyOperatorSelection = useCallback(
+    (nextIds: Set<string>) => {
+      setSelectedNodeIds(nextIds);
+      setSelectedOperatorLabel(selectedOperatorsLabel(nextIds, operatorLabel));
       setPage(0);
       setSelected(null);
     },
-    [dagOperatorId]
+    [operatorLabel, setSelectedNodeIds, setSelectedOperatorLabel]
+  );
+
+  const toggleOperator = useCallback(
+    (value: string) => {
+      const next = new Set(operatorIds);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        next.add(value);
+      }
+      applyOperatorSelection(next);
+    },
+    [applyOperatorSelection, operatorIds]
+  );
+
+  const selectAllOperators = useCallback(
+    () => applyOperatorSelection(new Set(Object.keys(entities.operators))),
+    [applyOperatorSelection, entities.operators]
+  );
+
+  const selectNoOperators = useCallback(
+    () => applyOperatorSelection(new Set()),
+    [applyOperatorSelection]
   );
 
   const resetFilters = useCallback(() => {
     setFilters(defaults);
-    setManualOperatorOverride({ dagOperatorId, value: null });
+    setSelectedNodeIds(new Set());
+    setSelectedOperatorLabel(null);
     setPage(0);
     setSelected(null);
-  }, [dagOperatorId, defaults]);
+  }, [defaults, setSelectedNodeIds, setSelectedOperatorLabel]);
 
-  const operatorOptions = useMemo<SelectFieldOption[]>(
+  const operatorOptions = useMemo<OptionMultiSelectOption[]>(
     () =>
       Object.values(entities.operators)
         .map(operator => ({
@@ -112,7 +140,7 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
           label: operator.instance_name ?? operator.operator_type_name ?? operator.id,
           description: operatorLocationDescription(operator, entities.plans, entities.workers),
         }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
+        .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? '')),
     [entities.operators, entities.plans, entities.workers]
   );
   const entityTypeOptions = useMemo<SelectFieldOption[]>(
@@ -139,14 +167,6 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
     },
     [entities.resources]
   );
-  const operatorLabel = useCallback(
-    (id: string) => {
-      const operator = entities.operators[id];
-      return operator ? (operator.instance_name ?? operator.operator_type_name ?? id) : id;
-    },
-    [entities.operators]
-  );
-
   const { errors: validationErrors, invalidFields: invalidFilterFields } = useMemo(
     () => validateEntityFilters(filters),
     [filters]
@@ -166,8 +186,8 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
     [filters, debouncedMinUsageS, debouncedWindowStart, debouncedWindowEnd]
   );
   const request = useMemo(
-    () => buildEntityRequest({ filters: effectiveFilters, operatorId, page, queryId, durationS }),
-    [durationS, effectiveFilters, operatorId, page, queryId]
+    () => buildEntityRequest({ filters: effectiveFilters, operatorIds, page, queryId, durationS }),
+    [durationS, effectiveFilters, operatorIds, page, queryId]
   );
   const query = useEntities({ engineId, request }, { enabled: validationErrors.length === 0 });
   const requestPending = query.isFetching;
@@ -177,7 +197,7 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
   const pageCount = Math.max(1, Math.ceil(total / pageSize));
   const visibleStart = total === 0 ? 0 : page * pageSize + 1;
   const visibleEnd = total === 0 ? 0 : Math.min(total, visibleStart + rows.length - 1);
-  const activeFilterCount = activeEntityFilterCount(filters, defaults, operatorId);
+  const activeFilterCount = activeEntityFilterCount(filters, defaults, operatorIds);
 
   return {
     filters: {
@@ -188,12 +208,14 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
       invalidFilterFields,
       hasNonDefaultSettings: hasNonDefaultEntitySettings(filters, defaults, activeFilterCount),
       activeFilterCount,
-      operatorId,
+      operatorIds,
       operatorOptions,
       entityTypeOptions,
       resourceOptions,
       update: updateFilters,
-      updateOperator,
+      toggleOperator,
+      selectAllOperators,
+      selectNoOperators,
       updateSortDir,
       reset: resetFilters,
     },

--- a/ui/src/components/entities-table/utils.ts
+++ b/ui/src/components/entities-table/utils.ts
@@ -9,6 +9,8 @@ import type {
   OperatorFilter,
   Plan,
   QueryFilter,
+  Resource,
+  ResourceGroup,
   SortDir,
   Worker,
 } from '@quent/utils';
@@ -193,6 +195,24 @@ export function operatorLocationDescription(
   const worker = plan.worker_id ? workers[plan.worker_id] : undefined;
   const workerLabel = worker ? (worker.instance_name ?? worker.id) : null;
   return workerLabel ? `Plan: ${planLabel} · Worker: ${workerLabel}` : `Plan: ${planLabel}`;
+}
+
+export function resourceLocationDescription(
+  resource: Resource,
+  resourceGroups: Record<string, ResourceGroup>,
+  workers: Record<string, Worker>
+): string | undefined {
+  const visited = new Set<string>();
+  let groupId: string | null = resource.parent_group_id;
+  while (groupId && !visited.has(groupId)) {
+    visited.add(groupId);
+    const worker = workers[groupId];
+    if (worker) {
+      return `Worker: ${worker.instance_name ?? worker.id}`;
+    }
+    groupId = resourceGroups[groupId]?.parent_group_id ?? null;
+  }
+  return undefined;
 }
 
 export function fsmSpan(fsm: FiniteStateMachine): { start: number; end: number } {

--- a/ui/src/components/entities-table/utils.ts
+++ b/ui/src/components/entities-table/utils.ts
@@ -5,9 +5,12 @@ import type {
   EntityListRequest,
   EntityListResponse,
   FiniteStateMachine,
+  Operator,
   OperatorFilter,
+  Plan,
   QueryFilter,
   SortDir,
+  Worker,
 } from '@quent/utils';
 import type { EntityFilters, EntityTableRow } from './types';
 
@@ -160,6 +163,22 @@ export function parseOptionalNumber(value: string): number | null {
   }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Builds a "Plan / Worker" subtitle so operators sharing the same name can be told apart. */
+export function operatorLocationDescription(
+  operator: Operator,
+  plans: Record<string, Plan>,
+  workers: Record<string, Worker>
+): string | undefined {
+  const plan = operator.plan_id ? plans[operator.plan_id] : undefined;
+  if (!plan) {
+    return undefined;
+  }
+  const planLabel = plan.instance_name ?? plan.id;
+  const worker = plan.worker_id ? workers[plan.worker_id] : undefined;
+  const workerLabel = worker ? (worker.instance_name ?? worker.id) : null;
+  return workerLabel ? `Plan: ${planLabel} · Worker: ${workerLabel}` : `Plan: ${planLabel}`;
 }
 
 export function fsmSpan(fsm: FiniteStateMachine): { start: number; end: number } {

--- a/ui/src/components/entities-table/utils.ts
+++ b/ui/src/components/entities-table/utils.ts
@@ -88,13 +88,13 @@ export function validateEntityFilters(filters: EntityFilters): EntityFilterValid
 
 export function buildEntityRequest({
   filters,
-  operatorId,
+  operatorIds,
   page,
   queryId,
   durationS,
 }: {
   filters: EntityFilters;
-  operatorId: string | null;
+  operatorIds: ReadonlySet<string>;
   page: number;
   queryId: string;
   durationS: number;
@@ -112,7 +112,7 @@ export function buildEntityRequest({
       },
       sort: { key: 'UsageDuration', dir: filters.sortDir },
       page: { max: normalizePageSize(filters.pageSize), page },
-      application: { operator_ids: operatorId != null ? [operatorId] : [] },
+      application: { operator_ids: [...operatorIds] },
     },
     app_params: { query_id: queryId },
   };
@@ -133,10 +133,10 @@ function numericFilterValueChanged(value: string, defaultValue: string): boolean
 export function activeEntityFilterCount(
   filters: EntityFilters,
   defaults: EntityFilters,
-  operatorId: string | null
+  operatorIds: ReadonlySet<string>
 ): number {
   return [
-    operatorId !== null,
+    operatorIds.size > 0,
     filters.entityType !== null,
     filters.resourceId !== null,
     filters.minUsageS !== '',
@@ -163,6 +163,20 @@ export function parseOptionalNumber(value: string): number | null {
   }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Builds the crossfilter chip label (e.g. shown in QueryToolbar) for a set of selected operators. */
+export function selectedOperatorsLabel(
+  operatorIds: ReadonlySet<string>,
+  operatorLabel: (id: string) => string
+): string | null {
+  if (operatorIds.size === 0) {
+    return null;
+  }
+  if (operatorIds.size === 1) {
+    return operatorLabel([...operatorIds][0]);
+  }
+  return `${operatorIds.size} operators`;
 }
 
 /** Builds a "Plan / Worker" subtitle so operators sharing the same name can be told apart. */

--- a/ui/src/components/entities-table/utils.ts
+++ b/ui/src/components/entities-table/utils.ts
@@ -197,6 +197,7 @@ export function operatorLocationDescription(
   return workerLabel ? `Plan: ${planLabel} · Worker: ${workerLabel}` : `Plan: ${planLabel}`;
 }
 
+/** Builds a "Worker" subtitle so resources sharing the same name across workers can be told apart. */
 export function resourceLocationDescription(
   resource: Resource,
   resourceGroups: Record<string, ResourceGroup>,


### PR DESCRIPTION
# Description

1. Adds context to each value in the "Operator" and "Resource" dropdowns (in the Entities tab). Previously, just the operator/resource name was shown, and it was impossible to distinguish options with the same name; now, plan (operator dropdown only) and worker information has been added to each option, allowing users to differentiate.
2. Ties in global operator filtering in with the Entities table. Now any selections made within the "Operator" dropdown on the Entities tab will be reflected in the DAG, timelines, pivot table, etc
3. Changes the Operator dropdown to use a multi-select, in order to choose multiple operators (and support multiple operator filters applied elsewhere in the app).
4. Small UI fixes - aligns field styles more closely with those from Query Plan Settings section, including adding the clear buttons where necessary, matching hover styles, and icon size tweaks.



## Testing

1. Go to Entities tab, open "Operator" searchable select dropdown
2. Ensure `plan` and `worker` information has been added in the new `description` field
3. Use the search bar to narrow down the list by one of the new fields in the `description`
4. Check the Resource dropdown, you should see a description added there as well
5. Select multiple operators from list; ensure this crossfilters all relevant components
6. Click to filter by operator(s) elsewhere in the app; ensure this also filters the entities tab 

## Screenshots

Dropdown changes:

https://github.com/user-attachments/assets/3e901e53-d191-4f13-bd9d-3c8011fb5f99

Operator crossfiltering:

https://github.com/user-attachments/assets/2401bebf-4ad5-47ec-9343-6863623f7aea