### PR TITLE
refactor(hooks): add deep-link-ready operator selection state

### DIFF
--- a/ui/packages/@quent/components/src/dag/DAGChart.test.ts
+++ b/ui/packages/@quent/components/src/dag/DAGChart.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { DAGNode } from '@quent/utils';
-import { resolveInspectedNodeData } from './dagSelection';
+import { resolveInspectedNodeData, resolveInspectedNodeSelections } from './dagSelection';
 
 const NODES: DAGNode[] = [
   {
@@ -32,5 +32,38 @@ describe('resolveInspectedNodeData', () => {
 
   it('does not inspect an ambiguous selection', () => {
     expect(resolveInspectedNodeData(NODES, new Set(['logical', 'other']))).toBeNull();
+  });
+
+  it('reconstructs multiple physical and higher-level selections', () => {
+    const resolved = resolveInspectedNodeSelections(
+      NODES,
+      new Set(['logical', 'physical-1', 'physical-2', 'other'])
+    );
+
+    expect(resolved.selections).toMatchObject([
+      {
+        selectionId: 'logical',
+        label: 'Logical join',
+        operatorIds: new Set(['logical', 'physical-1', 'physical-2']),
+      },
+      {
+        selectionId: 'other',
+        label: 'Other operator',
+        operatorIds: new Set(['other']),
+      },
+    ]);
+    expect(resolved.unresolvedOperatorIds).toEqual(new Set());
+  });
+
+  it('preserves IDs until matching DAG data is available', () => {
+    const selectedIds = new Set(['logical', 'physical-1', 'physical-2', 'unknown']);
+
+    const beforeData = resolveInspectedNodeSelections([], selectedIds);
+    expect(beforeData.selections).toEqual([]);
+    expect(beforeData.unresolvedOperatorIds).toEqual(selectedIds);
+
+    const afterData = resolveInspectedNodeSelections(NODES, selectedIds);
+    expect(afterData.selections.map(selection => selection.selectionId)).toEqual(['logical']);
+    expect(afterData.unresolvedOperatorIds).toEqual(new Set(['unknown']));
   });
 });

--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -309,12 +309,22 @@ const FlowLayout = ({
   useEffect(() => {
     const operatorIds = new Set(hydratedNodeIdsKey === '' ? [] : hydratedNodeIdsKey.split('\0'));
     const resolved = resolveInspectedNodeSelections(data.nodes, operatorIds);
-    updateOperatorSelection({
-      type: 'hydrate',
-      selections: resolved.selections,
-      unresolvedOperatorIds: resolved.unresolvedOperatorIds,
-    });
-  }, [data.nodes, hydratedNodeIdsKey, updateOperatorSelection]);
+    if (controlledSelectedNodeIds !== undefined) {
+      updateOperatorSelection({
+        type: 'replace',
+        selections: [
+          ...resolved.selections,
+          ...[...resolved.unresolvedOperatorIds].map(selectionId => ({
+            selectionId,
+            label: data.nodes.find(node => node.id === selectionId)?.label ?? selectionId,
+            operatorIds: new Set([selectionId]),
+          })),
+        ],
+      });
+      return;
+    }
+    updateOperatorSelection({ type: 'hydrate', selections: resolved.selections });
+  }, [controlledSelectedNodeIds, data.nodes, hydratedNodeIdsKey, updateOperatorSelection]);
 
   // Publish the set of operator IDs visible in this DAG so other consumers
   // (effective highlight/heatmap atoms) can decide whether a hover-driven

--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -31,6 +31,7 @@ import {
   useSelectedNodeIds,
   useSetSelectedNodeIds,
   useSetSelectedOperatorLabel,
+  useOperatorSelectionActions,
   useEdgeWidthConfig,
   useEdgeColoring,
   useEdgeColorPalette,
@@ -47,7 +48,7 @@ import { calculateLayout, NODE_LAYOUT_WIDTH, NODE_LAYOUT_HEIGHT, FLOW_BAR_HEIGHT
 import type { DAGData } from '../services/query-plan/types';
 import { QueryPlanNode, type QueryPlanNodeData } from '../query-plan/QueryPlanNode';
 import { DAGLegend } from './DAGLegend';
-import { resolveInspectedNodeData } from './dagSelection';
+import { resolveInspectedNodeSelections } from './dagSelection';
 import { shouldDimEdgeFromInteraction } from './edgeOpacity';
 import { parseCustomStatistics } from '../lib/queryBundle.utils';
 import {
@@ -286,6 +287,7 @@ const FlowLayout = ({
   const { fitView } = useReactFlow();
   const setSelectedNodeIds = useSetSelectedNodeIds();
   const setSelectedOperatorLabel = useSetSelectedOperatorLabel();
+  const updateOperatorSelection = useOperatorSelectionActions();
   const setDagDisplayedNodeIds = useSetDagDisplayedNodeIds();
   const setSelectedNodeData = useSetSelectedNodeData();
   const selectedNodeIds = useSelectedNodeIds();
@@ -296,13 +298,23 @@ const FlowLayout = ({
   // so toggling the overlay relayouts exactly once.
   const flowBarVisible = dataFlowEnabled && dataFlowMeta != null;
   const hasUserInteracted = useRef(false);
+  const hydratedNodeIdsKey = useMemo(
+    () =>
+      [...(controlledSelectedNodeIds === undefined ? selectedNodeIds : controlledSelectedNodeIds)]
+        .sort()
+        .join('\0'),
+    [controlledSelectedNodeIds, selectedNodeIds]
+  );
 
-  // Sync controlled selectedNodeIds into the atom when provided
   useEffect(() => {
-    if (controlledSelectedNodeIds !== undefined) {
-      setSelectedNodeIds(new Set(controlledSelectedNodeIds));
-    }
-  }, [controlledSelectedNodeIds, setSelectedNodeIds]);
+    const operatorIds = new Set(hydratedNodeIdsKey === '' ? [] : hydratedNodeIdsKey.split('\0'));
+    const resolved = resolveInspectedNodeSelections(data.nodes, operatorIds);
+    updateOperatorSelection({
+      type: 'hydrate',
+      selections: resolved.selections,
+      unresolvedOperatorIds: resolved.unresolvedOperatorIds,
+    });
+  }, [data.nodes, hydratedNodeIdsKey, updateOperatorSelection]);
 
   // Publish the set of operator IDs visible in this DAG so other consumers
   // (effective highlight/heatmap atoms) can decide whether a hover-driven
@@ -313,12 +325,6 @@ const FlowLayout = ({
       setDagDisplayedNodeIds(new Set());
     };
   }, [data.nodes, setDagDisplayedNodeIds]);
-
-  useEffect(() => {
-    const selected = resolveInspectedNodeData(data.nodes, selectedNodeIds);
-    setSelectedOperatorLabel(selected?.label ?? null);
-    setSelectedNodeData(selected);
-  }, [data.nodes, selectedNodeIds, setSelectedNodeData, setSelectedOperatorLabel]);
 
   const handleMoveStart = useCallback<OnMoveStart>(event => {
     if (event !== null) {

--- a/ui/packages/@quent/components/src/dag/dagSelection.ts
+++ b/ui/packages/@quent/components/src/dag/dagSelection.ts
@@ -1,31 +1,33 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { InspectedNodeData } from '@quent/hooks';
-import type { DAGNode } from '@quent/utils';
+import type { DAGNode, InspectedNodeData } from '@quent/utils';
 import { parseCustomStatistics } from '../lib/queryBundle.utils';
 import type { QueryPlanNodeData } from '../query-plan/QueryPlanNode';
 
-export function resolveInspectedNodeData(
-  nodes: readonly DAGNode[],
-  selectedNodeIds: ReadonlySet<string>
-): InspectedNodeData | null {
-  const selected = nodes.find(node => {
-    const metadata = node.metadata as QueryPlanNodeData['metadata'];
-    const ids = new Set([node.id, ...(metadata?.relatedOperatorIds ?? [])]);
-    return (
-      ids.size === selectedNodeIds.size && [...ids].every(nodeId => selectedNodeIds.has(nodeId))
-    );
-  });
-  if (!selected) {
-    return null;
-  }
+export interface ResolvedOperatorSelection {
+  selectionId: string;
+  label: string;
+  operatorIds: ReadonlySet<string>;
+  inspectedData: InspectedNodeData;
+}
 
-  const metadata = selected.metadata as QueryPlanNodeData['metadata'];
+export interface ResolvedOperatorSelections {
+  selections: ResolvedOperatorSelection[];
+  unresolvedOperatorIds: ReadonlySet<string>;
+}
+
+function getOperatorIds(node: DAGNode): Set<string> {
+  const metadata = node.metadata as QueryPlanNodeData['metadata'];
+  return new Set([node.id, ...(metadata?.relatedOperatorIds ?? [])]);
+}
+
+function inspectNode(node: DAGNode): InspectedNodeData {
+  const metadata = node.metadata as QueryPlanNodeData['metadata'];
   return {
-    nodeId: selected.id,
-    label: selected.label,
-    operationType: selected.type,
+    nodeId: node.id,
+    label: node.label,
+    operationType: node.type,
     statistics: parseCustomStatistics(metadata?.rawNode),
     relatedOperators: metadata?.relatedOperators?.map(operator => ({
       nodeId: operator.id,
@@ -34,4 +36,43 @@ export function resolveInspectedNodeData(
       statistics: parseCustomStatistics(operator),
     })),
   };
+}
+
+export function resolveInspectedNodeSelections(
+  nodes: readonly DAGNode[],
+  selectedNodeIds: ReadonlySet<string>
+): ResolvedOperatorSelections {
+  const unresolvedOperatorIds = new Set(selectedNodeIds);
+  const candidates = nodes
+    .map(node => ({ node, operatorIds: getOperatorIds(node) }))
+    .sort((a, b) => b.operatorIds.size - a.operatorIds.size);
+  const selections: ResolvedOperatorSelection[] = [];
+
+  for (const { node, operatorIds } of candidates) {
+    if (![...operatorIds].every(id => unresolvedOperatorIds.has(id))) {
+      continue;
+    }
+    for (const id of operatorIds) {
+      unresolvedOperatorIds.delete(id);
+    }
+    selections.push({
+      selectionId: node.id,
+      label: node.label,
+      operatorIds,
+      inspectedData: inspectNode(node),
+    });
+  }
+
+  return { selections, unresolvedOperatorIds };
+}
+
+export function resolveInspectedNodeData(
+  nodes: readonly DAGNode[],
+  selectedNodeIds: ReadonlySet<string>
+): InspectedNodeData | null {
+  const resolved = resolveInspectedNodeSelections(nodes, selectedNodeIds);
+  if (resolved.selections.length !== 1 || resolved.unresolvedOperatorIds.size > 0) {
+    return null;
+  }
+  return resolved.selections[0].inspectedData;
 }

--- a/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
@@ -3,7 +3,7 @@
 
 import type { DAGNode, DAGEdge, QueryPlanDataItem } from './types';
 import type { QueryBundle, EntityRef } from '@quent/utils';
-import { Operator, Port, Plan, PlanTree } from '@quent/utils';
+import { buildRelatedOperatorIdsById, Operator, Port, Plan, PlanTree } from '@quent/utils';
 
 interface PlanTreeNode extends PlanTree {
   query?: string | null;
@@ -50,40 +50,6 @@ const getNodeEntity = (
   }
 
   return undefined;
-};
-
-const buildRelatedOperatorIdsById = (
-  operators: Operator[],
-  selectedOperatorIds: ReadonlySet<string>
-): Map<string, string[]> => {
-  const childrenByParentId = new Map<string, string[]>();
-  for (const operator of operators) {
-    for (const parentId of operator.parent_operator_ids ?? []) {
-      const children = childrenByParentId.get(parentId);
-      if (children) {
-        children.push(operator.id);
-      } else {
-        childrenByParentId.set(parentId, [operator.id]);
-      }
-    }
-  }
-
-  const relatedById = new Map<string, string[]>();
-  for (const operatorId of selectedOperatorIds) {
-    const related = new Set<string>();
-    const stack = [...(childrenByParentId.get(operatorId) ?? [])];
-    while (stack.length > 0) {
-      const childId = stack.pop()!;
-      if (childId === operatorId || related.has(childId)) {
-        continue;
-      }
-      related.add(childId);
-      stack.push(...(childrenByParentId.get(childId) ?? []));
-    }
-    relatedById.set(operatorId, [...related]);
-  }
-
-  return relatedById;
 };
 
 /**

--- a/ui/packages/@quent/hooks/src/atoms/dag.ts
+++ b/ui/packages/@quent/hooks/src/atoms/dag.ts
@@ -2,12 +2,154 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atom } from 'jotai';
+import type { InspectedNodeData, OperatorSelectionState } from '@quent/utils';
+import {
+  addOperatorSelection as addSelection,
+  createOperatorSelectionState,
+  createEmptyOperatorSelectionState,
+  getActiveOperatorLabel,
+  getLastOperatorSelectionId,
+  getSelectedOperatorIds,
+  removeOperatorSelection as removeSelection,
+} from '../dag/operatorSelection';
+import { removeInspectedNodeData, upsertInspectedNodeData } from '../dag/inspectedNodeData';
+import { selectedNodesDataAtom } from './dagControls';
 
-/** The set of currently selected node IDs in the DAG chart */
-export const selectedNodeIdsAtom = atom(new Set<string>());
+export type OperatorSelectionAction =
+  | {
+      type: 'add';
+      selectionId: string;
+      label: string;
+      operatorIds: Iterable<string>;
+      inspectedData: InspectedNodeData;
+    }
+  | { type: 'remove'; selectionId: string }
+  | {
+      type: 'replace';
+      operatorIds: Iterable<string>;
+      inspectedData?: InspectedNodeData;
+    }
+  | {
+      type: 'hydrate';
+      selections: ReadonlyArray<{
+        selectionId: string;
+        label: string;
+        operatorIds: Iterable<string>;
+        inspectedData: InspectedNodeData;
+      }>;
+      unresolvedOperatorIds: Iterable<string>;
+    }
+  | { type: 'clear' };
 
-/** Display label of the currently selected operator */
-export const selectedOperatorLabelAtom = atom<string | null>(null);
+/** Canonical operator filter selection state */
+export const operatorSelectionAtom = atom<OperatorSelectionState>(
+  createEmptyOperatorSelectionState()
+);
+
+/** Updates operator filters and their inspected details as one transaction. */
+export const operatorSelectionActionAtom = atom(
+  null,
+  (get, set, action: OperatorSelectionAction): Set<string> => {
+    const currentSelection = get(operatorSelectionAtom);
+    const currentData = get(selectedNodesDataAtom);
+    let nextSelection: OperatorSelectionState;
+    let nextData: ReadonlyMap<string, InspectedNodeData>;
+
+    switch (action.type) {
+      case 'add':
+        nextSelection = addSelection(
+          currentSelection,
+          action.selectionId,
+          action.label,
+          action.operatorIds
+        );
+        nextData = new Map([...currentData].filter(([id]) => nextSelection.selections.has(id)));
+        if (nextSelection.selections.has(action.selectionId)) {
+          nextData = upsertInspectedNodeData(nextData, action.inspectedData);
+        }
+        break;
+      case 'remove':
+        nextSelection = removeSelection(currentSelection, action.selectionId);
+        nextData = removeInspectedNodeData(currentData, action.selectionId);
+        break;
+      case 'replace': {
+        const operatorIds = [...action.operatorIds];
+        if (action.inspectedData) {
+          nextSelection = addSelection(
+            createEmptyOperatorSelectionState(),
+            action.inspectedData.nodeId,
+            action.inspectedData.label,
+            operatorIds
+          );
+          nextData = new Map([[action.inspectedData.nodeId, action.inspectedData]]);
+        } else {
+          nextSelection = createOperatorSelectionState(operatorIds);
+          nextData = new Map([...currentData].filter(([id]) => nextSelection.selections.has(id)));
+        }
+        break;
+      }
+      case 'hydrate': {
+        nextSelection = createEmptyOperatorSelectionState();
+        nextData = new Map();
+        for (const id of action.unresolvedOperatorIds) {
+          nextSelection = addSelection(nextSelection, id, id, [id]);
+        }
+        for (const selection of action.selections) {
+          nextSelection = addSelection(
+            nextSelection,
+            selection.selectionId,
+            selection.label,
+            selection.operatorIds
+          );
+          if (nextSelection.selections.has(selection.selectionId)) {
+            nextData = upsertInspectedNodeData(nextData, selection.inspectedData);
+          }
+        }
+        break;
+      }
+      case 'clear':
+        nextSelection = createEmptyOperatorSelectionState();
+        nextData = new Map();
+        break;
+    }
+
+    set(operatorSelectionAtom, nextSelection);
+    set(selectedNodesDataAtom, nextData);
+    return getSelectedOperatorIds(nextSelection);
+  }
+);
+
+/** The operator IDs represented by the current selections */
+export const selectedNodeIdsAtom = atom(
+  get => getSelectedOperatorIds(get(operatorSelectionAtom)),
+  (_get, set, operatorIds: Set<string>) =>
+    set(operatorSelectionActionAtom, { type: 'replace', operatorIds })
+);
+
+/** Display label of the active operator selection */
+export const selectedOperatorLabelAtom = atom(
+  get => getActiveOperatorLabel(get(operatorSelectionAtom)),
+  (get, set, label: string | null) => {
+    const state = get(operatorSelectionAtom);
+    if (label === null) {
+      set(operatorSelectionAtom, { ...state, activeId: null });
+      return;
+    }
+
+    const activeId = state.activeId ?? getLastOperatorSelectionId(state.selections);
+    if (!activeId) {
+      return;
+    }
+    const activeSelection = state.selections.get(activeId);
+    if (!activeSelection) {
+      return;
+    }
+
+    const selections = new Map(state.selections);
+    selections.set(activeId, { ...activeSelection, label });
+    set(operatorSelectionAtom, { selections, activeId });
+  }
+);
 
 /** The currently selected plan ID in the query plan tree view */
 export const selectedPlanIdAtom = atom<string>('');

--- a/ui/packages/@quent/hooks/src/atoms/dag.ts
+++ b/ui/packages/@quent/hooks/src/atoms/dag.ts
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atom } from 'jotai';
-import type { InspectedNodeData, OperatorSelectionState } from '@quent/utils';
+import type {
+  InspectedNodeData,
+  OperatorSelectionInput,
+  OperatorSelectionState,
+} from '@quent/utils';
 import {
   addOperatorSelection as addSelection,
-  createOperatorSelectionState,
   createEmptyOperatorSelectionState,
   getActiveOperatorLabel,
   getLastOperatorSelectionId,
@@ -26,8 +29,7 @@ export type OperatorSelectionAction =
   | { type: 'remove'; selectionId: string }
   | {
       type: 'replace';
-      operatorIds: Iterable<string>;
-      inspectedData?: InspectedNodeData;
+      selections: ReadonlyArray<OperatorSelectionInput & { inspectedData?: InspectedNodeData }>;
     }
   | {
       type: 'hydrate';
@@ -37,7 +39,6 @@ export type OperatorSelectionAction =
         operatorIds: Iterable<string>;
         inspectedData: InspectedNodeData;
       }>;
-      unresolvedOperatorIds: Iterable<string>;
     }
   | { type: 'clear' };
 
@@ -73,27 +74,8 @@ export const operatorSelectionActionAtom = atom(
         nextData = removeInspectedNodeData(currentData, action.selectionId);
         break;
       case 'replace': {
-        const operatorIds = [...action.operatorIds];
-        if (action.inspectedData) {
-          nextSelection = addSelection(
-            createEmptyOperatorSelectionState(),
-            action.inspectedData.nodeId,
-            action.inspectedData.label,
-            operatorIds
-          );
-          nextData = new Map([[action.inspectedData.nodeId, action.inspectedData]]);
-        } else {
-          nextSelection = createOperatorSelectionState(operatorIds);
-          nextData = new Map([...currentData].filter(([id]) => nextSelection.selections.has(id)));
-        }
-        break;
-      }
-      case 'hydrate': {
         nextSelection = createEmptyOperatorSelectionState();
         nextData = new Map();
-        for (const id of action.unresolvedOperatorIds) {
-          nextSelection = addSelection(nextSelection, id, id, [id]);
-        }
         for (const selection of action.selections) {
           nextSelection = addSelection(
             nextSelection,
@@ -101,7 +83,22 @@ export const operatorSelectionActionAtom = atom(
             selection.label,
             selection.operatorIds
           );
-          if (nextSelection.selections.has(selection.selectionId)) {
+          if (!nextSelection.selections.has(selection.selectionId)) {
+            continue;
+          }
+          const inspectedData = selection.inspectedData ?? currentData.get(selection.selectionId);
+          if (inspectedData) {
+            nextData = upsertInspectedNodeData(nextData, inspectedData);
+          }
+        }
+        nextData = new Map([...nextData].filter(([id]) => nextSelection.selections.has(id)));
+        break;
+      }
+      case 'hydrate': {
+        nextSelection = currentSelection;
+        nextData = new Map(currentData);
+        for (const selection of action.selections) {
+          if (currentSelection.selections.has(selection.selectionId)) {
             nextData = upsertInspectedNodeData(nextData, selection.inspectedData);
           }
         }
@@ -123,7 +120,14 @@ export const operatorSelectionActionAtom = atom(
 export const selectedNodeIdsAtom = atom(
   get => getSelectedOperatorIds(get(operatorSelectionAtom)),
   (_get, set, operatorIds: Set<string>) =>
-    set(operatorSelectionActionAtom, { type: 'replace', operatorIds })
+    set(operatorSelectionActionAtom, {
+      type: 'replace',
+      selections: [...operatorIds].map(selectionId => ({
+        selectionId,
+        label: selectionId,
+        operatorIds: new Set([selectionId]),
+      })),
+    })
 );
 
 /** Display label of the active operator selection */

--- a/ui/packages/@quent/hooks/src/atoms/dagControls.ts
+++ b/ui/packages/@quent/hooks/src/atoms/dagControls.ts
@@ -11,7 +11,7 @@ import type {
   EdgeColoring,
   NodeLabelField,
   DagLayoutDirection,
-  StatValue,
+  InspectedNodeData,
 } from '@quent/utils';
 import { NODE_LABEL_FIELD, DAG_LAYOUT_DIRECTION } from '@quent/utils';
 import type { ContinuousPaletteName } from '@quent/utils';
@@ -36,19 +36,23 @@ export interface HighlightedNodeIdsState {
   primaryOperatorId: string | null;
 }
 
-export interface InspectedOperatorData {
-  nodeId: string;
-  label: string;
-  operationType: string;
-  statistics: Array<{ key: string; value: StatValue; quantity?: string }>;
-}
+/** Inspected details for every selected operator, keyed by selection id. */
+export const selectedNodesDataAtom = atom<ReadonlyMap<string, InspectedNodeData>>(new Map());
 
-export interface InspectedNodeData extends InspectedOperatorData {
-  relatedOperators?: InspectedOperatorData[];
-}
-
-/** Data for the currently selected/pinned node (persists in the panel after click) */
-export const selectedNodeDataAtom = atom<InspectedNodeData | null>(null);
+/** Last pinned node; writing replaces the whole inspected-node map. */
+export const selectedNodeDataAtom = atom(
+  get => {
+    const map = get(selectedNodesDataAtom);
+    let last: InspectedNodeData | null = null;
+    for (const value of map.values()) {
+      last = value;
+    }
+    return last;
+  },
+  (_get, set, value: InspectedNodeData | null) => {
+    set(selectedNodesDataAtom, value == null ? new Map() : new Map([[value.nodeId, value]]));
+  }
+);
 
 /** Consolidated hover/highlight state shared between table and DAG. */
 export const highlightedNodeIdsAtom = atom<HighlightedNodeIdsState>({

--- a/ui/packages/@quent/hooks/src/dag/dagControlSelectors.ts
+++ b/ui/packages/@quent/hooks/src/dag/dagControlSelectors.ts
@@ -4,6 +4,7 @@
 // Selector hooks for DAG control atoms (HOOKS-02: no raw atom exports).
 // Components use these hooks to read/write DAG visual control state.
 
+import { useMemo } from 'react';
 import { useAtomValue, useSetAtom, useAtom } from 'jotai';
 import {
   selectedColorField,
@@ -17,6 +18,7 @@ import {
   selectedNodeLabelFieldAtom,
   selectedDagLayoutDirectionAtom,
   selectedNodeDataAtom,
+  selectedNodesDataAtom,
   highlightedNodeIdsAtom,
   effectiveHighlightedNodeIdsAtom,
   effectiveHoveredStatAtom,
@@ -73,6 +75,11 @@ export function useSelectedNodeData() {
 }
 export function useSetSelectedNodeData() {
   return useSetAtom(selectedNodeDataAtom);
+}
+
+export function useSelectedNodesData() {
+  const map = useAtomValue(selectedNodesDataAtom);
+  return useMemo(() => [...map.values()], [map]);
 }
 
 export function useHighlightedNodeIds() {

--- a/ui/packages/@quent/hooks/src/dag/inspectedNodeData.test.ts
+++ b/ui/packages/@quent/hooks/src/dag/inspectedNodeData.test.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import type { InspectedNodeData } from '@quent/utils';
+import { removeInspectedNodeData, upsertInspectedNodeData } from './inspectedNodeData';
+
+const scan: InspectedNodeData = {
+  nodeId: 'scan',
+  label: 'Scan',
+  operationType: 'scan',
+  statistics: [],
+};
+
+const join: InspectedNodeData = {
+  nodeId: 'join',
+  label: 'Join',
+  operationType: 'join',
+  statistics: [],
+};
+
+describe('inspected node data', () => {
+  it('adds a second operator without replacing the first', () => {
+    const first = upsertInspectedNodeData(new Map(), scan);
+    const second = upsertInspectedNodeData(first, join);
+
+    expect([...second.keys()]).toEqual(['scan', 'join']);
+    expect(second.get('scan')).toEqual(scan);
+    expect(second.get('join')).toEqual(join);
+  });
+
+  it('removes only the requested operator', () => {
+    const both = upsertInspectedNodeData(upsertInspectedNodeData(new Map(), scan), join);
+
+    expect(removeInspectedNodeData(both, 'scan')).toEqual(new Map([['join', join]]));
+  });
+});

--- a/ui/packages/@quent/hooks/src/dag/inspectedNodeData.ts
+++ b/ui/packages/@quent/hooks/src/dag/inspectedNodeData.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { InspectedNodeData } from '@quent/utils';
+
+export function upsertInspectedNodeData(
+  current: ReadonlyMap<string, InspectedNodeData>,
+  data: InspectedNodeData
+): Map<string, InspectedNodeData> {
+  const next = new Map(current);
+  next.set(data.nodeId, data);
+  return next;
+}
+
+export function removeInspectedNodeData(
+  current: ReadonlyMap<string, InspectedNodeData>,
+  nodeId: string
+): ReadonlyMap<string, InspectedNodeData> {
+  if (!current.has(nodeId)) {
+    return current;
+  }
+  const next = new Map(current);
+  next.delete(nodeId);
+  return next;
+}

--- a/ui/packages/@quent/hooks/src/dag/operatorSelection.test.ts
+++ b/ui/packages/@quent/hooks/src/dag/operatorSelection.test.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import {
+  addOperatorSelection,
+  createEmptyOperatorSelectionState,
+  getActiveOperatorLabel,
+  getSelectedOperatorIds,
+  removeOperatorSelection,
+} from './operatorSelection';
+
+describe('operator selection', () => {
+  it('adds multiple selections without replacing the existing selection', () => {
+    const first = addOperatorSelection(
+      createEmptyOperatorSelectionState(),
+      'logical-1',
+      'Logical 1',
+      ['logical-1', 'physical-1']
+    );
+    const second = addOperatorSelection(first, 'logical-2', 'Logical 2', [
+      'logical-2',
+      'physical-2',
+    ]);
+
+    expect(getSelectedOperatorIds(second)).toEqual(
+      new Set(['logical-1', 'physical-1', 'logical-2', 'physical-2'])
+    );
+    expect(second.selections.get('logical-1')).toEqual({
+      label: 'Logical 1',
+      operatorIds: new Set(['logical-1', 'physical-1']),
+    });
+    expect(second.selections.get('logical-2')).toEqual({
+      label: 'Logical 2',
+      operatorIds: new Set(['logical-2', 'physical-2']),
+    });
+    expect(getActiveOperatorLabel(second)).toBe('Logical 2');
+  });
+
+  it('replaces a selected child with its containing parent selection', () => {
+    const child = addOperatorSelection(
+      createEmptyOperatorSelectionState(),
+      'physical-1',
+      'Physical 1',
+      ['physical-1']
+    );
+
+    const result = addOperatorSelection(child, 'logical-1', 'Logical 1', [
+      'logical-1',
+      'physical-1',
+    ]);
+
+    expect([...result.selections.keys()]).toEqual(['logical-1']);
+    expect(getSelectedOperatorIds(result)).toEqual(new Set(['logical-1', 'physical-1']));
+  });
+
+  it('ignores a child selection already covered by a selected parent', () => {
+    const parent = addOperatorSelection(
+      createEmptyOperatorSelectionState(),
+      'logical-1',
+      'Logical 1',
+      ['logical-1', 'physical-1']
+    );
+
+    const result = addOperatorSelection(parent, 'physical-1', 'Physical 1', ['physical-1']);
+
+    expect(result).toBe(parent);
+    expect([...result.selections.keys()]).toEqual(['logical-1']);
+  });
+
+  it('removes only the clicked selection and preserves overlapping operators', () => {
+    const first = addOperatorSelection(createEmptyOperatorSelectionState(), 'logical-1', 'First', [
+      'logical-1',
+      'shared',
+    ]);
+    const state = addOperatorSelection(first, 'logical-2', 'Second', ['logical-2', 'shared']);
+
+    const result = removeOperatorSelection(state, 'logical-1');
+
+    expect(getSelectedOperatorIds(result)).toEqual(new Set(['logical-2', 'shared']));
+    expect(result.selections).toEqual(
+      new Map([
+        [
+          'logical-2',
+          {
+            label: 'Second',
+            operatorIds: new Set(['logical-2', 'shared']),
+          },
+        ],
+      ])
+    );
+  });
+});

--- a/ui/packages/@quent/hooks/src/dag/operatorSelection.ts
+++ b/ui/packages/@quent/hooks/src/dag/operatorSelection.ts
@@ -30,19 +30,6 @@ export function getLastOperatorSelectionId(
   return lastId;
 }
 
-export function createOperatorSelectionState(
-  operatorIds: Iterable<string>
-): OperatorSelectionState {
-  const selections = new Map<string, OperatorSelection>();
-  for (const id of operatorIds) {
-    selections.set(id, { label: id, operatorIds: new Set([id]) });
-  }
-  return {
-    selections,
-    activeId: getLastOperatorSelectionId(selections),
-  };
-}
-
 function containsAll(container: ReadonlySet<string>, contained: ReadonlySet<string>): boolean {
   for (const id of contained) {
     if (!container.has(id)) {

--- a/ui/packages/@quent/hooks/src/dag/operatorSelection.ts
+++ b/ui/packages/@quent/hooks/src/dag/operatorSelection.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OperatorSelection, OperatorSelectionState } from '@quent/utils';
+
+export function createEmptyOperatorSelectionState(): OperatorSelectionState {
+  return {
+    selections: new Map(),
+    activeId: null,
+  };
+}
+
+export function getSelectedOperatorIds(state: OperatorSelectionState): Set<string> {
+  return new Set(
+    Array.from(state.selections.values()).flatMap(selection => [...selection.operatorIds])
+  );
+}
+
+export function getActiveOperatorLabel(state: OperatorSelectionState): string | null {
+  return state.activeId ? (state.selections.get(state.activeId)?.label ?? null) : null;
+}
+
+export function getLastOperatorSelectionId(
+  selections: ReadonlyMap<string, OperatorSelection>
+): string | null {
+  let lastId: string | null = null;
+  for (const id of selections.keys()) {
+    lastId = id;
+  }
+  return lastId;
+}
+
+export function createOperatorSelectionState(
+  operatorIds: Iterable<string>
+): OperatorSelectionState {
+  const selections = new Map<string, OperatorSelection>();
+  for (const id of operatorIds) {
+    selections.set(id, { label: id, operatorIds: new Set([id]) });
+  }
+  return {
+    selections,
+    activeId: getLastOperatorSelectionId(selections),
+  };
+}
+
+function containsAll(container: ReadonlySet<string>, contained: ReadonlySet<string>): boolean {
+  for (const id of contained) {
+    if (!container.has(id)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function addOperatorSelection(
+  state: OperatorSelectionState,
+  selectionId: string,
+  label: string,
+  operatorIds: Iterable<string>
+): OperatorSelectionState {
+  const selectedIds = new Set(operatorIds);
+  selectedIds.add(selectionId);
+
+  for (const [existingId, existing] of state.selections) {
+    if (existingId !== selectionId && containsAll(existing.operatorIds, selectedIds)) {
+      return state;
+    }
+  }
+
+  const selections = new Map(state.selections);
+  for (const [existingId, existing] of selections) {
+    if (existingId !== selectionId && containsAll(selectedIds, existing.operatorIds)) {
+      selections.delete(existingId);
+    }
+  }
+  selections.set(selectionId, { label, operatorIds: selectedIds });
+
+  return {
+    selections,
+    activeId: selectionId,
+  };
+}
+
+export function removeOperatorSelection(
+  state: OperatorSelectionState,
+  selectionId: string
+): OperatorSelectionState {
+  const selections = new Map(state.selections);
+  selections.delete(selectionId);
+
+  return {
+    selections,
+    activeId:
+      state.activeId === selectionId ? getLastOperatorSelectionId(selections) : state.activeId,
+  };
+}

--- a/ui/packages/@quent/hooks/src/dag/operatorSelectionActions.test.ts
+++ b/ui/packages/@quent/hooks/src/dag/operatorSelectionActions.test.ts
@@ -97,7 +97,10 @@ describe('operator selection actions', () => {
       inspectedData: joinData,
     });
 
-    store.set(operatorSelectionActionAtom, { type: 'replace', operatorIds: ['scan'] });
+    store.set(operatorSelectionActionAtom, {
+      type: 'replace',
+      selections: [{ selectionId: 'scan', label: 'Scan', operatorIds: new Set(['scan']) }],
+    });
 
     expect([...store.get(selectedNodesDataAtom).keys()]).toEqual(['scan']);
 
@@ -112,8 +115,14 @@ describe('operator selection actions', () => {
 
     store.set(operatorSelectionActionAtom, {
       type: 'replace',
-      operatorIds: ['join', 'physical-join'],
-      inspectedData: joinData,
+      selections: [
+        {
+          selectionId: 'join',
+          label: 'Join',
+          operatorIds: new Set(['join', 'physical-join']),
+          inspectedData: joinData,
+        },
+      ],
     });
 
     expect(store.get(operatorSelectionAtom).selections).toEqual(
@@ -130,8 +139,23 @@ describe('operator selection actions', () => {
     expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['join', joinData]]));
   });
 
-  it('hydrates resolved selections while preserving unknown IDs', () => {
+  it('hydrates inspection data without changing global selections', () => {
     const store = createStore();
+    store.set(operatorSelectionActionAtom, {
+      type: 'replace',
+      selections: [
+        {
+          selectionId: 'join',
+          label: 'Join',
+          operatorIds: new Set(['join', 'physical-join']),
+        },
+        {
+          selectionId: 'unknown',
+          label: 'Unknown operator',
+          operatorIds: new Set(['unknown']),
+        },
+      ],
+    });
 
     store.set(operatorSelectionActionAtom, {
       type: 'hydrate',
@@ -142,18 +166,29 @@ describe('operator selection actions', () => {
           operatorIds: ['join', 'physical-join'],
           inspectedData: groupedJoinData,
         },
+        {
+          selectionId: 'physical-join',
+          label: 'Physical join',
+          operatorIds: ['physical-join'],
+          inspectedData: scanData,
+        },
       ],
-      unresolvedOperatorIds: ['unknown'],
     });
 
     expect(store.get(operatorSelectionAtom).selections).toEqual(
       new Map([
-        ['unknown', { label: 'unknown', operatorIds: new Set(['unknown']) }],
         [
           'join',
           {
             label: 'Join',
             operatorIds: new Set(['join', 'physical-join']),
+          },
+        ],
+        [
+          'unknown',
+          {
+            label: 'Unknown operator',
+            operatorIds: new Set(['unknown']),
           },
         ],
       ])

--- a/ui/packages/@quent/hooks/src/dag/operatorSelectionActions.test.ts
+++ b/ui/packages/@quent/hooks/src/dag/operatorSelectionActions.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createStore } from 'jotai';
+import { describe, expect, it } from 'vitest';
+import { operatorSelectionActionAtom, operatorSelectionAtom } from '../atoms/dag';
+import { selectedNodesDataAtom } from '../atoms/dagControls';
+
+const scanData = {
+  nodeId: 'scan',
+  label: 'Scan',
+  operationType: 'scan',
+  statistics: [],
+};
+
+const joinData = {
+  nodeId: 'join',
+  label: 'Join',
+  operationType: 'join',
+  statistics: [],
+};
+
+const groupedJoinData = {
+  ...joinData,
+  relatedOperators: [scanData],
+};
+
+describe('operator selection actions', () => {
+  it('updates filter and inspection state together', () => {
+    const store = createStore();
+
+    const selectedIds = store.set(operatorSelectionActionAtom, {
+      type: 'add',
+      selectionId: 'scan',
+      label: 'Scan',
+      operatorIds: ['scan', 'physical-scan'],
+      inspectedData: scanData,
+    });
+
+    expect(selectedIds).toEqual(new Set(['scan', 'physical-scan']));
+    expect(store.get(operatorSelectionAtom).selections.has('scan')).toBe(true);
+    expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['scan', scanData]]));
+
+    store.set(operatorSelectionActionAtom, { type: 'remove', selectionId: 'scan' });
+
+    expect(store.get(operatorSelectionAtom).selections.size).toBe(0);
+    expect(store.get(selectedNodesDataAtom).size).toBe(0);
+  });
+
+  it('keeps only the parent inspection when parent and child selections overlap', () => {
+    const store = createStore();
+    store.set(operatorSelectionActionAtom, {
+      type: 'add',
+      selectionId: 'scan',
+      label: 'Scan',
+      operatorIds: ['scan'],
+      inspectedData: scanData,
+    });
+
+    store.set(operatorSelectionActionAtom, {
+      type: 'add',
+      selectionId: 'join',
+      label: 'Join',
+      operatorIds: ['join', 'scan'],
+      inspectedData: groupedJoinData,
+    });
+
+    expect([...store.get(operatorSelectionAtom).selections.keys()]).toEqual(['join']);
+    expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['join', groupedJoinData]]));
+
+    store.set(operatorSelectionActionAtom, {
+      type: 'add',
+      selectionId: 'scan',
+      label: 'Scan',
+      operatorIds: ['scan'],
+      inspectedData: scanData,
+    });
+
+    expect([...store.get(operatorSelectionAtom).selections.keys()]).toEqual(['join']);
+    expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['join', groupedJoinData]]));
+  });
+
+  it('prunes stale inspection data when replacing or clearing selections', () => {
+    const store = createStore();
+    store.set(operatorSelectionActionAtom, {
+      type: 'add',
+      selectionId: 'scan',
+      label: 'Scan',
+      operatorIds: ['scan'],
+      inspectedData: scanData,
+    });
+    store.set(operatorSelectionActionAtom, {
+      type: 'add',
+      selectionId: 'join',
+      label: 'Join',
+      operatorIds: ['join'],
+      inspectedData: joinData,
+    });
+
+    store.set(operatorSelectionActionAtom, { type: 'replace', operatorIds: ['scan'] });
+
+    expect([...store.get(selectedNodesDataAtom).keys()]).toEqual(['scan']);
+
+    store.set(operatorSelectionActionAtom, { type: 'clear' });
+
+    expect(store.get(operatorSelectionAtom).selections.size).toBe(0);
+    expect(store.get(selectedNodesDataAtom).size).toBe(0);
+  });
+
+  it('hydrates a grouped replacement as one inspected selection', () => {
+    const store = createStore();
+
+    store.set(operatorSelectionActionAtom, {
+      type: 'replace',
+      operatorIds: ['join', 'physical-join'],
+      inspectedData: joinData,
+    });
+
+    expect(store.get(operatorSelectionAtom).selections).toEqual(
+      new Map([
+        [
+          'join',
+          {
+            label: 'Join',
+            operatorIds: new Set(['join', 'physical-join']),
+          },
+        ],
+      ])
+    );
+    expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['join', joinData]]));
+  });
+
+  it('hydrates resolved selections while preserving unknown IDs', () => {
+    const store = createStore();
+
+    store.set(operatorSelectionActionAtom, {
+      type: 'hydrate',
+      selections: [
+        {
+          selectionId: 'join',
+          label: 'Join',
+          operatorIds: ['join', 'physical-join'],
+          inspectedData: groupedJoinData,
+        },
+      ],
+      unresolvedOperatorIds: ['unknown'],
+    });
+
+    expect(store.get(operatorSelectionAtom).selections).toEqual(
+      new Map([
+        ['unknown', { label: 'unknown', operatorIds: new Set(['unknown']) }],
+        [
+          'join',
+          {
+            label: 'Join',
+            operatorIds: new Set(['join', 'physical-join']),
+          },
+        ],
+      ])
+    );
+    expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['join', groupedJoinData]]));
+  });
+});

--- a/ui/packages/@quent/hooks/src/dag/useOperatorSelection.ts
+++ b/ui/packages/@quent/hooks/src/dag/useOperatorSelection.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useAtomValue, useSetAtom } from 'jotai';
+import { operatorSelectionActionAtom, operatorSelectionAtom } from '../atoms/dag';
+
+export type { OperatorSelectionAction } from '../atoms/dag';
+
+export const useOperatorSelection = () => useAtomValue(operatorSelectionAtom);
+export const useOperatorSelectionActions = () => useSetAtom(operatorSelectionActionAtom);

--- a/ui/packages/@quent/hooks/src/deepLink/useSerializableViewState.ts
+++ b/ui/packages/@quent/hooks/src/deepLink/useSerializableViewState.ts
@@ -4,8 +4,14 @@
 import { useCallback } from 'react';
 import { useStore } from 'jotai';
 import type { SortingState } from '@tanstack/react-table';
-import type { ContinuousPaletteName, DagLayoutDirection, NodeLabelField } from '@quent/utils';
-import { selectedNodeIdsAtom, selectedPlanIdAtom } from '../atoms/dag';
+import {
+  resolveOperatorSelections,
+  type ContinuousPaletteName,
+  type DagLayoutDirection,
+  type NodeLabelField,
+  type Operator,
+} from '@quent/utils';
+import { operatorSelectionActionAtom, selectedNodeIdsAtom, selectedPlanIdAtom } from '../atoms/dag';
 import {
   dataFlowEnabledAtom,
   dataFlowIsPlayingAtom,
@@ -83,11 +89,13 @@ export interface HydratableViewState {
 interface SerializableViewStateOptions {
   operatorTablePersistKey: string;
   operatorTableGroupKeys: readonly string[];
+  operators?: readonly Operator[];
 }
 
 export function useSerializableViewState({
   operatorTablePersistKey,
   operatorTableGroupKeys,
+  operators,
 }: SerializableViewStateOptions) {
   const store = useStore();
 
@@ -147,7 +155,14 @@ export function useSerializableViewState({
         store.set(selectedPlanIdAtom, state.selection.planId);
       }
       if (state.selection?.operatorNodeIds !== undefined) {
-        store.set(selectedNodeIdsAtom, new Set(state.selection.operatorNodeIds));
+        if (operators) {
+          store.set(operatorSelectionActionAtom, {
+            type: 'replace',
+            selections: resolveOperatorSelections(operators, state.selection.operatorNodeIds),
+          });
+        } else {
+          store.set(selectedNodeIdsAtom, new Set(state.selection.operatorNodeIds));
+        }
       }
 
       const dag = state.dag;
@@ -217,7 +232,7 @@ export function useSerializableViewState({
         store.set(sortingAtomFamily(operatorTablePersistKey), table.sort);
       }
     },
-    [operatorTableGroupKeys, operatorTablePersistKey, store]
+    [operatorTableGroupKeys, operatorTablePersistKey, operators, store]
   );
 
   return { read, hydrate } as const;

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -11,6 +11,11 @@ export {
   useSelectedOperatorLabel,
   useSetSelectedOperatorLabel,
 } from './dag/useSelectedOperatorLabel';
+export {
+  useOperatorSelection,
+  useOperatorSelectionActions,
+  type OperatorSelectionAction,
+} from './dag/useOperatorSelection';
 export { useSelectedPlanId, useSetSelectedPlanId } from './dag/useSelectedPlanId';
 export { useHoveredWorkerId, useSetHoveredWorkerId } from './dag/useHoveredWorkerId';
 
@@ -85,6 +90,7 @@ export {
   useSelectedDagLayoutDirection,
   useSelectedNodeData,
   useSetSelectedNodeData,
+  useSelectedNodesData,
   useHighlightedNodeIds,
   useSetHighlightedNodeIds,
   useEffectiveHighlightedNodeIds,
@@ -93,12 +99,8 @@ export {
   useSetHoveredStat,
   useSetDagDisplayedNodeIds,
 } from './dag/dagControlSelectors';
-export type {
-  HoveredStatInfo,
-  HighlightedNodeIdsState,
-  InspectedOperatorData,
-  InspectedNodeData,
-} from './atoms/dagControls';
+export type { HoveredStatInfo, HighlightedNodeIdsState } from './atoms/dagControls';
+export type { InspectedNodeData, InspectedOperatorData } from '@quent/utils';
 
 // Data-flow overlay hooks (HOOKS-02: selector hooks over private atoms)
 export {

--- a/ui/packages/@quent/utils/src/index.ts
+++ b/ui/packages/@quent/utils/src/index.ts
@@ -79,6 +79,14 @@ export type {
   DAGEdge,
 } from './dagTypes';
 
+// Operator selection and inspection types
+export type {
+  OperatorSelection,
+  OperatorSelectionState,
+  InspectedOperatorData,
+  InspectedNodeData,
+} from './operatorTypes';
+
 export { AGG_MODES } from './aggMode';
 export type { AggMode } from './aggMode';
 

--- a/ui/packages/@quent/utils/src/index.ts
+++ b/ui/packages/@quent/utils/src/index.ts
@@ -82,10 +82,16 @@ export type {
 // Operator selection and inspection types
 export type {
   OperatorSelection,
+  OperatorSelectionInput,
   OperatorSelectionState,
   InspectedOperatorData,
   InspectedNodeData,
 } from './operatorTypes';
+export {
+  buildRelatedOperatorIdsById,
+  getOperatorDisplayLabel,
+  resolveOperatorSelections,
+} from './operatorHierarchy';
 
 export { AGG_MODES } from './aggMode';
 export type { AggMode } from './aggMode';

--- a/ui/packages/@quent/utils/src/operatorHierarchy.test.ts
+++ b/ui/packages/@quent/utils/src/operatorHierarchy.test.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import type { Operator } from './types';
+import { buildRelatedOperatorIdsById, resolveOperatorSelections } from './operatorHierarchy';
+
+function makeOperator(id: string, label: string, parentOperatorIds: string[] = []): Operator {
+  return {
+    id,
+    plan_id: null,
+    parent_operator_ids: parentOperatorIds,
+    instance_name: label,
+    operator_type_name: null,
+    custom_attributes: {},
+    statistics: null,
+    active_span: null,
+  };
+}
+
+describe('operator hierarchy', () => {
+  it('finds direct and transitive descendants', () => {
+    const operators = [
+      makeOperator('logical', 'Logical'),
+      makeOperator('intermediate', 'Intermediate', ['logical']),
+      makeOperator('physical', 'Physical', ['intermediate']),
+    ];
+
+    expect(buildRelatedOperatorIdsById(operators).get('logical')).toEqual([
+      'intermediate',
+      'physical',
+    ]);
+  });
+
+  it('handles parent cycles without including the root', () => {
+    const operators = [
+      makeOperator('left', 'Left', ['right']),
+      makeOperator('right', 'Right', ['left']),
+    ];
+
+    expect(buildRelatedOperatorIdsById(operators).get('left')).toEqual(['right']);
+  });
+
+  it('collapses a complete descendant set into its maximal parent', () => {
+    const operators = [
+      makeOperator('logical', 'Logical'),
+      makeOperator('left', 'Left', ['logical']),
+      makeOperator('right', 'Right', ['logical']),
+    ];
+
+    expect(resolveOperatorSelections(operators, ['logical', 'left', 'right'])).toEqual([
+      {
+        selectionId: 'logical',
+        label: 'Logical',
+        operatorIds: new Set(['logical', 'left', 'right']),
+      },
+    ]);
+  });
+
+  it('splits a parent when one covered child is deselected', () => {
+    const operators = [
+      makeOperator('logical', 'Logical'),
+      makeOperator('left', 'Left', ['logical']),
+      makeOperator('right', 'Right', ['logical']),
+    ];
+
+    const selections = resolveOperatorSelections(operators, ['logical', 'right']);
+
+    expect(new Map(selections.map(selection => [selection.selectionId, selection.label]))).toEqual(
+      new Map([
+        ['right', 'Right'],
+        ['logical', 'Logical'],
+      ])
+    );
+  });
+});

--- a/ui/packages/@quent/utils/src/operatorHierarchy.ts
+++ b/ui/packages/@quent/utils/src/operatorHierarchy.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Operator } from './types';
+import type { OperatorSelectionInput } from './operatorTypes';
+
+export function getOperatorDisplayLabel(operator: Operator): string {
+  return operator.instance_name ?? operator.operator_type_name ?? operator.id;
+}
+
+export function buildRelatedOperatorIdsById(
+  operators: readonly Operator[],
+  rootOperatorIds: Iterable<string> = operators.map(operator => operator.id)
+): Map<string, string[]> {
+  const childrenByParentId = new Map<string, string[]>();
+  for (const operator of operators) {
+    for (const parentId of operator.parent_operator_ids ?? []) {
+      const children = childrenByParentId.get(parentId) ?? [];
+      children.push(operator.id);
+      childrenByParentId.set(parentId, children);
+    }
+  }
+
+  const relatedById = new Map<string, string[]>();
+  for (const operatorId of rootOperatorIds) {
+    const related = new Set<string>();
+    const stack = [...(childrenByParentId.get(operatorId) ?? [])];
+    while (stack.length > 0) {
+      const childId = stack.pop()!;
+      if (childId === operatorId || related.has(childId)) {
+        continue;
+      }
+      related.add(childId);
+      stack.push(...(childrenByParentId.get(childId) ?? []));
+    }
+    relatedById.set(operatorId, [...related].sort());
+  }
+
+  return relatedById;
+}
+
+export function resolveOperatorSelections(
+  operators: readonly Operator[],
+  selectedOperatorIds: Iterable<string>
+): OperatorSelectionInput[] {
+  const selectedIds = [...new Set(selectedOperatorIds)];
+  const remainingIds = new Set(selectedIds);
+  const operatorsById = new Map(operators.map(operator => [operator.id, operator]));
+  const relatedById = buildRelatedOperatorIdsById(operators, selectedIds);
+  const orderById = new Map(selectedIds.map((id, index) => [id, index]));
+  const candidates = selectedIds
+    .flatMap(id => {
+      const operator = operatorsById.get(id);
+      if (!operator) {
+        return [];
+      }
+      return [
+        {
+          operator,
+          operatorIds: new Set([id, ...(relatedById.get(id) ?? [])]),
+        },
+      ];
+    })
+    .sort(
+      (left, right) =>
+        right.operatorIds.size - left.operatorIds.size ||
+        (orderById.get(left.operator.id) ?? 0) - (orderById.get(right.operator.id) ?? 0)
+    );
+
+  const selections: OperatorSelectionInput[] = [];
+  for (const candidate of candidates) {
+    if (![...candidate.operatorIds].every(id => remainingIds.has(id))) {
+      continue;
+    }
+    selections.push({
+      selectionId: candidate.operator.id,
+      label: getOperatorDisplayLabel(candidate.operator),
+      operatorIds: candidate.operatorIds,
+    });
+    for (const id of candidate.operatorIds) {
+      remainingIds.delete(id);
+    }
+  }
+
+  for (const id of selectedIds) {
+    if (!remainingIds.delete(id)) {
+      continue;
+    }
+    const operator = operatorsById.get(id);
+    selections.push({
+      selectionId: id,
+      label: operator ? getOperatorDisplayLabel(operator) : id,
+      operatorIds: new Set([id]),
+    });
+  }
+
+  return selections;
+}

--- a/ui/packages/@quent/utils/src/operatorTypes.ts
+++ b/ui/packages/@quent/utils/src/operatorTypes.ts
@@ -8,6 +8,10 @@ export interface OperatorSelection {
   readonly operatorIds: ReadonlySet<string>;
 }
 
+export interface OperatorSelectionInput extends OperatorSelection {
+  readonly selectionId: string;
+}
+
 export interface OperatorSelectionState {
   readonly selections: ReadonlyMap<string, OperatorSelection>;
   readonly activeId: string | null;

--- a/ui/packages/@quent/utils/src/operatorTypes.ts
+++ b/ui/packages/@quent/utils/src/operatorTypes.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { StatValue } from './dagTypes';
+
+export interface OperatorSelection {
+  readonly label: string;
+  readonly operatorIds: ReadonlySet<string>;
+}
+
+export interface OperatorSelectionState {
+  readonly selections: ReadonlyMap<string, OperatorSelection>;
+  readonly activeId: string | null;
+}
+
+export interface InspectedOperatorData {
+  nodeId: string;
+  label: string;
+  operationType: string;
+  statistics: Array<{ key: string; value: StatValue; quantity?: string }>;
+}
+
+export interface InspectedNodeData extends InspectedOperatorData {
+  relatedOperators?: InspectedOperatorData[];
+}

--- a/ui/src/components/entities-table/EntitiesTable.test.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createStore, Provider } from 'jotai';
 import {
@@ -319,9 +319,6 @@ describe('EntitiesTable', () => {
     expect(screen.getByTestId('operator-selection-labels')).toHaveTextContent(
       JSON.stringify(['Logical Operator'])
     );
-    const toolbarBadges = screen.getByTestId('operator-filter-badges');
-    expect(within(toolbarBadges).getByText('Logical Operator')).toBeInTheDocument();
-    expect(within(toolbarBadges).queryByText('Child One')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('option', { name: 'Child One' }));
 
@@ -333,8 +330,6 @@ describe('EntitiesTable', () => {
     expect(screen.getByTestId('operator-selection-labels')).toHaveTextContent(
       JSON.stringify(['Child Two', 'Logical Operator'])
     );
-    expect(within(toolbarBadges).getByText('Child Two')).toBeInTheDocument();
-    expect(within(toolbarBadges).queryByText('child-two')).not.toBeInTheDocument();
   });
 
   it('shows empty state when the response contains no entities', () => {

--- a/ui/src/components/entities-table/EntitiesTable.test.tsx
+++ b/ui/src/components/entities-table/EntitiesTable.test.tsx
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createStore, Provider } from 'jotai';
-import { useSetSelectedNodeIds } from '@quent/hooks';
+import {
+  useOperatorSelection,
+  useOperatorSelectionActions,
+  useSelectedNodeIds,
+} from '@quent/hooks';
 import type { EntityRef, QueryBundle } from '@quent/utils';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { EntitiesTable } from './EntitiesTable';
@@ -48,6 +52,33 @@ const queryBundle = {
   },
 } as unknown as QueryBundle<EntityRef>;
 
+const logicalOperatorQueryBundle = {
+  ...queryBundle,
+  entities: {
+    ...queryBundle.entities,
+    operators: {
+      logical: {
+        id: 'logical',
+        instance_name: 'Logical Operator',
+        operator_type_name: 'Logical',
+        parent_operator_ids: [],
+      },
+      'child-one': {
+        id: 'child-one',
+        instance_name: 'Child One',
+        operator_type_name: 'Physical',
+        parent_operator_ids: ['logical'],
+      },
+      'child-two': {
+        id: 'child-two',
+        instance_name: 'Child Two',
+        operator_type_name: 'Physical',
+        parent_operator_ids: ['logical'],
+      },
+    },
+  },
+} as unknown as QueryBundle<EntityRef>;
+
 const fsm = {
   id: 'entity-1',
   type_name: 'Task',
@@ -71,11 +102,40 @@ const fsm = {
 };
 
 function DagSelectionControl() {
-  const setSelectedNodeIds = useSetSelectedNodeIds();
+  const updateOperatorSelection = useOperatorSelectionActions();
   return (
-    <button type="button" onClick={() => setSelectedNodeIds(new Set(['operator-1']))}>
+    <button
+      type="button"
+      onClick={() =>
+        updateOperatorSelection({
+          type: 'add',
+          selectionId: 'operator-1',
+          label: 'Operator One',
+          operatorIds: ['operator-1'],
+          inspectedData: {
+            nodeId: 'operator-1',
+            label: 'Operator One',
+            operationType: 'scan',
+            statistics: [],
+          },
+        })
+      }
+    >
       Select DAG operator
     </button>
+  );
+}
+
+function OperatorSelectionProbe() {
+  const operatorIds = useSelectedNodeIds();
+  const selection = useOperatorSelection();
+  return (
+    <>
+      <output data-testid="selected-operator-ids">{JSON.stringify([...operatorIds].sort())}</output>
+      <output data-testid="operator-selection-labels">
+        {JSON.stringify([...selection.selections.values()].map(value => value.label).sort())}
+      </output>
+    </>
   );
 }
 
@@ -187,6 +247,7 @@ describe('EntitiesTable', () => {
   });
 
   it('supports selecting multiple operators from the dropdown', () => {
+    const store = createStore();
     const multiOperatorQueryBundle = {
       ...queryBundle,
       entities: {
@@ -203,7 +264,15 @@ describe('EntitiesTable', () => {
     } as unknown as QueryBundle<EntityRef>;
 
     renderTable(
-      <EntitiesTable engineId="engine-1" queryId="query-1" queryBundle={multiOperatorQueryBundle} />
+      <>
+        <OperatorSelectionProbe />
+        <EntitiesTable
+          engineId="engine-1"
+          queryId="query-1"
+          queryBundle={multiOperatorQueryBundle}
+        />
+      </>,
+      { store }
     );
 
     fireEvent.click(screen.getByRole('combobox', { name: 'Operator' }));
@@ -217,6 +286,55 @@ describe('EntitiesTable', () => {
     );
     expect(params.request.entry.application.operator_ids).toHaveLength(2);
     expect(screen.getByRole('combobox', { name: 'Operator' })).toHaveTextContent('2 selected');
+    expect(screen.getByTestId('operator-selection-labels')).toHaveTextContent(
+      JSON.stringify(['Operator One', 'Operator Two'])
+    );
+  });
+
+  it('groups logical operators and splits the group when a child is deselected', () => {
+    const store = createStore();
+    renderTable(
+      <>
+        <OperatorSelectionProbe />
+        <EntitiesTable
+          engineId="engine-1"
+          queryId="query-1"
+          queryBundle={logicalOperatorQueryBundle}
+        />
+      </>,
+      { store }
+    );
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Operator' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Logical Operator' }));
+
+    let params = useEntities.mock.lastCall?.[0];
+    expect(params.request.entry.application.operator_ids).toEqual(
+      expect.arrayContaining(['logical', 'child-one', 'child-two'])
+    );
+    expect(params.request.entry.application.operator_ids).toHaveLength(3);
+    expect(screen.getByTestId('selected-operator-ids')).toHaveTextContent(
+      JSON.stringify(['child-one', 'child-two', 'logical'])
+    );
+    expect(screen.getByTestId('operator-selection-labels')).toHaveTextContent(
+      JSON.stringify(['Logical Operator'])
+    );
+    const toolbarBadges = screen.getByTestId('operator-filter-badges');
+    expect(within(toolbarBadges).getByText('Logical Operator')).toBeInTheDocument();
+    expect(within(toolbarBadges).queryByText('Child One')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('option', { name: 'Child One' }));
+
+    params = useEntities.mock.lastCall?.[0];
+    expect(params.request.entry.application.operator_ids).toEqual(
+      expect.arrayContaining(['logical', 'child-two'])
+    );
+    expect(params.request.entry.application.operator_ids).toHaveLength(2);
+    expect(screen.getByTestId('operator-selection-labels')).toHaveTextContent(
+      JSON.stringify(['Child Two', 'Logical Operator'])
+    );
+    expect(within(toolbarBadges).getByText('Child Two')).toBeInTheDocument();
+    expect(within(toolbarBadges).queryByText('child-two')).not.toBeInTheDocument();
   });
 
   it('shows empty state when the response contains no entities', () => {

--- a/ui/src/components/entities-table/useEntityTable.ts
+++ b/ui/src/components/entities-table/useEntityTable.ts
@@ -4,12 +4,19 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useEntities, useEntityList } from '@quent/client';
 import {
+  useOperatorSelection,
+  useOperatorSelectionActions,
   useSelectedNodeIds,
-  useSetSelectedNodeIds,
-  useSetSelectedOperatorLabel,
 } from '@quent/hooks';
 import type { OptionMultiSelectOption, SelectFieldOption } from '@quent/components';
-import type { EntityRef, FiniteStateMachine, QueryBundle, SortDir } from '@quent/utils';
+import {
+  buildRelatedOperatorIdsById,
+  resolveOperatorSelections,
+  type EntityRef,
+  type FiniteStateMachine,
+  type QueryBundle,
+  type SortDir,
+} from '@quent/utils';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import type { EntityFilters } from './types';
 import {
@@ -22,7 +29,6 @@ import {
   normalizePageSize,
   operatorLocationDescription,
   resourceLocationDescription,
-  selectedOperatorsLabel,
   validateEntityFilters,
 } from './utils';
 
@@ -36,9 +42,11 @@ interface UseEntityTableParams {
 
 export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTableParams) {
   const { entities, duration_s: durationS } = queryBundle;
+  const operatorSelection = useOperatorSelection();
   const operatorIds = useSelectedNodeIds();
-  const setSelectedNodeIds = useSetSelectedNodeIds();
-  const setSelectedOperatorLabel = useSetSelectedOperatorLabel();
+  const updateOperatorSelection = useOperatorSelectionActions();
+  const operators = useMemo(() => Object.values(entities.operators), [entities.operators]);
+  const relatedOperatorIdsById = useMemo(() => buildRelatedOperatorIdsById(operators), [operators]);
   const defaults = useMemo(() => defaultEntityFilters(durationS), [durationS]);
   // The "Window (s)" slider is bounded by the query duration, which is often far longer than
   // when entities actually occur. Use the longest-running entity's end time as a tighter,
@@ -94,25 +102,35 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
 
   const applyOperatorSelection = useCallback(
     (nextIds: Set<string>) => {
-      setSelectedNodeIds(nextIds);
-      setSelectedOperatorLabel(selectedOperatorsLabel(nextIds, operatorLabel));
+      updateOperatorSelection({
+        type: 'replace',
+        selections: resolveOperatorSelections(operators, nextIds),
+      });
       setPage(0);
       setSelected(null);
     },
-    [operatorLabel, setSelectedNodeIds, setSelectedOperatorLabel]
+    [operators, updateOperatorSelection]
   );
 
   const toggleOperator = useCallback(
     (value: string) => {
       const next = new Set(operatorIds);
-      if (next.has(value)) {
+      const selectedGroup = operatorSelection.selections.get(value);
+      if (selectedGroup) {
+        for (const id of selectedGroup.operatorIds) {
+          next.delete(id);
+        }
+      } else if (next.has(value)) {
         next.delete(value);
       } else {
         next.add(value);
+        for (const id of relatedOperatorIdsById.get(value) ?? []) {
+          next.add(id);
+        }
       }
       applyOperatorSelection(next);
     },
-    [applyOperatorSelection, operatorIds]
+    [applyOperatorSelection, operatorIds, operatorSelection.selections, relatedOperatorIdsById]
   );
 
   const selectAllOperators = useCallback(
@@ -127,22 +145,21 @@ export function useEntityTable({ engineId, queryId, queryBundle }: UseEntityTabl
 
   const resetFilters = useCallback(() => {
     setFilters(defaults);
-    setSelectedNodeIds(new Set());
-    setSelectedOperatorLabel(null);
+    updateOperatorSelection({ type: 'clear' });
     setPage(0);
     setSelected(null);
-  }, [defaults, setSelectedNodeIds, setSelectedOperatorLabel]);
+  }, [defaults, updateOperatorSelection]);
 
   const operatorOptions = useMemo<OptionMultiSelectOption[]>(
     () =>
-      Object.values(entities.operators)
+      operators
         .map(operator => ({
           value: operator.id,
           label: operator.instance_name ?? operator.operator_type_name ?? operator.id,
           description: operatorLocationDescription(operator, entities.plans, entities.workers),
         }))
         .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? '')),
-    [entities.operators, entities.plans, entities.workers]
+    [entities.plans, entities.workers, operators]
   );
   const entityTypeOptions = useMemo<SelectFieldOption[]>(
     () =>

--- a/ui/src/components/entities-table/utils.ts
+++ b/ui/src/components/entities-table/utils.ts
@@ -167,20 +167,6 @@ export function parseOptionalNumber(value: string): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-/** Builds the crossfilter chip label (e.g. shown in QueryToolbar) for a set of selected operators. */
-export function selectedOperatorsLabel(
-  operatorIds: ReadonlySet<string>,
-  operatorLabel: (id: string) => string
-): string | null {
-  if (operatorIds.size === 0) {
-    return null;
-  }
-  if (operatorIds.size === 1) {
-    return operatorLabel([...operatorIds][0]);
-  }
-  return `${operatorIds.size} operators`;
-}
-
 /** Builds a "Plan / Worker" subtitle so operators sharing the same name can be told apart. */
 export function operatorLocationDescription(
   operator: Operator,

--- a/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
+++ b/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
@@ -13,6 +13,7 @@ import {
   useZoomRange,
 } from '@quent/hooks';
 import { NVTX_SECTION_ID, toast, Toaster } from '@quent/components';
+import type { Operator } from '@quent/utils';
 import { render, screen, waitFor, userEvent } from '@/test/test-utils';
 import {
   expandedIdsAtom,
@@ -45,6 +46,28 @@ const BOUNDARY_PROPS = {
 
 const RESOURCE_A_ID = '01a025ff-ea8b-7881-9d31-72a275872c9d';
 const RESOURCE_B_ID = '01a025ff-ea8b-7881-9d31-72a275872c9e';
+const DEEP_LINK_OPERATORS: Operator[] = [
+  {
+    id: 'operator-a',
+    plan_id: null,
+    parent_operator_ids: [],
+    instance_name: 'Operator A',
+    operator_type_name: null,
+    custom_attributes: {},
+    statistics: null,
+    active_span: null,
+  },
+  {
+    id: 'operator-child',
+    plan_id: null,
+    parent_operator_ids: ['operator-a'],
+    instance_name: 'Operator Child',
+    operator_type_name: null,
+    custom_attributes: {},
+    statistics: null,
+    active_span: null,
+  },
+];
 
 function ViewportProbe() {
   const immediate = useZoomRange();
@@ -240,7 +263,10 @@ describe('DeepLinkBoundary', () => {
     const encoded = encodeDeepLinkState({
       route: { engineId: 'e', queryId: 'q', tab: 'timeline' },
       timeline: { zoomRange: { start: 10, end: 40 } },
-      selection: { planId: 'plan-a', operatorNodeIds: ['operator-a', 'operator-unknown'] },
+      selection: {
+        planId: 'plan-a',
+        operatorNodeIds: ['operator-a', 'operator-child', 'operator-unknown'],
+      },
       resources: {
         expandedRowIds: ['worker-a'],
         resourceFilter: {
@@ -284,7 +310,11 @@ describe('DeepLinkBoundary', () => {
 
     render(
       <JotaiProvider>
-        <DeepLinkBoundary {...BOUNDARY_PROPS} encodedState={encoded.value}>
+        <DeepLinkBoundary
+          {...BOUNDARY_PROPS}
+          operators={DEEP_LINK_OPERATORS}
+          encodedState={encoded.value}
+        >
           <SerializableStateProbe />
           <OperatorSelectionProbe />
         </DeepLinkBoundary>
@@ -296,7 +326,7 @@ describe('DeepLinkBoundary', () => {
       view: {
         selection: {
           planId: 'plan-a',
-          operatorNodeIds: ['operator-a', 'operator-unknown'],
+          operatorNodeIds: ['operator-a', 'operator-child', 'operator-unknown'],
         },
         dag: {
           nodeColorField: 'duration_s',
@@ -337,7 +367,11 @@ describe('DeepLinkBoundary', () => {
     });
     expect(screen.getByTestId('operator-selection')).toHaveTextContent(
       JSON.stringify([
-        { id: 'operator-a', label: 'operator-a', operatorIds: ['operator-a'] },
+        {
+          id: 'operator-a',
+          label: 'Operator A',
+          operatorIds: ['operator-a', 'operator-child'],
+        },
         {
           id: 'operator-unknown',
           label: 'operator-unknown',

--- a/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
+++ b/ui/src/features/deep-link/DeepLinkBoundary.test.tsx
@@ -6,6 +6,7 @@ import { Provider as JotaiProvider, createStore, useAtomValue, useSetAtom } from
 import {
   useDebouncedZoomRange,
   useHydrateTimelineAtoms,
+  useOperatorSelection,
   useSerializableViewState,
   useSetDebouncedZoomRange,
   useSetZoomRange,
@@ -83,6 +84,21 @@ function SerializableStateProbe() {
           resourceFilter,
         },
       })}
+    </output>
+  );
+}
+
+function OperatorSelectionProbe() {
+  const selection = useOperatorSelection();
+  return (
+    <output data-testid="operator-selection">
+      {JSON.stringify(
+        [...selection.selections].map(([id, value]) => ({
+          id,
+          label: value.label,
+          operatorIds: [...value.operatorIds],
+        }))
+      )}
     </output>
   );
 }
@@ -224,7 +240,7 @@ describe('DeepLinkBoundary', () => {
     const encoded = encodeDeepLinkState({
       route: { engineId: 'e', queryId: 'q', tab: 'timeline' },
       timeline: { zoomRange: { start: 10, end: 40 } },
-      selection: { planId: 'plan-a', operatorNodeIds: ['operator-a'] },
+      selection: { planId: 'plan-a', operatorNodeIds: ['operator-a', 'operator-unknown'] },
       resources: {
         expandedRowIds: ['worker-a'],
         resourceFilter: {
@@ -270,6 +286,7 @@ describe('DeepLinkBoundary', () => {
       <JotaiProvider>
         <DeepLinkBoundary {...BOUNDARY_PROPS} encodedState={encoded.value}>
           <SerializableStateProbe />
+          <OperatorSelectionProbe />
         </DeepLinkBoundary>
       </JotaiProvider>
     );
@@ -277,7 +294,10 @@ describe('DeepLinkBoundary', () => {
     const value = JSON.parse(screen.getByTestId('serializable-state').textContent ?? '{}');
     expect(value).toMatchObject({
       view: {
-        selection: { planId: 'plan-a', operatorNodeIds: ['operator-a'] },
+        selection: {
+          planId: 'plan-a',
+          operatorNodeIds: ['operator-a', 'operator-unknown'],
+        },
         dag: {
           nodeColorField: 'duration_s',
           nodeColorPalette: 'viridis',
@@ -315,6 +335,16 @@ describe('DeepLinkBoundary', () => {
         },
       },
     });
+    expect(screen.getByTestId('operator-selection')).toHaveTextContent(
+      JSON.stringify([
+        { id: 'operator-a', label: 'operator-a', operatorIds: ['operator-a'] },
+        {
+          id: 'operator-unknown',
+          label: 'operator-unknown',
+          operatorIds: ['operator-unknown'],
+        },
+      ])
+    );
   });
 
   it('clears an existing resource filter when shared state omits resources', () => {

--- a/ui/src/features/deep-link/DeepLinkBoundary.tsx
+++ b/ui/src/features/deep-link/DeepLinkBoundary.tsx
@@ -17,7 +17,7 @@ import {
   useSetDebouncedZoomRange,
   useSetZoomRange,
 } from '@quent/hooks';
-import { DAG_LAYOUT_DIRECTION, NODE_LABEL_FIELD } from '@quent/utils';
+import { DAG_LAYOUT_DIRECTION, NODE_LABEL_FIELD, type Operator } from '@quent/utils';
 import { toast } from '@quent/components';
 import {
   expandedIdsAtom,
@@ -53,6 +53,7 @@ interface DeepLinkBoundaryProps {
   activeTab?: DeepLinkTab;
   durationSeconds: number;
   defaultRootResourceType?: string | null;
+  operators?: readonly Operator[];
   encodedState?: string;
   isQueryReady: boolean;
 }
@@ -80,6 +81,7 @@ export function DeepLinkBoundary({
   activeTab,
   durationSeconds,
   defaultRootResourceType = null,
+  operators,
   encodedState,
   isQueryReady,
 }: DeepLinkBoundaryProps) {
@@ -91,6 +93,7 @@ export function DeepLinkBoundary({
     useSerializableViewState({
       operatorTablePersistKey: OPERATOR_TABLE_PERSIST_KEY,
       operatorTableGroupKeys: OPERATOR_TABLE_INDEX_ORDER,
+      operators,
     });
   const intakeRoute = useRef({ engineId, queryId, activeTab }).current;
   const [isHydrated, setIsHydrated] = useState(!encodedState);

--- a/ui/src/routes/profile.engine.$engineId.tsx
+++ b/ui/src/routes/profile.engine.$engineId.tsx
@@ -3,7 +3,7 @@
 
 import { createFileRoute, Outlet, useMatch } from '@tanstack/react-router';
 import { Provider } from 'jotai';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { QueryPlan } from '@/components/QueryPlan';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@quent/components';
 import { DeepLinkBoundary } from '@/features/deep-link';
@@ -49,6 +49,10 @@ function ProfileLayout() {
   const queryId = queryMatch?.params?.queryId;
   const encodedState = queryMatch?.search?.s;
   const queryBundle = queryMatch?.loaderData;
+  const operators = useMemo(
+    () => (queryBundle ? Object.values(queryBundle.entities.operators) : undefined),
+    [queryBundle]
+  );
   const timelineMatch = useMatch({
     from: '/profile/engine/$engineId/query/$queryId/timeline',
     shouldThrow: false,
@@ -78,6 +82,7 @@ function ProfileLayout() {
         activeTab={activeTab}
         durationSeconds={queryBundle?.duration_s ?? 0}
         defaultRootResourceType={defaultRootResourceType(queryBundle)}
+        operators={operators}
         encodedState={encodedState}
         isQueryReady={isQueryReady}
       >


### PR DESCRIPTION
# Description

* Add final selection and inspected-data types in [operatorTypes.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/utils/src/operatorTypes.ts), pure selection/deduplication logic in [operatorSelection.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/hooks/src/dag/operatorSelection.ts), inspected-data map helpers in [inspectedNodeData.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/hooks/src/dag/inspectedNodeData.ts), and their unit tests.



* Add the transactional action atom and multi-inspection map through [dag.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/hooks/src/atoms/dag.ts) and [dagControls.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/hooks/src/atoms/dagControls.ts), including parent/child overlap deduplication and stale inspected-data pruning.



* Export selector/action hooks through [useOperatorSelection.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/hooks/src/dag/useOperatorSelection.ts), [dagControlSelectors.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/hooks/src/dag/dagControlSelectors.ts), and package indexes; update the type-only import in [dagSelection.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/dagSelection.ts).



* Preserve selectedNodeIdsAtom, useSelectedNodeData, and their setters as backward-compatible shims. Keep all existing components on those shims in this PR.



* Keep the existing operatorNodeIds[] schema and encoding in [useSerializableViewState.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/hooks/src/deepLink/useSerializableViewState.ts); IDs are already serialized correctly.



* After DAG data loads, reconcile URL-restored IDs into complete logical selections: recover display labels, parent/related-operator grouping, statistics, and inspected panel data from the loaded DAG metadata.



* Extend [dagSelection.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/dagSelection.ts) with a pure multi-selection resolver and add an atomic hydration action so partially loaded metadata never reaches consumers.



* Preserve unknown IDs as placeholders until matching DAG data is available rather than silently dropping URL state.



* Cover single physical operators, higher-level parent/child groups, multiple selections, delayed DAG loading, and unknown IDs in [DAGChart.test.ts](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/DAGChart.test.ts) and [DeepLinkBoundary.test.tsx](https://github.com/rapidsai/quent/pull/ui/src/features/deep-link/DeepLinkBoundary.test.tsx).


### Selected operator state consolidation:

* Consolidate selected-operator state into a single canonical selection model shared across DAG, entity filters, and deep links.
* Add reusable operator hierarchy utilities for descendant resolution, display labels, and grouped selections.

## Related Issues


## Testing

Result after merge: click behavior remains single-select, but the final state model is ready and existing deep links restore meaningful labels and detail-panel content without a URL-format change.

## Screenshots

<!-- For UI changes, include screenshots or videos when possible. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>