### PR TITLE
feat(components): improve operator inspection UI

### DIFF
--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -142,11 +142,9 @@ const VariableWidthEdge = ({
   const isInSelection = selectedNodeIds.has(source) || selectedNodeIds.has(target);
   const isInHighlight =
     hasActiveHighlight && (highlightedNodeIds.has(source) || highlightedNodeIds.has(target));
-  // While a hover-driven highlight set is active, it overrides the
-  // selection-based dim (matching `QueryPlanNode`).
-  const dimFromHighlight = hasActiveHighlight && !isInHighlight;
-  const dimFromSelection = !hasActiveHighlight && hasSelection && !isInSelection;
-  const isEdgeDimmed = edgeDimmed || dimFromHighlight || dimFromSelection;
+  const dimFromInteraction =
+    (hasActiveHighlight || hasSelection) && !isInHighlight && !isInSelection;
+  const isEdgeDimmed = edgeDimmed || dimFromInteraction;
 
   let edgeLabelValue: string | undefined;
   if (edgeColoring) {

--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -48,6 +48,7 @@ import type { DAGData } from '../services/query-plan/types';
 import { QueryPlanNode, type QueryPlanNodeData } from '../query-plan/QueryPlanNode';
 import { DAGLegend } from './DAGLegend';
 import { resolveInspectedNodeData } from './dagSelection';
+import { shouldDimEdgeFromInteraction } from './edgeOpacity';
 import { parseCustomStatistics } from '../lib/queryBundle.utils';
 import {
   continuousColor,
@@ -136,14 +137,12 @@ const VariableWidthEdge = ({
     }
   }
 
-  const hasSelection = selectedNodeIds.size > 0;
-  const hasActiveHighlight = highlightedNodeIds !== null;
-  // An edge "belongs to" a set when at least one endpoint is in the set.
-  const isInSelection = selectedNodeIds.has(source) || selectedNodeIds.has(target);
-  const isInHighlight =
-    hasActiveHighlight && (highlightedNodeIds.has(source) || highlightedNodeIds.has(target));
-  const dimFromInteraction =
-    (hasActiveHighlight || hasSelection) && !isInHighlight && !isInSelection;
+  const dimFromInteraction = shouldDimEdgeFromInteraction({
+    sourceId: source,
+    targetId: target,
+    selectedNodeIds,
+    highlightedNodeIds,
+  });
   const isEdgeDimmed = edgeDimmed || dimFromInteraction;
 
   let edgeLabelValue: string | undefined;

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
-import { render, screen } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { Provider } from 'jotai';
 import { useSetSelectedNodeData } from '@quent/hooks';
+import { getOperationTypeColor } from '@quent/utils';
 import { DAGNodeInfoPanel } from './DAGNodeInfoPanel';
 
 function SelectedNode() {
@@ -36,6 +37,36 @@ function SelectedNode() {
   return <DAGNodeInfoPanel />;
 }
 
+function SwitchSelectedNode() {
+  const [showLogical, setShowLogical] = useState(true);
+  const setSelectedNodeData = useSetSelectedNodeData();
+
+  useEffect(() => {
+    setSelectedNodeData(
+      showLogical
+        ? {
+            nodeId: 'logical',
+            label: 'Logical join',
+            operationType: 'logicaljoin',
+            statistics: [],
+          }
+        : {
+            nodeId: 'scan',
+            label: 'Table scan',
+            operationType: 'scan',
+            statistics: [],
+          }
+    );
+  }, [setSelectedNodeData, showLogical]);
+
+  return (
+    <>
+      <button onClick={() => setShowLogical(value => !value)}>Switch operator</button>
+      <DAGNodeInfoPanel />
+    </>
+  );
+}
+
 describe('DAGNodeInfoPanel', () => {
   it('shows statistics for every related child operator', async () => {
     render(
@@ -44,11 +75,72 @@ describe('DAGNodeInfoPanel', () => {
       </Provider>
     );
 
-    expect(await screen.findByText('Build hash table')).toBeInTheDocument();
+    const title = await screen.findByTestId('operator-details-title');
+    expect(within(title).getByText('Logical join')).toHaveAttribute('title', 'Logical join');
+    expect(screen.getByText('Build hash table')).toBeInTheDocument();
     expect(screen.getByText('Probe hash table')).toBeInTheDocument();
     expect(screen.getByText('build rows:')).toBeInTheDocument();
     expect(screen.getByText('probe rows:')).toBeInTheDocument();
     expect(screen.getByText('physical-1')).toBeInTheDocument();
     expect(screen.getByText('physical-2')).toBeInTheDocument();
+
+    const bars = screen.getAllByTestId('operator-color-bar');
+    expect(
+      bars.filter(bar => bar.getAttribute('data-operation-type') === 'logicaljoin')
+    ).not.toHaveLength(0);
+    expect(bars.find(bar => bar.getAttribute('data-operation-type') === 'hashbuild')).toHaveStyle({
+      backgroundColor: getOperationTypeColor('hashbuild'),
+    });
+    expect(bars.find(bar => bar.getAttribute('data-operation-type') === 'hashprobe')).toHaveStyle({
+      backgroundColor: getOperationTypeColor('hashprobe'),
+    });
+  });
+
+  it('resets collapsed operators when the selected root changes', async () => {
+    render(
+      <Provider>
+        <SwitchSelectedNode />
+      </Provider>
+    );
+
+    const logicalToggle = await screen.findByRole('button', {
+      name: 'Toggle Logical join details',
+    });
+    fireEvent.click(logicalToggle);
+    expect(logicalToggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch operator' }));
+    expect(
+      await screen.findByRole('button', { name: 'Toggle Table scan details' })
+    ).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch operator' }));
+    expect(
+      await screen.findByRole('button', { name: 'Toggle Logical join details' })
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses related child operators independently', async () => {
+    render(
+      <Provider>
+        <SelectedNode />
+      </Provider>
+    );
+
+    const relatedToggle = await screen.findByRole('button', {
+      name: 'Toggle Build hash table details',
+    });
+    expect(relatedToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('build rows:')).toBeInTheDocument();
+
+    fireEvent.click(relatedToggle);
+
+    expect(relatedToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('build rows:')).not.toBeInTheDocument();
+    expect(screen.getByText('probe rows:')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toggle Logical join details' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
   });
 });

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { ChevronUp, ChevronDown } from 'lucide-react';
 import {
   useSelectedNodeData,
@@ -9,32 +9,42 @@ import {
   useDataFlowIsPlaying,
   useDataFlowMeta,
   useDataFlowFrame,
+  type DataFlowMeta,
+  type DataFlowFrame,
+  type InspectedNodeData,
   type InspectedOperatorData,
 } from '@quent/hooks';
 import { DataText } from '../ui/data-text';
 import { thinScrollbarClass } from '../ui/thin-scroll';
-import { cn, formatStatWithQuantity, type QuantitySpec } from '@quent/utils';
+import { cn, formatStatWithQuantity, getOperationTypeColor, type QuantitySpec } from '@quent/utils';
 import { DataFlowMatrix } from './DataFlowMatrix';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
 
-const OperatorStatistics = ({
+const OperatorColorBar = ({
+  operationType,
+  className,
+}: {
+  operationType: string;
+  className?: string;
+}) => (
+  <span
+    aria-hidden
+    data-testid="operator-color-bar"
+    data-operation-type={operationType}
+    className={cn('shrink-0 rounded-full', className)}
+    style={{ backgroundColor: getOperationTypeColor(operationType) }}
+  />
+);
+
+const OperatorStatFields = ({
   operator,
   quantitySpecs,
-  showHeader = false,
 }: {
   operator: InspectedOperatorData;
   quantitySpecs?: { [key: string]: QuantitySpec | undefined };
-  showHeader?: boolean;
 }) => (
-  <div className={showHeader ? 'border-t pt-1.5 mt-1.5' : ''}>
-    {showHeader && (
-      <div className="flex items-center gap-2 min-w-0 mb-1">
-        <DataText className="text-xs font-medium truncate">{operator.label}</DataText>
-        <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded flex-shrink-0">
-          {operator.operationType}
-        </DataText>
-      </div>
-    )}
+  <>
     <div className="text-xs flex items-center justify-between">
       <DataText className="capitalize">ID:</DataText>
       <DataText className="text-muted-foreground ml-1 truncate">{operator.nodeId}</DataText>
@@ -68,7 +78,119 @@ const OperatorStatistics = ({
         )}
       </div>
     ))}
-  </div>
+  </>
+);
+
+const OperatorAccordion = ({
+  operator,
+  open,
+  onOpenChange,
+  children,
+}: {
+  operator: InspectedOperatorData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}) => (
+  <Collapsible
+    open={open}
+    onOpenChange={onOpenChange}
+    className="flex min-w-0 gap-2"
+    data-testid={`operator-accordion-${operator.nodeId}`}
+  >
+    <OperatorColorBar operationType={operator.operationType} className="w-1 self-stretch" />
+    <div className="min-w-0 flex-1">
+      <CollapsibleTrigger
+        className="group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm px-1.5 py-1 my-1 text-left hover:bg-muted/50"
+        aria-label={`Toggle ${operator.label} details`}
+      >
+        <DataText className="min-w-0 truncate text-xs font-medium" title={operator.label}>
+          {operator.label}
+        </DataText>
+        <DataText className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs capitalize text-muted-foreground">
+          {operator.operationType}
+        </DataText>
+        <ChevronDown className="ml-auto h-3 w-3 shrink-0 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </div>
+  </Collapsible>
+);
+
+const OperatorDetailsBlock = ({
+  operator,
+  quantitySpecs,
+  isOpen,
+  onOpenChange,
+}: {
+  operator: InspectedNodeData;
+  quantitySpecs?: { [key: string]: QuantitySpec | undefined };
+  isOpen: (id: string) => boolean;
+  onOpenChange: (id: string, open: boolean) => void;
+}) => (
+  <OperatorAccordion
+    operator={operator}
+    open={isOpen(operator.nodeId)}
+    onOpenChange={open => onOpenChange(operator.nodeId, open)}
+  >
+    <OperatorStatFields operator={operator} quantitySpecs={quantitySpecs} />
+    {operator.relatedOperators?.map(related => (
+      <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
+        <OperatorAccordion
+          operator={related}
+          open={isOpen(related.nodeId)}
+          onOpenChange={open => onOpenChange(related.nodeId, open)}
+        >
+          <OperatorStatFields operator={related} quantitySpecs={quantitySpecs} />
+        </OperatorAccordion>
+      </div>
+    ))}
+  </OperatorAccordion>
+);
+
+const OperatorDataFlowBlock = ({
+  operator,
+  meta,
+  frame,
+  isDark,
+  isOpen,
+  onOpenChange,
+}: {
+  operator: InspectedNodeData;
+  meta: DataFlowMeta;
+  frame: DataFlowFrame;
+  isDark: boolean;
+  isOpen: (id: string) => boolean;
+  onOpenChange: (id: string, open: boolean) => void;
+}) => (
+  <OperatorAccordion
+    operator={operator}
+    open={isOpen(operator.nodeId)}
+    onOpenChange={open => onOpenChange(operator.nodeId, open)}
+  >
+    <DataFlowMatrix
+      meta={meta}
+      frame={frame}
+      operatorFrame={frame.perOperator.get(operator.nodeId)}
+      isDark={isDark}
+    />
+    {operator.relatedOperators?.map(related => (
+      <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
+        <OperatorAccordion
+          operator={related}
+          open={isOpen(related.nodeId)}
+          onOpenChange={open => onOpenChange(related.nodeId, open)}
+        >
+          <DataFlowMatrix
+            meta={meta}
+            frame={frame}
+            operatorFrame={frame.perOperator.get(related.nodeId)}
+            isDark={isDark}
+          />
+        </OperatorAccordion>
+      </div>
+    ))}
+  </OperatorAccordion>
 );
 
 export const DAGNodeInfoPanel = ({
@@ -84,20 +206,34 @@ export const DAGNodeInfoPanel = ({
   const dataFlowMeta = useDataFlowMeta();
   const dataFlowFrame = useDataFlowFrame();
   const [isExpanded, setIsExpanded] = useState(false);
-  const selectedNodeId = selectedNodeData?.nodeId;
   const [activeTab, setActiveTab] = useState('stats');
-
-  const operatorFrame =
-    dataFlowEnabled && selectedNodeData && dataFlowMeta && dataFlowFrame
-      ? dataFlowFrame.perOperator.get(selectedNodeData.nodeId)
-      : undefined;
+  const [closedOperatorIds, setClosedOperatorIds] = useState<Set<string>>(() => new Set());
+  const selectedNodeId = selectedNodeData?.nodeId;
+  const hasSelection = selectedNodeData != null;
 
   const showDataFlowTab = dataFlowEnabled && dataFlowMeta != null;
+  const isOperatorOpen = (id: string) => !closedOperatorIds.has(id);
+  const setOperatorOpen = (id: string, open: boolean) => {
+    setClosedOperatorIds(prev => {
+      const isClosed = prev.has(id);
+      if (open ? !isClosed : isClosed) {
+        return prev;
+      }
+      const next = new Set(prev);
+      if (open) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
 
   useEffect(() => {
-    setIsExpanded(selectedNodeId !== undefined);
+    setIsExpanded(hasSelection);
     setActiveTab('stats');
-  }, [selectedNodeId]);
+    setClosedOperatorIds(new Set());
+  }, [hasSelection, selectedNodeId]);
 
   useEffect(() => {
     if (isPlaying && isExpanded && showDataFlowTab) {
@@ -109,17 +245,30 @@ export const DAGNodeInfoPanel = ({
 
   const statsContent = selectedNodeData ? (
     <div className="flex flex-col gap-1 pr-2 pt-1.5">
-      <OperatorStatistics operator={selectedNodeData} quantitySpecs={quantitySpecs} />
-      {selectedNodeData.relatedOperators?.map(operator => (
-        <OperatorStatistics
-          key={operator.nodeId}
-          operator={operator}
-          quantitySpecs={quantitySpecs}
-          showHeader
-        />
-      ))}
+      <OperatorDetailsBlock
+        operator={selectedNodeData}
+        quantitySpecs={quantitySpecs}
+        isOpen={isOperatorOpen}
+        onOpenChange={setOperatorOpen}
+      />
     </div>
   ) : null;
+
+  const dataFlowContent =
+    selectedNodeData && dataFlowMeta && dataFlowFrame ? (
+      <div className="flex flex-col">
+        <OperatorDataFlowBlock
+          operator={selectedNodeData}
+          meta={dataFlowMeta}
+          frame={dataFlowFrame}
+          isDark={isDark}
+          isOpen={isOperatorOpen}
+          onOpenChange={setOperatorOpen}
+        />
+      </div>
+    ) : (
+      <p className="pt-6 text-xs text-muted-foreground text-center">No tasks at this bin</p>
+    );
 
   return (
     <div className="border-t bg-card flex-shrink-0">
@@ -131,16 +280,27 @@ export const DAGNodeInfoPanel = ({
           {selectedNodeData && (
             <>
               <span className="text-muted-foreground text-xs flex-shrink-0">·</span>
-              <DataText className="text-xs font-medium truncate">{selectedNodeData.label}</DataText>
-              <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded flex-shrink-0">
-                {selectedNodeData.operationType}
-              </DataText>
+              <div
+                data-testid="operator-details-title"
+                className="flex min-w-0 items-center gap-1.5 overflow-hidden"
+              >
+                <OperatorColorBar
+                  operationType={selectedNodeData.operationType}
+                  className="h-3 w-1"
+                />
+                <DataText className="text-xs font-medium truncate" title={selectedNodeData.label}>
+                  {selectedNodeData.label}
+                </DataText>
+                <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded flex-shrink-0">
+                  {selectedNodeData.operationType}
+                </DataText>
+              </div>
             </>
           )}
         </div>
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          disabled={!selectedNodeData}
+          disabled={!hasSelection}
           className="ml-2 rounded p-1 hover:bg-muted transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-auto disabled:hover:bg-transparent flex-shrink-0"
           aria-label="Toggle operator details"
         >
@@ -153,7 +313,7 @@ export const DAGNodeInfoPanel = ({
       </div>
 
       {isExpanded &&
-        selectedNodeData &&
+        hasSelection &&
         (showDataFlowTab ? (
           <Tabs
             value={activeTab}
@@ -172,18 +332,7 @@ export const DAGNodeInfoPanel = ({
               {statsContent}
             </TabsContent>
             <TabsContent value="data-flow" className={scrollClass}>
-              {operatorFrame && dataFlowMeta && dataFlowFrame ? (
-                <DataFlowMatrix
-                  meta={dataFlowMeta}
-                  frame={dataFlowFrame}
-                  operatorFrame={operatorFrame}
-                  isDark={isDark}
-                />
-              ) : (
-                <p className="pt-6 text-xs text-muted-foreground text-center">
-                  No tasks at this bin
-                </p>
-              )}
+              {dataFlowContent}
             </TabsContent>
           </Tabs>
         ) : (

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -1,197 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState, type ReactNode } from 'react';
-import { ChevronUp, ChevronDown } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import {
-  useSelectedNodeData,
   useDataFlowEnabled,
+  useDataFlowFrame,
   useDataFlowIsPlaying,
   useDataFlowMeta,
-  useDataFlowFrame,
-  type DataFlowMeta,
-  type DataFlowFrame,
-  type InspectedNodeData,
-  type InspectedOperatorData,
+  useSelectedNodeData,
 } from '@quent/hooks';
+import { cn, type QuantitySpec } from '@quent/utils';
+import { OperatorColorBar, OperatorDataFlowBlock, OperatorDetailsBlock } from '../node-info';
 import { DataText } from '../ui/data-text';
 import { thinScrollbarClass } from '../ui/thin-scroll';
-import { cn, formatStatWithQuantity, getOperationTypeColor, type QuantitySpec } from '@quent/utils';
-import { DataFlowMatrix } from './DataFlowMatrix';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
-
-const OperatorColorBar = ({
-  operationType,
-  className,
-}: {
-  operationType: string;
-  className?: string;
-}) => (
-  <span
-    aria-hidden
-    data-testid="operator-color-bar"
-    data-operation-type={operationType}
-    className={cn('shrink-0 rounded-full', className)}
-    style={{ backgroundColor: getOperationTypeColor(operationType) }}
-  />
-);
-
-const OperatorStatFields = ({
-  operator,
-  quantitySpecs,
-}: {
-  operator: InspectedOperatorData;
-  quantitySpecs?: { [key: string]: QuantitySpec | undefined };
-}) => (
-  <>
-    <div className="text-xs flex items-center justify-between">
-      <DataText className="capitalize">ID:</DataText>
-      <DataText className="text-muted-foreground ml-1 truncate">{operator.nodeId}</DataText>
-    </div>
-    {operator.statistics.map(({ key, value, quantity }) => (
-      <div key={key} className="text-xs">
-        {Array.isArray(value) ? (
-          <div className="flex items-center justify-between gap-0.5">
-            <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
-            <div className="ml-2 flex flex-col gap-0.5">
-              {value.map((item, i) => (
-                <DataText key={i} className="text-muted-foreground whitespace-pre-line">
-                  {String(item)}
-                </DataText>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-center justify-between">
-            <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
-            <DataText className="text-muted-foreground ml-1">
-              {typeof value === 'number'
-                ? formatStatWithQuantity(
-                    value,
-                    key,
-                    quantity && quantitySpecs ? quantitySpecs[quantity] : undefined
-                  )
-                : String(value)}
-            </DataText>
-          </div>
-        )}
-      </div>
-    ))}
-  </>
-);
-
-const OperatorAccordion = ({
-  operator,
-  open,
-  onOpenChange,
-  children,
-}: {
-  operator: InspectedOperatorData;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  children: ReactNode;
-}) => (
-  <Collapsible
-    open={open}
-    onOpenChange={onOpenChange}
-    className="flex min-w-0 gap-2"
-    data-testid={`operator-accordion-${operator.nodeId}`}
-  >
-    <OperatorColorBar operationType={operator.operationType} className="w-1 self-stretch" />
-    <div className="min-w-0 flex-1">
-      <CollapsibleTrigger
-        className="group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm px-1.5 py-1 my-1 text-left hover:bg-muted/50"
-        aria-label={`Toggle ${operator.label} details`}
-      >
-        <DataText className="min-w-0 truncate text-xs font-medium" title={operator.label}>
-          {operator.label}
-        </DataText>
-        <DataText className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs capitalize text-muted-foreground">
-          {operator.operationType}
-        </DataText>
-        <ChevronDown className="ml-auto h-3 w-3 shrink-0 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
-      </CollapsibleTrigger>
-      <CollapsibleContent>{children}</CollapsibleContent>
-    </div>
-  </Collapsible>
-);
-
-const OperatorDetailsBlock = ({
-  operator,
-  quantitySpecs,
-  isOpen,
-  onOpenChange,
-}: {
-  operator: InspectedNodeData;
-  quantitySpecs?: { [key: string]: QuantitySpec | undefined };
-  isOpen: (id: string) => boolean;
-  onOpenChange: (id: string, open: boolean) => void;
-}) => (
-  <OperatorAccordion
-    operator={operator}
-    open={isOpen(operator.nodeId)}
-    onOpenChange={open => onOpenChange(operator.nodeId, open)}
-  >
-    <OperatorStatFields operator={operator} quantitySpecs={quantitySpecs} />
-    {operator.relatedOperators?.map(related => (
-      <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
-        <OperatorAccordion
-          operator={related}
-          open={isOpen(related.nodeId)}
-          onOpenChange={open => onOpenChange(related.nodeId, open)}
-        >
-          <OperatorStatFields operator={related} quantitySpecs={quantitySpecs} />
-        </OperatorAccordion>
-      </div>
-    ))}
-  </OperatorAccordion>
-);
-
-const OperatorDataFlowBlock = ({
-  operator,
-  meta,
-  frame,
-  isDark,
-  isOpen,
-  onOpenChange,
-}: {
-  operator: InspectedNodeData;
-  meta: DataFlowMeta;
-  frame: DataFlowFrame;
-  isDark: boolean;
-  isOpen: (id: string) => boolean;
-  onOpenChange: (id: string, open: boolean) => void;
-}) => (
-  <OperatorAccordion
-    operator={operator}
-    open={isOpen(operator.nodeId)}
-    onOpenChange={open => onOpenChange(operator.nodeId, open)}
-  >
-    <DataFlowMatrix
-      meta={meta}
-      frame={frame}
-      operatorFrame={frame.perOperator.get(operator.nodeId)}
-      isDark={isDark}
-    />
-    {operator.relatedOperators?.map(related => (
-      <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
-        <OperatorAccordion
-          operator={related}
-          open={isOpen(related.nodeId)}
-          onOpenChange={open => onOpenChange(related.nodeId, open)}
-        >
-          <DataFlowMatrix
-            meta={meta}
-            frame={frame}
-            operatorFrame={frame.perOperator.get(related.nodeId)}
-            isDark={isDark}
-          />
-        </OperatorAccordion>
-      </div>
-    ))}
-  </OperatorAccordion>
-);
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 
 export const DAGNodeInfoPanel = ({
   isDark = false,

--- a/ui/packages/@quent/components/src/dag/DataFlowMatrix.tsx
+++ b/ui/packages/@quent/components/src/dag/DataFlowMatrix.tsx
@@ -32,7 +32,7 @@ export const DataFlowMatrix = ({
 }: {
   meta: DataFlowMeta;
   frame: DataFlowFrame;
-  operatorFrame: DataFlowOperatorFrame;
+  operatorFrame?: DataFlowOperatorFrame;
   isDark: boolean;
 }) => {
   const paletteTheme: PaletteTheme = isDark ? 'dark' : 'light';
@@ -106,12 +106,12 @@ export const DataFlowMatrix = ({
               {dimensionColumns.map(({ key: k, index: dimensionIndex }) => (
                 <td key={k.key} className="text-right px-1.5 text-muted-foreground">
                   <DataText>
-                    {fmt(operatorFrame.matrix[stateIndex]?.[dimensionIndex] ?? 0)}
+                    {fmt(operatorFrame?.matrix[stateIndex]?.[dimensionIndex] ?? 0)}
                   </DataText>
                 </td>
               ))}
               <td className="text-right pl-1.5">
-                <DataText>{fmt(operatorFrame.byState[stateIndex] ?? 0)}</DataText>
+                <DataText>{fmt(operatorFrame?.byState[stateIndex] ?? 0)}</DataText>
               </td>
             </tr>
           ))}
@@ -121,11 +121,11 @@ export const DataFlowMatrix = ({
             </th>
             {dimensionColumns.map(({ key: k, index: dimensionIndex }) => (
               <td key={k.key} className="text-right px-1.5 pt-0.5">
-                <DataText>{fmt(operatorFrame.byDimension[dimensionIndex] ?? 0)}</DataText>
+                <DataText>{fmt(operatorFrame?.byDimension[dimensionIndex] ?? 0)}</DataText>
               </td>
             ))}
             <td className="text-right pl-1.5 pt-0.5 font-medium">
-              <DataText>{fmt(operatorFrame.total)}</DataText>
+              <DataText>{fmt(operatorFrame?.total ?? 0)}</DataText>
             </td>
           </tr>
         </tbody>

--- a/ui/packages/@quent/components/src/dag/edgeOpacity.test.ts
+++ b/ui/packages/@quent/components/src/dag/edgeOpacity.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { shouldDimEdgeFromInteraction } from './edgeOpacity';
+
+describe('shouldDimEdgeFromInteraction', () => {
+  it('dims an edge that is neither selected nor highlighted', () => {
+    expect(
+      shouldDimEdgeFromInteraction({
+        sourceId: 'other-source',
+        targetId: 'other-target',
+        selectedNodeIds: new Set(['selected']),
+        highlightedNodeIds: new Set(['highlighted']),
+      })
+    ).toBe(true);
+  });
+
+  it('keeps an edge touching a selected node visible during a highlight elsewhere', () => {
+    expect(
+      shouldDimEdgeFromInteraction({
+        sourceId: 'selected',
+        targetId: 'other',
+        selectedNodeIds: new Set(['selected']),
+        highlightedNodeIds: new Set(['highlighted']),
+      })
+    ).toBe(false);
+  });
+});

--- a/ui/packages/@quent/components/src/dag/edgeOpacity.ts
+++ b/ui/packages/@quent/components/src/dag/edgeOpacity.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function shouldDimEdgeFromInteraction({
+  sourceId,
+  targetId,
+  selectedNodeIds,
+  highlightedNodeIds,
+}: {
+  sourceId: string;
+  targetId: string;
+  selectedNodeIds: ReadonlySet<string>;
+  highlightedNodeIds: ReadonlySet<string> | null;
+}): boolean {
+  const hasSelection = selectedNodeIds.size > 0;
+  const hasActiveHighlight = highlightedNodeIds !== null;
+  const touchesSelection = selectedNodeIds.has(sourceId) || selectedNodeIds.has(targetId);
+  const touchesHighlight =
+    highlightedNodeIds?.has(sourceId) === true || highlightedNodeIds?.has(targetId) === true;
+
+  return (hasActiveHighlight || hasSelection) && !touchesHighlight && !touchesSelection;
+}

--- a/ui/packages/@quent/components/src/node-info/OperatorAccordion.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorAccordion.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+import type { InspectedOperatorData } from '@quent/hooks';
+import { DataText } from '../ui/data-text';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
+import { OperatorColorBar } from './OperatorColorBar';
+
+export interface OperatorDisclosureState {
+  isOpen: (id: string) => boolean;
+  onOpenChange: (id: string, open: boolean) => void;
+}
+
+export const OperatorAccordion = ({
+  operator,
+  open,
+  onOpenChange,
+  children,
+}: {
+  operator: InspectedOperatorData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}) => (
+  <Collapsible
+    open={open}
+    onOpenChange={onOpenChange}
+    className="flex min-w-0 gap-2"
+    data-testid={`operator-accordion-${operator.nodeId}`}
+  >
+    <OperatorColorBar operationType={operator.operationType} className="w-1 self-stretch" />
+    <div className="min-w-0 flex-1">
+      <CollapsibleTrigger
+        className="group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm px-1.5 py-1 my-1 text-left hover:bg-muted/50"
+        aria-label={`Toggle ${operator.label} details`}
+      >
+        <DataText className="min-w-0 truncate text-xs font-medium" title={operator.label}>
+          {operator.label}
+        </DataText>
+        <DataText className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs capitalize text-muted-foreground">
+          {operator.operationType}
+        </DataText>
+        <ChevronDown className="ml-auto h-3 w-3 shrink-0 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </div>
+  </Collapsible>
+);

--- a/ui/packages/@quent/components/src/node-info/OperatorColorBar.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorColorBar.tsx
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cn, getOperationTypeColor } from '@quent/utils';
+
+export const OperatorColorBar = ({
+  operationType,
+  className,
+}: {
+  operationType: string;
+  className?: string;
+}) => (
+  <span
+    aria-hidden
+    data-testid="operator-color-bar"
+    data-operation-type={operationType}
+    className={cn('shrink-0 rounded-full', className)}
+    style={{ backgroundColor: getOperationTypeColor(operationType) }}
+  />
+);

--- a/ui/packages/@quent/components/src/node-info/OperatorDataFlowBlock.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorDataFlowBlock.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DataFlowFrame, DataFlowMeta, InspectedNodeData } from '@quent/hooks';
+import { DataFlowMatrix } from '../dag/DataFlowMatrix';
+import { OperatorAccordion, type OperatorDisclosureState } from './OperatorAccordion';
+
+export const OperatorDataFlowBlock = ({
+  operator,
+  meta,
+  frame,
+  isDark,
+  isOpen,
+  onOpenChange,
+}: {
+  operator: InspectedNodeData;
+  meta: DataFlowMeta;
+  frame: DataFlowFrame;
+  isDark: boolean;
+} & OperatorDisclosureState) => (
+  <OperatorAccordion
+    operator={operator}
+    open={isOpen(operator.nodeId)}
+    onOpenChange={open => onOpenChange(operator.nodeId, open)}
+  >
+    <DataFlowMatrix
+      meta={meta}
+      frame={frame}
+      operatorFrame={frame.perOperator.get(operator.nodeId)}
+      isDark={isDark}
+    />
+    {operator.relatedOperators?.map(related => (
+      <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
+        <OperatorAccordion
+          operator={related}
+          open={isOpen(related.nodeId)}
+          onOpenChange={open => onOpenChange(related.nodeId, open)}
+        >
+          <DataFlowMatrix
+            meta={meta}
+            frame={frame}
+            operatorFrame={frame.perOperator.get(related.nodeId)}
+            isDark={isDark}
+          />
+        </OperatorAccordion>
+      </div>
+    ))}
+  </OperatorAccordion>
+);

--- a/ui/packages/@quent/components/src/node-info/OperatorDetailsBlock.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorDetailsBlock.tsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { InspectedNodeData } from '@quent/hooks';
+import type { QuantitySpec } from '@quent/utils';
+import { OperatorAccordion, type OperatorDisclosureState } from './OperatorAccordion';
+import { OperatorStatFields } from './OperatorStatFields';
+
+export const OperatorDetailsBlock = ({
+  operator,
+  quantitySpecs,
+  isOpen,
+  onOpenChange,
+}: {
+  operator: InspectedNodeData;
+  quantitySpecs?: { [key: string]: QuantitySpec | undefined };
+} & OperatorDisclosureState) => (
+  <OperatorAccordion
+    operator={operator}
+    open={isOpen(operator.nodeId)}
+    onOpenChange={open => onOpenChange(operator.nodeId, open)}
+  >
+    <OperatorStatFields operator={operator} quantitySpecs={quantitySpecs} />
+    {operator.relatedOperators?.map(related => (
+      <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
+        <OperatorAccordion
+          operator={related}
+          open={isOpen(related.nodeId)}
+          onOpenChange={open => onOpenChange(related.nodeId, open)}
+        >
+          <OperatorStatFields operator={related} quantitySpecs={quantitySpecs} />
+        </OperatorAccordion>
+      </div>
+    ))}
+  </OperatorAccordion>
+);

--- a/ui/packages/@quent/components/src/node-info/OperatorStatFields.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorStatFields.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { InspectedOperatorData } from '@quent/hooks';
+import { formatStatWithQuantity, type QuantitySpec } from '@quent/utils';
+import { DataText } from '../ui/data-text';
+
+export const OperatorStatFields = ({
+  operator,
+  quantitySpecs,
+}: {
+  operator: InspectedOperatorData;
+  quantitySpecs?: { [key: string]: QuantitySpec | undefined };
+}) => (
+  <>
+    <div className="text-xs flex items-center justify-between">
+      <DataText className="capitalize">ID:</DataText>
+      <DataText className="text-muted-foreground ml-1 truncate">{operator.nodeId}</DataText>
+    </div>
+    {operator.statistics.map(({ key, value, quantity }) => (
+      <div key={key} className="text-xs">
+        {Array.isArray(value) ? (
+          <div className="flex items-center justify-between gap-0.5">
+            <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
+            <div className="ml-2 flex flex-col gap-0.5">
+              {value.map((item, i) => (
+                <DataText key={i} className="text-muted-foreground whitespace-pre-line">
+                  {String(item)}
+                </DataText>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <DataText className="capitalize">{key.replace(/_/g, ' ')}:</DataText>
+            <DataText className="text-muted-foreground ml-1">
+              {typeof value === 'number'
+                ? formatStatWithQuantity(
+                    value,
+                    key,
+                    quantity && quantitySpecs ? quantitySpecs[quantity] : undefined
+                  )
+                : String(value)}
+            </DataText>
+          </div>
+        )}
+      </div>
+    ))}
+  </>
+);

--- a/ui/packages/@quent/components/src/node-info/index.ts
+++ b/ui/packages/@quent/components/src/node-info/index.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { OperatorAccordion } from './OperatorAccordion';
+export type { OperatorDisclosureState } from './OperatorAccordion';
+export { OperatorColorBar } from './OperatorColorBar';
+export { OperatorDataFlowBlock } from './OperatorDataFlowBlock';
+export { OperatorDetailsBlock } from './OperatorDetailsBlock';
+export { OperatorStatFields } from './OperatorStatFields';

--- a/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
+++ b/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
@@ -29,6 +29,7 @@ import { formatStatWithQuantity, type QuantitySpec } from '@quent/utils';
 import { parseCustomStatistics } from '../lib/queryBundle.utils';
 import { DataText } from '../ui/data-text';
 import { NodeFlowBar } from './NodeFlowBar';
+import { getNodeOpacityClass } from './nodeOpacity';
 
 export interface QueryPlanNodeData extends Record<string, unknown> {
   label: string;
@@ -74,35 +75,6 @@ const nodeVariants = cva(
     },
   }
 );
-
-function nodeOpacityClass({
-  hoveredStat,
-  highlightedNodeIds,
-  operatorId,
-  isDimmed,
-}: {
-  hoveredStat: { values: Map<string, number> } | null | undefined;
-  highlightedNodeIds: Set<string> | null;
-  operatorId: string;
-  isDimmed: boolean;
-}): string {
-  if (hoveredStat) {
-    return hoveredStat.values.has(operatorId) ? 'opacity-100' : 'opacity-20';
-  }
-  // An active highlight set fully overrides the selection-based dim so that
-  // hovered (highlighted) operators are always visible, even when a DAG
-  // selection would otherwise dim them. The atom is fed through
-  // `effectiveHighlightedNodeIdsAtom`, which clears `ids` when nothing in
-  // the highlight set is actually shown — so an empty/null set here means
-  // "no meaningful highlight" and we leave everything at full opacity.
-  if (highlightedNodeIds !== null && highlightedNodeIds.size > 0) {
-    return highlightedNodeIds.has(operatorId) ? 'opacity-100' : 'opacity-35';
-  }
-  if (isDimmed) {
-    return 'opacity-35';
-  }
-  return 'opacity-100';
-}
 
 /** Memoized DAG node rendered inside ReactFlow. */
 export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
@@ -165,11 +137,12 @@ export const QueryPlanNode = memo(({ data }: { data: QueryPlanNodeData }) => {
     return continuousColor(t, nodePalette, isDark);
   }, [hoveredStat, operatorId, nodePalette, isDark]);
 
-  const opacityClass = nodeOpacityClass({
-    hoveredStat,
+  const opacityClass = getNodeOpacityClass({
+    hoveredStatValues: hoveredStat?.values,
     highlightedNodeIds: highlightState.ids,
     operatorId,
     isDimmed,
+    isSelected,
   });
 
   const isActiveHighlight = isHighlighted && !isSelected;

--- a/ui/packages/@quent/components/src/query-plan/nodeOpacity.test.ts
+++ b/ui/packages/@quent/components/src/query-plan/nodeOpacity.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { getNodeOpacityClass } from './nodeOpacity';
+
+describe('getNodeOpacityClass', () => {
+  it('keeps every selected node highlighted during a DAG hover', () => {
+    expect(
+      getNodeOpacityClass({
+        hoveredStatValues: null,
+        highlightedNodeIds: new Set(['hovered']),
+        operatorId: 'selected',
+        isDimmed: false,
+        isSelected: true,
+      })
+    ).toBe('opacity-100');
+  });
+
+  it('dims nodes that are neither selected nor hovered', () => {
+    expect(
+      getNodeOpacityClass({
+        hoveredStatValues: null,
+        highlightedNodeIds: new Set(['hovered']),
+        operatorId: 'other',
+        isDimmed: true,
+        isSelected: false,
+      })
+    ).toBe('opacity-35');
+  });
+});

--- a/ui/packages/@quent/components/src/query-plan/nodeOpacity.ts
+++ b/ui/packages/@quent/components/src/query-plan/nodeOpacity.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function getNodeOpacityClass({
+  hoveredStatValues,
+  highlightedNodeIds,
+  operatorId,
+  isDimmed,
+  isSelected,
+}: {
+  hoveredStatValues: ReadonlyMap<string, number> | null | undefined;
+  highlightedNodeIds: ReadonlySet<string> | null;
+  operatorId: string;
+  isDimmed: boolean;
+  isSelected: boolean;
+}): string {
+  if (hoveredStatValues) {
+    return hoveredStatValues.has(operatorId) || isSelected ? 'opacity-100' : 'opacity-20';
+  }
+  if (highlightedNodeIds !== null && highlightedNodeIds.size > 0) {
+    return highlightedNodeIds.has(operatorId) || isSelected ? 'opacity-100' : 'opacity-35';
+  }
+  if (isDimmed) {
+    return 'opacity-35';
+  }
+  return 'opacity-100';
+}

--- a/ui/src/components/DataFlowOverlay.test.tsx
+++ b/ui/src/components/DataFlowOverlay.test.tsx
@@ -5,13 +5,14 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { useEffect } from 'react';
 import { Provider } from 'jotai';
 import { ReactFlowProvider } from '@xyflow/react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import {
   useDataFlowSync,
   useSetDataFlowEnabled,
   useSetDataFlowLabelMeasure,
   useSetDataFlowSelectedDimensions,
   useSetSelectedNodeData,
+  type InspectedNodeData,
 } from '@quent/hooks';
 import { DagPlayhead, DAGLegend, DAGNodeInfoPanel, NodeFlowBar } from '@quent/components';
 import type { DataFlowTimelineBinned, EntityRef, QueryBundle } from '@quent/utils';
@@ -387,23 +388,31 @@ describe('tier (dimension) selection', () => {
 });
 
 describe('DAGNodeInfoPanel matrix under tier selection', () => {
-  function renderPanel(selectedDimensions: ReadonlySet<string> | null) {
-    function SelectNode() {
+  const selectedOperator: InspectedNodeData = {
+    nodeId: 'op-1',
+    label: 'Op 1',
+    operationType: 'scan',
+    statistics: [],
+  };
+
+  function renderPanel(
+    selectedDimensions: ReadonlySet<string> | null,
+    operator: InspectedNodeData = selectedOperator
+  ) {
+    function SelectNode({ value }: { value: InspectedNodeData }) {
       const setSelectedNodeData = useSetSelectedNodeData();
       useEffect(() => {
-        setSelectedNodeData({
-          nodeId: 'op-1',
-          label: 'Op 1',
-          operationType: 'scan',
-          statistics: [],
-        });
-      }, [setSelectedNodeData]);
+        setSelectedNodeData(value);
+      }, [setSelectedNodeData, value]);
       return <DAGNodeInfoPanel />;
     }
     return render(
       <Provider>
         <Harness response={RESPONSE} selectedDimensions={selectedDimensions}>
-          <SelectNode />
+          <>
+            <DagPlayhead />
+            <SelectNode value={operator} />
+          </>
         </Harness>
       </Provider>
     );
@@ -421,6 +430,34 @@ describe('DAGNodeInfoPanel matrix under tier selection', () => {
     fireEvent.mouseDown(screen.getByRole('tab', { name: 'Data Flow' }), { button: 0 });
     expect(screen.getByText('Memory')).toBeInTheDocument();
     expect(screen.queryByText('Filesystem')).not.toBeInTheDocument();
+  });
+
+  it('keeps a zero-filled matrix visible at an all-zero bin', () => {
+    renderPanel(null);
+    fireEvent.keyDown(screen.getByRole('slider'), { key: 'End' });
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Data Flow' }), { button: 0 });
+
+    expect(screen.queryByText('No tasks at this bin')).not.toBeInTheDocument();
+    expect(within(screen.getByRole('table')).getAllByText('0')).toHaveLength(9);
+  });
+
+  it('renders matrices for a higher-level operator and its nested operators', () => {
+    renderPanel(null, {
+      nodeId: 'logical',
+      label: 'Logical operator',
+      operationType: 'join',
+      statistics: [],
+      relatedOperators: [selectedOperator],
+    });
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Data Flow' }), { button: 0 });
+
+    const parent = screen.getByTestId('operator-accordion-logical');
+    expect(within(parent).getByRole('button', { name: 'Toggle Op 1 details' })).toBeInTheDocument();
+
+    const matrices = screen.getAllByRole('table');
+    expect(matrices).toHaveLength(2);
+    expect(within(matrices[0]).getAllByText('0')).toHaveLength(9);
+    expect(within(matrices[1]).getAllByText('1.0')).not.toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
# Description

* Adapt [DAGNodeInfoPanel.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx) to use main’s useSelectedNodeData() while adding parent/child accordions, operation-type bars, nested stats, and nested data-flow matrices.



* Include panel tests in [DAGNodeInfoPanel.test.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx), optional zero-filled frames in [DataFlowMatrix.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/DataFlowMatrix.tsx), and higher-level/data-flow coverage in [DataFlowOverlay.test.tsx](https://github.com/rapidsai/quent/pull/ui/src/components/DataFlowOverlay.test.tsx).

* Reset per-operator collapse state when the selected root operator changes, so closed children do not leak between selections.

* Do not include multi-selection atoms, toolbar changes, DAG click changes, or multiple top-level panel titles.

* Extract the pure opacity helper and tests in [nodeOpacity.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/query-plan/nodeOpacity.ts) and [nodeOpacity.test.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/query-plan/nodeOpacity.test.ts), then use it from [QueryPlanNode.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx).

* Include only the edge-interaction dimming hunk from [DAGChart.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/DAGChart.tsx); defer all click/selection-state rewrites.


## Related Issues
<!-- Link related issues: closes #123, relates to #456 -->

## Testing
Result after merge: one selected logical operator still behaves as on main, its physical operators are nested and color-coded, and selected nodes/edges remain visible during hover highlights.

Selected node(s) remain highlighted when hovering others:

https://github.com/user-attachments/assets/4d1d148f-4b9f-4355-b1e9-e01444d6aa57

Nested node detail panel on higher level operator selection:

https://github.com/user-attachments/assets/7dd449e6-648c-4791-87b7-6f4177d87502

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>