### PR TITLE
feat(schema,vibe): improve schema explorer workspace

### DIFF
--- a/experimental/vibe/ui/pnpm-lock.yaml
+++ b/experimental/vibe/ui/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
+      paneforge:
+        specifier: 1.0.2
+        version: 1.0.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       svelte:
         specifier: 'catalog:'
         version: 5.56.8(@typescript-eslint/types@8.66.0)
@@ -900,6 +903,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1029,6 +1033,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1286,6 +1293,11 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  paneforge@1.0.2:
+    resolution: {integrity: sha512-KzmIXQH1wCfwZ4RsMohD/IUtEjVhteR+c+ulb/CHYJHX8SuDXoJmChtsc/Xs5Wl8NHS4L5Q7cxL8MG40gSU1bA==}
+    peerDependencies:
+      svelte: ^5.29.0
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1340,6 +1352,16 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  runed@0.23.4:
+    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  runed@0.29.2:
+    resolution: {integrity: sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -1381,6 +1403,9 @@ packages:
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1392,6 +1417,12 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: ^5.0.0 || ^6.0.0
+
+  svelte-toolbelt@0.9.3:
+    resolution: {integrity: sha512-HCSWxCtVmv+c6g1ACb8LTwHVbDqLKJvHpo6J8TaqwUme2hj9ATJCpjCPNISR1OCq2Q4U1KT41if9ON0isINQZw==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.30.2
 
   svelte@5.56.8:
     resolution: {integrity: sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==}
@@ -2509,6 +2540,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2721,6 +2754,12 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  paneforge@1.0.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)):
+    dependencies:
+      runed: 0.23.4(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+      svelte: 5.56.8(@typescript-eslint/types@8.66.0)
+      svelte-toolbelt: 0.9.3(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -2776,6 +2815,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  runed@0.23.4(svelte@5.56.8(@typescript-eslint/types@8.66.0)):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.56.8(@typescript-eslint/types@8.66.0)
+
+  runed@0.29.2(svelte@5.56.8(@typescript-eslint/types@8.66.0)):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.56.8(@typescript-eslint/types@8.66.0)
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -2804,6 +2853,10 @@ snapshots:
 
   style-mod@4.1.3: {}
 
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -2820,6 +2873,13 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-toolbelt@0.9.3(svelte@5.56.8(@typescript-eslint/types@8.66.0)):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.29.2(svelte@5.56.8(@typescript-eslint/types@8.66.0))
+      style-to-object: 1.0.14
+      svelte: 5.56.8(@typescript-eslint/types@8.66.0)
 
   svelte@5.56.8(@typescript-eslint/types@8.66.0):
     dependencies:

--- a/experimental/vibe/ui/schema-explorer/README.md
+++ b/experimental/vibe/ui/schema-explorer/README.md
@@ -16,6 +16,18 @@ pixi run --frozen pnpm --dir experimental/vibe/ui explorer
 
 Open the local URL printed by Vite, normally `http://localhost:5173`.
 
+## Example links
+
+Open a built-in model directly with the `example` query parameter, for example:
+
+```text
+https://rapidsai.github.io/quent/?example=dynamo-inference
+```
+
+Available values are `simple`, `hello`, `dynamo-inference`, `simulator`, and
+`sirius`. Selecting another example updates the current URL without reloading
+the page.
+
 ## YAML WebAssembly
 
 The editor parses YAML through a browser build of `quent-yaml`. Regenerate the

--- a/experimental/vibe/ui/schema-explorer/package.json
+++ b/experimental/vibe/ui/schema-explorer/package.json
@@ -18,6 +18,7 @@
     "@codemirror/view": "^6.43.6",
     "@quent/schema-viewer": "workspace:*",
     "codemirror": "^6.0.2",
+    "paneforge": "1.0.2",
     "svelte": "catalog:"
   },
   "devDependencies": {

--- a/experimental/vibe/ui/schema-explorer/src/App.svelte
+++ b/experimental/vibe/ui/schema-explorer/src/App.svelte
@@ -16,6 +16,12 @@
     type SchemaPath,
     type SchemaSelection,
   } from '@quent/schema-viewer';
+  import {
+    Pane,
+    PaneGroup,
+    PaneResizer,
+    type PaneAPI,
+  } from 'paneforge';
 
   import EntityNode from './EntityNode.svelte';
   import GraphConfigBar from './GraphConfigBar.svelte';
@@ -32,10 +38,16 @@
 
   type ModelSelectionId = ExampleModelId | 'loaded';
 
-  let modelId = $state<ModelSelectionId>('simple');
+  const initialModel =
+    yamlExampleModels.find(
+      ({ id }) =>
+        id === new URLSearchParams(window.location.search).get('example'),
+    ) ?? yamlExampleModels[0]!;
+
+  let modelId = $state<ModelSelectionId>(initialModel.id);
   let loadedFileName = $state<string | null>(null);
   let yamlFileInput = $state<HTMLInputElement | null>(null);
-  let yamlSource = $state(yamlExampleModels[0]!.source);
+  let yamlSource = $state(initialModel.source);
   let schema = $state<Schema | null>(null);
   let parserStatus = $state<'parsing' | 'valid' | 'invalid'>('parsing');
   let parserError = $state<string | null>(null);
@@ -43,6 +55,13 @@
   let hoverSelection = $state<SchemaSelection | null>(null);
   let breadcrumbPreview = $state<SchemaSelection | null>(null);
   let activeView = $state<EntityGraphView>('graph');
+  let graphExpanded = $state(false);
+  let editorCollapsed = $state(false);
+  let graphCollapsed = $state(false);
+  let selectionsCollapsed = $state(false);
+  let editorPane = $state<PaneAPI | null>(null);
+  let graphPane = $state<PaneAPI | null>(null);
+  let selectionsPane = $state<PaneAPI | null>(null);
   let config = $state<ResolvedEntityGraphConfig>({
     ...DEFAULT_ENTITY_GRAPH_CONFIG,
   });
@@ -161,6 +180,20 @@
     config = { ...config, [key]: value };
   }
 
+  function toggleGraphExpanded(): void {
+    graphExpanded = !graphExpanded;
+  }
+
+  function collapseGraphPane(): void {
+    graphPane?.collapse();
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && graphExpanded) {
+      graphExpanded = false;
+    }
+  }
+
   function changeModel(event: Event): void {
     const nextId = (event.currentTarget as HTMLSelectElement).value;
     const next = yamlExampleModels.find(
@@ -170,6 +203,7 @@
     modelId = next.id;
     loadedFileName = null;
     yamlSource = next.source;
+    setExampleUrl(next.id);
     selection = null;
     hoverSelection = null;
     breadcrumbPreview = null;
@@ -184,12 +218,23 @@
       yamlSource = await file.text();
       loadedFileName = file.name;
       modelId = 'loaded';
+      setExampleUrl(null);
       selection = null;
       hoverSelection = null;
       breadcrumbPreview = null;
     } finally {
       input.value = '';
     }
+  }
+
+  function setExampleUrl(example: ExampleModelId | null): void {
+    const url = new URL(window.location.href);
+    if (example) {
+      url.searchParams.set('example', example);
+    } else {
+      url.searchParams.delete('example');
+    }
+    window.history.replaceState(window.history.state, '', url);
   }
 
   function downloadYaml(): void {
@@ -218,177 +263,334 @@
   <title>Quent Schema Explorer</title>
 </svelte:head>
 
-<main class="grid h-dvh min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-3 overflow-hidden bg-base-200 p-4 text-base-content">
-  <header class="flex min-w-0 flex-wrap items-center gap-3">
-    <h1 class="truncate text-xl font-semibold">
-      Quent Schema Explorer
-    </h1>
-    <label class="flex shrink-0 items-center gap-2">
-      <span class="text-xs font-medium">Example</span>
-      <select
-        class="select select-bordered select-sm w-48"
-        value={modelId}
-        onchange={changeModel}
-      >
-        {#if loadedFileName}
-          <option value="loaded">{loadedFileName}</option>
-        {/if}
-        {#each yamlExampleModels as candidate}
-          <option value={candidate.id}>{candidate.label}</option>
-        {/each}
-      </select>
-    </label>
-    <input
-      class="hidden"
-      type="file"
-      accept=".yaml,.yml,application/yaml,text/yaml"
-      bind:this={yamlFileInput}
-      onchange={loadYamlFile}
-    />
-    <div class="join shrink-0">
-      <button
-        class="btn btn-sm join-item"
-        type="button"
-        onclick={() => yamlFileInput?.click()}
-      >
-        Load
-      </button>
-      <button
-        class="btn btn-sm join-item"
-        type="button"
-        aria-label="Download current YAML"
-        onclick={downloadYaml}
-      >
-        Save
-      </button>
-    </div>
-  </header>
+<svelte:window onkeydown={handleWindowKeydown} />
 
-  <div class="grid min-h-0 min-w-0 grid-cols-[minmax(18rem,min(42vw,80ch))_minmax(0,1fr)] gap-3 max-lg:grid-cols-1 max-lg:grid-rows-2">
+{#snippet graphWorkspace()}
+  <div
+    class={[
+      'grid h-full min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto]',
+      !graphExpanded && 'gap-3',
+    ]}
+  >
     <section
-      class="card card-border grid min-h-0 w-full max-w-[80ch] grid-rows-[auto_minmax(0,1fr)_8rem] overflow-hidden bg-base-100"
-      aria-label="Quent YAML editor"
+      class="card card-border min-h-0 overflow-hidden bg-base-100"
+      aria-label="Schema visualization"
     >
-      <div class="flex items-center justify-between gap-3 border-b border-base-300 px-3 py-2">
-        <strong class="text-sm">Schema YAML</strong>
-        <span
-          class={[
-            'badge badge-sm uppercase',
-            parserStatus === 'valid' && 'badge-success',
-            parserStatus === 'invalid' && 'badge-error',
-            parserStatus === 'parsing' && 'badge-ghost',
-          ].filter(Boolean).join(' ')}
-          data-state={parserStatus}
-        >
-          {parserStatus}
-        </span>
-      </div>
-      <YamlEditor bind:value={yamlSource} />
-      <div
-        class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] border-t border-base-300 bg-base-200/50"
-        aria-label="YAML errors"
-      >
-        <div class="flex items-center justify-between px-3 py-1.5">
-          <span class="text-xs font-medium">Errors</span>
-          {#if parserError}
-            <span class="badge badge-error badge-xs">1</span>
-          {/if}
-        </div>
-        {#if parserError}
-          <pre class="min-h-0 overflow-auto bg-error/10 px-3 py-2 font-mono text-xs whitespace-pre-wrap text-error" role="alert">{parserError}</pre>
-        {:else}
-          <p class="px-3 py-2 text-xs text-base-content/45">
-            {parserStatus === 'parsing' ? 'Checking YAML…' : 'No errors.'}
-          </p>
-        {/if}
+      <div class="schema-explorer-graph min-h-0 h-full overflow-hidden">
+        <quent-entity-graph
+          class="block h-full min-h-0"
+          {schema}
+          {selection}
+          {config}
+          nodeComponent={EntityNode}
+          onquent-hover={handleHover}
+          onquent-hover-end={handleHoverEnd}
+          onquent-select={handleSelection}
+          onquent-view-change={handleViewChange}
+        ></quent-entity-graph>
       </div>
     </section>
 
-    <div
-      class="grid min-h-0 min-w-0 grid-cols-[minmax(0,1fr)_minmax(28rem,34rem)] gap-3 max-xl:grid-cols-[minmax(0,1fr)_24rem]"
-      aria-label="Schema explorer"
-    >
-      <div class="grid min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto] gap-3">
-        <section
-          class="card card-border min-h-0 overflow-hidden bg-base-100"
-          aria-label="Schema visualization"
-        >
-          <div class="schema-explorer-graph min-h-0 h-full overflow-hidden">
-            <quent-entity-graph
-              class="block h-full min-h-0"
-              {schema}
-              {selection}
-              {config}
-              nodeComponent={EntityNode}
-              onquent-hover={handleHover}
-              onquent-hover-end={handleHoverEnd}
-              onquent-select={handleSelection}
-              onquent-view-change={handleViewChange}
-            ></quent-entity-graph>
-          </div>
-        </section>
-
-        {#if activeView === 'graph'}
-          <GraphConfigBar {config} onChange={setConfig} />
-        {/if}
-      </div>
-
-      <aside
-        class="card card-border grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden bg-base-100"
-        aria-label="Selections"
-        aria-live="polite"
+    {#if activeView === 'graph'}
+      <GraphConfigBar
+        {config}
+        expanded={graphExpanded}
+        onCollapse={graphExpanded ? undefined : collapseGraphPane}
+        onChange={setConfig}
+        onToggleExpanded={toggleGraphExpanded}
+      />
+    {:else}
+      <div
+        class="card card-border flex-row justify-end gap-2 bg-base-100 p-2"
+        aria-label="View pane controls"
       >
-        <header class="border-b border-base-300 px-3 py-2">
-          <h2 class="text-sm font-semibold">Selections</h2>
-        </header>
-        {#if tooltipSelection}
-          <SelectionBreadcrumbs
-            selection={tooltipSelection}
-            entityKind={selectedEntityKind}
-            onSelect={selectElement}
-            onPreview={previewBreadcrumb}
-            onPreviewEnd={endBreadcrumbPreview}
-          />
-        {:else}
-          <div></div>
+        {#if !graphExpanded}
+          <button
+            class="btn btn-xs btn-ghost"
+            type="button"
+            onclick={collapseGraphPane}
+          >Hide pane</button>
         {/if}
-        <div class="min-h-0 min-w-0 overflow-auto p-3">
-          {#if detailKind === 'fsm'}
-            <quent-fsm-details
-              {schema}
-              path={detailPath}
-              selection={paneSelection}
-              isolateState={isolateFsmState}
-              onquent-select={handleSelection}
-            ></quent-fsm-details>
-          {:else if detailKind === 'resource'}
-            <quent-resource-details
-              {schema}
-              path={detailPath}
-              selection={paneSelection}
-              onquent-select={handleSelection}
-            ></quent-resource-details>
-          {:else if detailKind === 'record'}
-            <quent-record-details
-              {schema}
-              path={detailPath}
-              selection={paneSelection}
-              onquent-select={handleSelection}
-            ></quent-record-details>
-          {:else if detailKind === 'events'}
-            <quent-entity-events
-              {schema}
-              path={detailPath}
-              selection={paneSelection}
-              onquent-select={handleSelection}
-            ></quent-entity-events>
-          {:else}
-            <p class="m-auto max-w-48 text-center text-sm text-base-content/50">
-              Select or hover over an element to inspect it.
-            </p>
-          {/if}
-        </div>
-      </aside>
-    </div>
+        <button
+          class="btn btn-xs"
+          type="button"
+          aria-pressed={graphExpanded}
+          onclick={toggleGraphExpanded}
+        >{graphExpanded ? 'Restore' : 'Expand view'}</button>
+      </div>
+    {/if}
   </div>
+{/snippet}
+
+<main
+  class={[
+    'grid h-dvh min-h-0 overflow-hidden bg-base-200 text-base-content',
+    graphExpanded
+      ? 'grid-rows-[minmax(0,1fr)]'
+      : 'grid-rows-[auto_minmax(0,1fr)] gap-3 p-4',
+  ]}
+>
+  {#if !graphExpanded}
+    <header class="flex min-w-0 flex-wrap items-center gap-3">
+      <h1 class="truncate text-xl font-semibold">
+        Quent Schema Explorer
+      </h1>
+      <label class="flex shrink-0 items-center gap-2">
+        <span class="text-xs font-medium">Example</span>
+        <select
+          class="select select-bordered select-sm w-48"
+          value={modelId}
+          onchange={changeModel}
+        >
+          {#if loadedFileName}
+            <option value="loaded">{loadedFileName}</option>
+          {/if}
+          {#each yamlExampleModels as candidate}
+            <option value={candidate.id}>{candidate.label}</option>
+          {/each}
+        </select>
+      </label>
+      <input
+        class="hidden"
+        type="file"
+        accept=".yaml,.yml,application/yaml,text/yaml"
+        bind:this={yamlFileInput}
+        onchange={loadYamlFile}
+      />
+      <div class="join shrink-0">
+        <button
+          class="btn btn-sm join-item"
+          type="button"
+          onclick={() => yamlFileInput?.click()}
+        >
+          Load
+        </button>
+        <button
+          class="btn btn-sm join-item"
+          type="button"
+          aria-label="Download current YAML"
+          onclick={downloadYaml}
+        >
+          Save
+        </button>
+      </div>
+    </header>
+  {/if}
+
+  {#if graphExpanded}
+    {@render graphWorkspace()}
+  {:else}
+    <PaneGroup
+      class="min-h-0 min-w-0"
+      direction="horizontal"
+      autoSaveId="quent-schema-explorer-main"
+    >
+      <Pane
+        id="yaml-pane"
+        bind:this={editorPane}
+        class="min-h-0 min-w-0"
+        defaultSize={32}
+        minSize={15}
+        maxSize={45}
+        collapsible
+        collapsedSize={3}
+        onCollapse={() => (editorCollapsed = true)}
+        onExpand={() => (editorCollapsed = false)}
+      >
+        {#if editorCollapsed}
+          <button
+            class="btn btn-ghost h-full min-h-0 w-full rounded-none px-0"
+            type="button"
+            aria-label="Expand YAML editor"
+            onclick={() => editorPane?.expand()}
+          >
+            <span class="rotate-180 text-xs [writing-mode:vertical-rl]">YAML</span>
+          </button>
+        {:else}
+          <section
+            class="card card-border grid h-full min-h-0 w-full max-w-[80ch] grid-rows-[auto_minmax(0,1fr)_8rem] overflow-hidden bg-base-100"
+            aria-label="Quent YAML editor"
+          >
+            <div class="flex items-center justify-between gap-3 border-b border-base-300 px-3 py-2">
+              <strong class="text-sm">Schema YAML</strong>
+              <div class="flex items-center gap-2">
+                <span
+                  class={[
+                    'badge badge-sm uppercase',
+                    parserStatus === 'valid' && 'badge-success',
+                    parserStatus === 'invalid' && 'badge-error',
+                    parserStatus === 'parsing' && 'badge-ghost',
+                  ].filter(Boolean).join(' ')}
+                  data-state={parserStatus}
+                >
+                  {parserStatus}
+                </span>
+                <button
+                  class="btn btn-xs btn-ghost"
+                  type="button"
+                  onclick={() => editorPane?.collapse()}
+                >Hide</button>
+              </div>
+            </div>
+            <YamlEditor bind:value={yamlSource} />
+            <div
+              class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] border-t border-base-300 bg-base-200/50"
+              aria-label="YAML errors"
+            >
+              <div class="flex items-center justify-between px-3 py-1.5">
+                <span class="text-xs font-medium">Errors</span>
+                {#if parserError}
+                  <span class="badge badge-error badge-xs">1</span>
+                {/if}
+              </div>
+              {#if parserError}
+                <pre class="min-h-0 overflow-auto bg-error/10 px-3 py-2 font-mono text-xs whitespace-pre-wrap text-error" role="alert">{parserError}</pre>
+              {:else}
+                <p class="px-3 py-2 text-xs text-base-content/45">
+                  {parserStatus === 'parsing' ? 'Checking YAML…' : 'No errors.'}
+                </p>
+              {/if}
+            </div>
+          </section>
+        {/if}
+      </Pane>
+
+      <PaneResizer
+        class="group flex w-3 shrink-0 items-center justify-center outline-none"
+        aria-label="Resize YAML and explorer panes"
+      >
+        <span class="pointer-events-none h-12 w-1 rounded-full bg-base-300 group-hover:bg-primary group-focus-visible:bg-primary group-data-[active=pointer]:bg-primary"></span>
+      </PaneResizer>
+
+      <Pane
+        id="explorer-pane"
+        class="min-h-0 min-w-0"
+        defaultSize={68}
+        minSize={30}
+      >
+        <PaneGroup
+          class="min-h-0 min-w-0"
+          direction="horizontal"
+          autoSaveId="quent-schema-explorer-details"
+        >
+          <Pane
+            id="graph-pane"
+            bind:this={graphPane}
+            class="min-h-0 min-w-0"
+            defaultSize={65}
+            minSize={25}
+            collapsible
+            collapsedSize={4}
+            onCollapse={() => (graphCollapsed = true)}
+            onExpand={() => (graphCollapsed = false)}
+          >
+            {#if graphCollapsed}
+              <button
+                class="btn btn-ghost h-full min-h-0 w-full rounded-none px-0"
+                type="button"
+                aria-label="Expand graph pane"
+                onclick={() => graphPane?.expand()}
+              >
+                <span class="rotate-180 text-xs [writing-mode:vertical-rl]">Explorer</span>
+              </button>
+            {:else}
+              {@render graphWorkspace()}
+            {/if}
+          </Pane>
+
+          <PaneResizer
+            class="group flex w-3 shrink-0 items-center justify-center outline-none"
+            aria-label="Resize graph and selections panes"
+          >
+            <span class="pointer-events-none h-12 w-1 rounded-full bg-base-300 group-hover:bg-primary group-focus-visible:bg-primary group-data-[active=pointer]:bg-primary"></span>
+          </PaneResizer>
+
+          <Pane
+            id="selections-pane"
+            bind:this={selectionsPane}
+            class="min-h-0 min-w-0"
+            defaultSize={35}
+            minSize={15}
+            collapsible
+            collapsedSize={4}
+            onCollapse={() => (selectionsCollapsed = true)}
+            onExpand={() => (selectionsCollapsed = false)}
+          >
+            {#if selectionsCollapsed}
+              <button
+                class="btn btn-ghost h-full min-h-0 w-full rounded-none px-0"
+                type="button"
+                aria-label="Expand selections pane"
+                onclick={() => selectionsPane?.expand()}
+              >
+                <span class="rotate-180 text-xs [writing-mode:vertical-rl]">Selections</span>
+              </button>
+            {:else}
+              <aside
+                class="card card-border grid h-full min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden bg-base-100"
+                aria-label="Selections"
+                aria-live="polite"
+              >
+                <header class="flex items-center justify-between gap-2 border-b border-base-300 px-3 py-2">
+                  <h2 class="text-sm font-semibold">Selections</h2>
+                  <button
+                    class="btn btn-xs btn-ghost"
+                    type="button"
+                    onclick={() => selectionsPane?.collapse()}
+                  >Hide</button>
+                </header>
+                {#if tooltipSelection}
+                  <SelectionBreadcrumbs
+                    selection={tooltipSelection}
+                    entityKind={selectedEntityKind}
+                    onSelect={selectElement}
+                    onPreview={previewBreadcrumb}
+                    onPreviewEnd={endBreadcrumbPreview}
+                  />
+                {:else}
+                  <div></div>
+                {/if}
+                <div class="min-h-0 min-w-0 overflow-auto p-3">
+                  {#if detailKind === 'fsm'}
+                    <quent-fsm-details
+                      {schema}
+                      path={detailPath}
+                      selection={paneSelection}
+                      isolateState={isolateFsmState}
+                      onquent-select={handleSelection}
+                    ></quent-fsm-details>
+                  {:else if detailKind === 'resource'}
+                    <quent-resource-details
+                      {schema}
+                      path={detailPath}
+                      selection={paneSelection}
+                      onquent-select={handleSelection}
+                    ></quent-resource-details>
+                  {:else if detailKind === 'record'}
+                    <quent-record-details
+                      {schema}
+                      path={detailPath}
+                      selection={paneSelection}
+                      onquent-select={handleSelection}
+                    ></quent-record-details>
+                  {:else if detailKind === 'events'}
+                    <quent-entity-events
+                      {schema}
+                      path={detailPath}
+                      selection={paneSelection}
+                      onquent-select={handleSelection}
+                    ></quent-entity-events>
+                  {:else}
+                    <p class="m-auto max-w-48 text-center text-sm text-base-content/50">
+                      Select or hover over an element to inspect it.
+                    </p>
+                  {/if}
+                </div>
+              </aside>
+            {/if}
+          </Pane>
+        </PaneGroup>
+      </Pane>
+    </PaneGroup>
+  {/if}
 </main>

--- a/experimental/vibe/ui/schema-explorer/src/GraphConfigBar.svelte
+++ b/experimental/vibe/ui/schema-explorer/src/GraphConfigBar.svelte
@@ -6,13 +6,22 @@
 
   interface Props {
     config: ResolvedEntityGraphConfig;
+    expanded: boolean;
+    onCollapse?: () => void;
     onChange: <Key extends keyof ResolvedEntityGraphConfig>(
       key: Key,
       value: ResolvedEntityGraphConfig[Key],
     ) => void;
+    onToggleExpanded: () => void;
   }
 
-  let { config, onChange }: Props = $props();
+  let {
+    config,
+    expanded,
+    onCollapse,
+    onChange,
+    onToggleExpanded,
+  }: Props = $props();
 </script>
 
 <div
@@ -20,7 +29,21 @@
   data-role="graph-configuration"
   aria-label="Entity graph configuration"
 >
-  <details class="dropdown dropdown-top order-last ml-auto shrink-0">
+  <div class="order-last ml-auto flex shrink-0 items-center gap-2">
+    {#if onCollapse}
+      <button class="btn btn-xs btn-ghost" type="button" onclick={onCollapse}>
+        Hide pane
+      </button>
+    {/if}
+    <button
+      class="btn btn-xs"
+      type="button"
+      aria-pressed={expanded}
+      onclick={onToggleExpanded}
+    >
+      {expanded ? 'Restore' : 'Expand graph'}
+    </button>
+    <details class="dropdown dropdown-top dropdown-end">
     <summary class="btn btn-xs">Layout</summary>
     <div
       class="dropdown-content z-30 grid w-96 max-w-[80vw] grid-cols-2 gap-3 rounded-box border border-base-300 bg-base-100 p-3 shadow-lg"
@@ -155,7 +178,8 @@
         Make room around high-degree nodes
       </label>
     </div>
-  </details>
+    </details>
+  </div>
   <fieldset class="grid shrink-0 gap-1">
     <legend class="text-[0.65rem] font-medium">References</legend>
     <div class="join" aria-label="Reference filter">


### PR DESCRIPTION
## Summary

- make the YAML editor, visualization, and selections panes resizable
and independently collapsible
- persist pane dimensions across reloads
- add full-screen visualization mode with Escape-to-restore
- support direct links to built-in examples through the `example` query parameter
- use Paneforge for accessible pane resizing and layout persistence

## Testing

- `pnpm --dir experimental/vibe/ui --filter @quent-experimental/ schema-explorer check`
- `pnpm --dir experimental/vibe/ui --filter @quent-experimental/ schema-explorer lint`
- production build with the `/quent/` Pages base
- browser checks for resizing, persistence, collapsing, full-screen mode, and example links
- `git diff --check`

_Written by Codex._