### PR TITLE
feat(components): support multi-operator selection across query views

### DIFF
--- a/ui/packages/@quent/components/src/dag/DAGChart.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGChart.tsx
@@ -29,8 +29,7 @@ import {
 import '@xyflow/react/dist/style.css';
 import {
   useSelectedNodeIds,
-  useSetSelectedNodeIds,
-  useSetSelectedOperatorLabel,
+  useOperatorSelection,
   useOperatorSelectionActions,
   useEdgeWidthConfig,
   useEdgeColoring,
@@ -38,7 +37,6 @@ import {
   useSelectedEdgeWidthField,
   useSelectedEdgeColorField,
   useEffectiveHighlightedNodeIds,
-  useSetSelectedNodeData,
   useSetDagDisplayedNodeIds,
   useSelectedDagLayoutDirection,
   useDataFlowEnabled,
@@ -56,6 +54,7 @@ import {
   getOperationTypeColor,
   buildOperatorColorMap,
   inferFieldFormatter,
+  type InspectedNodeData,
   type QuantitySpec,
 } from '@quent/utils';
 
@@ -269,6 +268,21 @@ interface DAGProps {
   onSelectionChange?: (nodeIds: string[]) => void;
 }
 
+function inspectedNodeFromFlowNode(node: Node<QueryPlanNodeData>): InspectedNodeData {
+  return {
+    nodeId: node.id,
+    label: node.data.label,
+    operationType: node.data.operationType,
+    statistics: parseCustomStatistics(node.data.metadata?.rawNode),
+    relatedOperators: node.data.metadata?.relatedOperators?.map(operator => ({
+      nodeId: operator.id,
+      label: operator.instance_name ?? operator.operator_type_name ?? 'Operator',
+      operationType: operator.operator_type_name?.toLowerCase() ?? 'operator',
+      statistics: parseCustomStatistics(operator),
+    })),
+  };
+}
+
 const FlowLayout = ({
   data,
   containerRef,
@@ -285,11 +299,9 @@ const FlowLayout = ({
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<QueryPlanNodeData>>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const { fitView } = useReactFlow();
-  const setSelectedNodeIds = useSetSelectedNodeIds();
-  const setSelectedOperatorLabel = useSetSelectedOperatorLabel();
+  const operatorSelection = useOperatorSelection();
   const updateOperatorSelection = useOperatorSelectionActions();
   const setDagDisplayedNodeIds = useSetDagDisplayedNodeIds();
-  const setSelectedNodeData = useSetSelectedNodeData();
   const selectedNodeIds = useSelectedNodeIds();
   const [layoutDirection] = useSelectedDagLayoutDirection();
   const dataFlowEnabled = useDataFlowEnabled();
@@ -418,46 +430,30 @@ const FlowLayout = ({
 
   const handleNodeClick = useCallback(
     (_event: MouseEvent, node: Node<QueryPlanNodeData>): void => {
-      if (selectedNodeIds.has(node.id)) {
-        setSelectedNodeIds(new Set());
-        setSelectedOperatorLabel(null);
-        setSelectedNodeData(null);
-        onSelectionChange?.([]);
-      } else {
-        const selectionIds = getSelectionIds(node);
-        const newSet = new Set(selectionIds);
-        setSelectedNodeIds(newSet);
-        setSelectedOperatorLabel(node.data.label);
-        setSelectedNodeData({
-          nodeId: node.id,
-          label: node.data.label,
-          operationType: node.data.operationType,
-          statistics: parseCustomStatistics(node.data.metadata?.rawNode),
-          relatedOperators: node.data.metadata?.relatedOperators?.map(operator => ({
-            nodeId: operator.id,
-            label: operator.instance_name ?? operator.operator_type_name ?? 'Operator',
-            operationType: operator.operator_type_name?.toLowerCase() ?? 'operator',
-            statistics: parseCustomStatistics(operator),
-          })),
+      let nextSelectedIds: Set<string>;
+      if (operatorSelection.selections.has(node.id)) {
+        nextSelectedIds = updateOperatorSelection({
+          type: 'remove',
+          selectionId: node.id,
         });
-        onSelectionChange?.(selectionIds);
+      } else {
+        nextSelectedIds = updateOperatorSelection({
+          type: 'add',
+          selectionId: node.id,
+          label: node.data.label,
+          operatorIds: getSelectionIds(node),
+          inspectedData: inspectedNodeFromFlowNode(node),
+        });
       }
+      onSelectionChange?.([...nextSelectedIds]);
     },
-    [
-      getSelectionIds,
-      selectedNodeIds,
-      setSelectedNodeIds,
-      setSelectedOperatorLabel,
-      setSelectedNodeData,
-      onSelectionChange,
-    ]
+    [getSelectionIds, operatorSelection, updateOperatorSelection, onSelectionChange]
   );
 
   const handlePaneClick = useCallback(() => {
-    setSelectedNodeIds(new Set());
-    setSelectedOperatorLabel(null);
-    setSelectedNodeData(null);
-  }, [setSelectedNodeIds, setSelectedOperatorLabel, setSelectedNodeData]);
+    updateOperatorSelection({ type: 'clear' });
+    onSelectionChange?.([]);
+  }, [onSelectionChange, updateOperatorSelection]);
 
   // Re-fit view when the react-flow container is resized, but only if the user
   // hasn't interacted with the chart (to maintain any focus states applied)

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { Provider } from 'jotai';
-import { useSetSelectedNodeData } from '@quent/hooks';
+import { useOperatorSelectionActions, useSetSelectedNodeData } from '@quent/hooks';
 import { getOperationTypeColor } from '@quent/utils';
 import { DAGNodeInfoPanel } from './DAGNodeInfoPanel';
 
@@ -67,6 +67,47 @@ function SwitchSelectedNode() {
   );
 }
 
+function TwoSelectedNodes() {
+  const updateOperatorSelection = useOperatorSelectionActions();
+
+  useEffect(() => {
+    updateOperatorSelection({
+      type: 'add',
+      selectionId: 'scan',
+      label: 'Table scan',
+      operatorIds: ['scan'],
+      inspectedData: {
+        nodeId: 'scan',
+        label: 'Table scan',
+        operationType: 'scan',
+        statistics: [{ key: 'output_rows', value: 10 }],
+      },
+    });
+    updateOperatorSelection({
+      type: 'add',
+      selectionId: 'join',
+      label: 'Hash join',
+      operatorIds: ['join'],
+      inspectedData: {
+        nodeId: 'join',
+        label: 'Hash join',
+        operationType: 'hashjoin',
+        statistics: [{ key: 'build_rows', value: 20 }],
+        relatedOperators: [
+          {
+            nodeId: 'probe',
+            label: 'Probe hash table',
+            operationType: 'hashprobe',
+            statistics: [{ key: 'probe_rows', value: 30 }],
+          },
+        ],
+      },
+    });
+  }, [updateOperatorSelection]);
+
+  return <DAGNodeInfoPanel />;
+}
+
 describe('DAGNodeInfoPanel', () => {
   it('shows statistics for every related child operator', async () => {
     render(
@@ -96,7 +137,52 @@ describe('DAGNodeInfoPanel', () => {
     });
   });
 
-  it('resets collapsed operators when the selected root changes', async () => {
+  it('shows statistics for every selected operator', async () => {
+    render(
+      <Provider>
+        <TwoSelectedNodes />
+      </Provider>
+    );
+
+    const title = await screen.findByTestId('operator-details-title');
+    expect(within(title).getByText('Table scan')).toHaveAttribute('title', 'Table scan');
+    expect(within(title).getByText('Hash join')).toHaveAttribute('title', 'Hash join');
+    expect(screen.getByText('output rows:')).toBeInTheDocument();
+    expect(screen.getByText('build rows:')).toBeInTheDocument();
+    expect(screen.getByText('Probe hash table')).toBeInTheDocument();
+    expect(screen.getByText('probe rows:')).toBeInTheDocument();
+
+    const titleBars = within(title).getAllByTestId('operator-color-bar');
+    expect(titleBars[0]).toHaveAttribute('data-operation-type', 'scan');
+    expect(titleBars[0]).toHaveStyle({ backgroundColor: getOperationTypeColor('scan') });
+    expect(titleBars[1]).toHaveAttribute('data-operation-type', 'hashjoin');
+    expect(titleBars[1]).toHaveStyle({ backgroundColor: getOperationTypeColor('hashjoin') });
+  });
+
+  it('collapses a selected operator without hiding the others', async () => {
+    render(
+      <Provider>
+        <TwoSelectedNodes />
+      </Provider>
+    );
+
+    const scanToggle = await screen.findByRole('button', { name: 'Toggle Table scan details' });
+    const joinToggle = screen.getByRole('button', { name: 'Toggle Hash join details' });
+    expect(scanToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(joinToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('output rows:')).toBeInTheDocument();
+    expect(screen.getByText('build rows:')).toBeInTheDocument();
+
+    fireEvent.click(scanToggle);
+
+    expect(scanToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(joinToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.queryByText('output rows:')).not.toBeInTheDocument();
+    expect(screen.getByText('build rows:')).toBeInTheDocument();
+    expect(screen.getByText('Probe hash table')).toBeInTheDocument();
+  });
+
+  it('resets collapsed operators when the selection changes', async () => {
     render(
       <Provider>
         <SwitchSelectedNode />

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx
@@ -8,7 +8,7 @@ import {
   useDataFlowFrame,
   useDataFlowIsPlaying,
   useDataFlowMeta,
-  useSelectedNodeData,
+  useSelectedNodesData,
 } from '@quent/hooks';
 import { cn, type QuantitySpec } from '@quent/utils';
 import { OperatorColorBar, OperatorDataFlowBlock, OperatorDetailsBlock } from '../node-info';
@@ -23,7 +23,7 @@ export const DAGNodeInfoPanel = ({
   isDark?: boolean;
   quantitySpecs?: { [key: string]: QuantitySpec | undefined };
 }) => {
-  const selectedNodeData = useSelectedNodeData();
+  const selectedNodes = useSelectedNodesData();
   const dataFlowEnabled = useDataFlowEnabled();
   const isPlaying = useDataFlowIsPlaying();
   const dataFlowMeta = useDataFlowMeta();
@@ -31,8 +31,10 @@ export const DAGNodeInfoPanel = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [activeTab, setActiveTab] = useState('stats');
   const [closedOperatorIds, setClosedOperatorIds] = useState<Set<string>>(() => new Set());
-  const selectedNodeId = selectedNodeData?.nodeId;
-  const hasSelection = selectedNodeData != null;
+  const hasSelection = selectedNodes.length > 0;
+  const showHeaders = selectedNodes.length > 1;
+  const selectedNode = selectedNodes[0];
+  const selectedNodeIdsKey = selectedNodes.map(node => node.nodeId).join('\0');
 
   const showDataFlowTab = dataFlowEnabled && dataFlowMeta != null;
   const isOperatorOpen = (id: string) => !closedOperatorIds.has(id);
@@ -54,9 +56,14 @@ export const DAGNodeInfoPanel = ({
 
   useEffect(() => {
     setIsExpanded(hasSelection);
-    setActiveTab('stats');
+    if (!hasSelection) {
+      setActiveTab('stats');
+    }
+  }, [hasSelection]);
+
+  useEffect(() => {
     setClosedOperatorIds(new Set());
-  }, [hasSelection, selectedNodeId]);
+  }, [selectedNodeIdsKey]);
 
   useEffect(() => {
     if (isPlaying && isExpanded && showDataFlowTab) {
@@ -66,28 +73,36 @@ export const DAGNodeInfoPanel = ({
 
   const scrollClass = cn('px-4 pb-2 h-48 overflow-auto', thinScrollbarClass);
 
-  const statsContent = selectedNodeData ? (
+  const statsContent = hasSelection ? (
     <div className="flex flex-col gap-1 pr-2 pt-1.5">
-      <OperatorDetailsBlock
-        operator={selectedNodeData}
-        quantitySpecs={quantitySpecs}
-        isOpen={isOperatorOpen}
-        onOpenChange={setOperatorOpen}
-      />
+      {selectedNodes.map((operator, index) => (
+        <div key={operator.nodeId} className={index > 0 ? 'border-t pt-1.5 mt-1.5' : ''}>
+          <OperatorDetailsBlock
+            operator={operator}
+            quantitySpecs={quantitySpecs}
+            isOpen={isOperatorOpen}
+            onOpenChange={setOperatorOpen}
+          />
+        </div>
+      ))}
     </div>
   ) : null;
 
   const dataFlowContent =
-    selectedNodeData && dataFlowMeta && dataFlowFrame ? (
+    dataFlowMeta && dataFlowFrame ? (
       <div className="flex flex-col">
-        <OperatorDataFlowBlock
-          operator={selectedNodeData}
-          meta={dataFlowMeta}
-          frame={dataFlowFrame}
-          isDark={isDark}
-          isOpen={isOperatorOpen}
-          onOpenChange={setOperatorOpen}
-        />
+        {selectedNodes.map((operator, index) => (
+          <div key={operator.nodeId} className={index > 0 ? 'border-t pt-1.5 mt-1.5' : ''}>
+            <OperatorDataFlowBlock
+              operator={operator}
+              meta={dataFlowMeta}
+              frame={dataFlowFrame}
+              isDark={isDark}
+              isOpen={isOperatorOpen}
+              onOpenChange={setOperatorOpen}
+            />
+          </div>
+        ))}
       </div>
     ) : (
       <p className="pt-6 text-xs text-muted-foreground text-center">No tasks at this bin</p>
@@ -100,23 +115,27 @@ export const DAGNodeInfoPanel = ({
           <span className="text-xs text-muted-foreground font-medium flex-shrink-0">
             Operator Details
           </span>
-          {selectedNodeData && (
+          {selectedNode && (
             <>
               <span className="text-muted-foreground text-xs flex-shrink-0">·</span>
               <div
                 data-testid="operator-details-title"
                 className="flex min-w-0 items-center gap-1.5 overflow-hidden"
               >
-                <OperatorColorBar
-                  operationType={selectedNodeData.operationType}
-                  className="h-3 w-1"
-                />
-                <DataText className="text-xs font-medium truncate" title={selectedNodeData.label}>
-                  {selectedNodeData.label}
-                </DataText>
-                <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded flex-shrink-0">
-                  {selectedNodeData.operationType}
-                </DataText>
+                {selectedNodes.map((operator, index) => (
+                  <span key={operator.nodeId} className="flex min-w-0 items-center gap-1">
+                    {index > 0 && <span className="text-muted-foreground text-xs shrink-0">,</span>}
+                    <OperatorColorBar operationType={operator.operationType} className="h-3 w-1" />
+                    <DataText className="text-xs font-medium truncate" title={operator.label}>
+                      {operator.label}
+                    </DataText>
+                    {!showHeaders && (
+                      <DataText className="text-xs text-muted-foreground capitalize px-1.5 py-0.5 bg-muted rounded flex-shrink-0">
+                        {operator.operationType}
+                      </DataText>
+                    )}
+                  </span>
+                ))}
               </div>
             </>
           )}

--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -114,6 +114,8 @@ export type { TreeDataItem } from './ui/tree-view';
 export { TreeTable } from './ui/tree-table';
 export type { Column, ColumnComponent, IconComponent } from './ui/tree-table';
 export { Badge, badgeVariants } from './ui/badge';
+export { TruncatedBadgeList } from './ui/truncated-badge-list';
+export type { TruncatedBadgeListProps } from './ui/truncated-badge-list';
 export { OptionMultiSelect } from './ui/option-multi-select';
 export type { OptionMultiSelectOption } from './ui/option-multi-select';
 export {

--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -6,9 +6,8 @@ import { useCallback, useMemo } from 'react';
 import { useTimelineEchartsTheme } from '../timeline/timelineEchartsTheme';
 import {
   useSelectedNodeIds,
-  useSetSelectedNodeIds,
-  useSetSelectedOperatorLabel,
-  useSetSelectedNodeData,
+  useOperatorSelection,
+  useOperatorSelectionActions,
   useSetSelectedPlanId,
   useNodeColoringValue,
   useNodeColorPalette,
@@ -47,10 +46,9 @@ export function OperatorGanttChart({
   height = DEFAULT_HEIGHT,
   isDark,
 }: OperatorGanttChartProps) {
-  const setSelectedNodeIds = useSetSelectedNodeIds();
-  const setSelectedOperatorLabel = useSetSelectedOperatorLabel();
+  const operatorSelection = useOperatorSelection();
+  const updateOperatorSelection = useOperatorSelectionActions();
   const setSelectedPlanId = useSetSelectedPlanId();
-  const setSelectedNodeData = useSetSelectedNodeData();
   const { textColor } = useTimelineEchartsTheme(isDark);
   const nodeColoring = useNodeColoringValue();
   const [nodePalette] = useNodeColorPalette();
@@ -173,18 +171,20 @@ export function OperatorGanttChart({
         if (!op) {
           return;
         }
-        if (selectedNodeIds.size === 1 && selectedNodeIds.has(op.operatorId)) {
-          setSelectedNodeIds(new Set());
-          setSelectedOperatorLabel(null);
-          setSelectedNodeData(null);
+        if (operatorSelection.selections.has(op.operatorId)) {
+          updateOperatorSelection({ type: 'remove', selectionId: op.operatorId });
         } else {
-          setSelectedNodeIds(new Set([op.operatorId]));
-          setSelectedOperatorLabel(op.label);
-          setSelectedNodeData({
-            nodeId: op.operatorId,
+          updateOperatorSelection({
+            type: 'add',
+            selectionId: op.operatorId,
             label: op.label,
-            operationType: op.typeName,
-            statistics: op.statistics,
+            operatorIds: [op.operatorId],
+            inspectedData: {
+              nodeId: op.operatorId,
+              label: op.label,
+              operationType: op.typeName,
+              statistics: op.statistics,
+            },
           });
           if (op.planId) {
             setSelectedPlanId(op.planId);
@@ -192,14 +192,7 @@ export function OperatorGanttChart({
         }
       },
     }),
-    [
-      operators,
-      selectedNodeIds,
-      setSelectedNodeIds,
-      setSelectedOperatorLabel,
-      setSelectedPlanId,
-      setSelectedNodeData,
-    ]
+    [operators, operatorSelection, setSelectedPlanId, updateOperatorSelection]
   );
 
   return (

--- a/ui/packages/@quent/components/src/timeline/QueryToolbar.test.tsx
+++ b/ui/packages/@quent/components/src/timeline/QueryToolbar.test.tsx
@@ -2,17 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'jotai';
 import { describe, expect, it } from 'vitest';
 import {
   useSelectedNodeData,
   useSelectedNodeIds,
+  useSelectedNodesData,
   useSelectedOperatorLabel,
   useSetSelectedNodeData,
   useSetSelectedNodeIds,
   useSetSelectedOperatorLabel,
+  useOperatorSelectionActions,
 } from '@quent/hooks';
 import { QueryToolbar } from './QueryToolbar';
 
@@ -34,17 +36,107 @@ function SeedOperatorFilter() {
   return null;
 }
 
+function ToolbarHarness() {
+  const selectedNodeIds = useSelectedNodeIds();
+  const selectedNodeData = useSelectedNodeData();
+  const updateOperatorSelection = useOperatorSelectionActions();
+
+  useEffect(() => {
+    updateOperatorSelection({
+      type: 'add',
+      selectionId: 'parent',
+      label: 'Parent operator',
+      operatorIds: ['parent', 'child'],
+      inspectedData: {
+        nodeId: 'parent',
+        label: 'Parent operator',
+        operationType: 'logical',
+        statistics: [],
+      },
+    });
+  }, [updateOperatorSelection]);
+
+  return (
+    <>
+      <QueryToolbar />
+      <span data-testid="selected-count">{selectedNodeIds.size}</span>
+      <span data-testid="selected-details">{selectedNodeData?.nodeId ?? 'none'}</span>
+    </>
+  );
+}
+
 function OperatorLabel() {
   return <span data-testid="operator-label">{useSelectedOperatorLabel() ?? 'none'}</span>;
 }
 
-function OperatorSelectionProbe() {
+function MultiOperatorToolbarHarness() {
   const selectedNodeIds = useSelectedNodeIds();
-  const selectedNodeData = useSelectedNodeData();
+  const selectedNodes = useSelectedNodesData();
+  const updateOperatorSelection = useOperatorSelectionActions();
+
+  useEffect(() => {
+    for (let index = 0; index < 5; index += 1) {
+      const number = index + 1;
+      const id = `operator-${number}`;
+      updateOperatorSelection({
+        type: 'add',
+        selectionId: id,
+        label: `Operator ${number}`,
+        operatorIds: [id],
+        inspectedData: {
+          nodeId: id,
+          label: `Operator ${number}`,
+          operationType: 'physical',
+          statistics: [],
+        },
+      });
+    }
+  }, [updateOperatorSelection]);
+
   return (
     <>
+      <QueryToolbar />
       <span data-testid="selected-count">{selectedNodeIds.size}</span>
-      <span data-testid="selected-details">{selectedNodeData?.nodeId ?? 'none'}</span>
+      <span data-testid="inspected-count">{selectedNodes.length}</span>
+    </>
+  );
+}
+
+function TwoOperatorToolbarHarness() {
+  const selectedNodes = useSelectedNodesData();
+  const updateOperatorSelection = useOperatorSelectionActions();
+
+  useEffect(() => {
+    updateOperatorSelection({
+      type: 'add',
+      selectionId: 'scan',
+      label: 'Scan',
+      operatorIds: ['scan'],
+      inspectedData: {
+        nodeId: 'scan',
+        label: 'Scan',
+        operationType: 'scan',
+        statistics: [],
+      },
+    });
+    updateOperatorSelection({
+      type: 'add',
+      selectionId: 'join',
+      label: 'Join',
+      operatorIds: ['join'],
+      inspectedData: {
+        nodeId: 'join',
+        label: 'Join',
+        operationType: 'join',
+        statistics: [],
+      },
+    });
+  }, [updateOperatorSelection]);
+
+  return (
+    <>
+      <QueryToolbar />
+      <span data-testid="inspected-ids">{selectedNodes.map(node => node.nodeId).join(',')}</span>
     </>
   );
 }
@@ -76,7 +168,7 @@ describe('QueryToolbar', () => {
       </Provider>
     );
 
-    await user.click(await screen.findByRole('button', { name: 'Clear operator filter Scan' }));
+    await user.click(await screen.findByRole('button', { name: 'Clear all operator filters' }));
     expect(screen.getByTestId('operator-label')).toHaveTextContent('none');
     expect(screen.getByRole('textbox', { name: 'Filter resources' })).toHaveValue('id:gpu-0');
   });
@@ -85,15 +177,56 @@ describe('QueryToolbar', () => {
     const user = userEvent.setup();
     render(
       <Provider>
-        <SeedOperatorFilter />
-        <OperatorSelectionProbe />
-        <QueryToolbar />
+        <ToolbarHarness />
       </Provider>
     );
 
-    await user.click(await screen.findByRole('button', { name: 'Clear operator filter Scan' }));
+    await user.click(await screen.findByRole('button', { name: 'Clear all operator filters' }));
 
     expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
     expect(screen.getByTestId('selected-details')).toHaveTextContent('none');
+  });
+
+  it('caps badges and supports individual and bulk clearing', async () => {
+    render(
+      <Provider>
+        <MultiOperatorToolbarHarness />
+      </Provider>
+    );
+
+    expect(await screen.findByText('Operator 1')).toBeInTheDocument();
+    expect(screen.getByText('Operator 2')).toBeInTheDocument();
+    expect(screen.getByText('Operator 3')).toBeInTheDocument();
+    expect(screen.queryByText('Operator 4')).not.toBeInTheDocument();
+    expect(screen.getByText('and 2 more')).toBeInTheDocument();
+    expect(screen.getByText('and 2 more')).toHaveAttribute('title', 'Operator 4, Operator 5');
+    expect(screen.getByTestId('operator-filter-badges')).toHaveClass('max-w-[40%]');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Operator 2' }));
+
+    expect(screen.getByTestId('selected-count')).toHaveTextContent('4');
+    expect(screen.getByTestId('inspected-count')).toHaveTextContent('4');
+    expect(screen.getByText('Operator 4')).toBeInTheDocument();
+    expect(screen.getByText('and 1 more')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all operator filters' }));
+
+    expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('inspected-count')).toHaveTextContent('0');
+    expect(screen.getByText('No filters')).toBeInTheDocument();
+  });
+
+  it('keeps remaining operator details after removing the last-clicked badge', async () => {
+    render(
+      <Provider>
+        <TwoOperatorToolbarHarness />
+      </Provider>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove Join' }));
+
+    expect(screen.getByTestId('inspected-ids')).toHaveTextContent('scan');
+    expect(screen.getByText('Scan')).toBeInTheDocument();
+    expect(screen.queryByText('Join')).not.toBeInTheDocument();
   });
 });

--- a/ui/packages/@quent/components/src/timeline/QueryToolbar.tsx
+++ b/ui/packages/@quent/components/src/timeline/QueryToolbar.tsx
@@ -1,54 +1,93 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useMemo, type ReactNode } from 'react';
 import { X, Filter } from 'lucide-react';
-import {
-  useSelectedOperatorLabel,
-  useSetSelectedNodeIds,
-  useSetSelectedOperatorLabel,
-  useSetSelectedNodeData,
-} from '@quent/hooks';
+import { useOperatorSelection, useOperatorSelectionActions } from '@quent/hooks';
+import { Badge } from '../ui/badge';
+import { TruncatedBadgeList } from '../ui/truncated-badge-list';
+
+const MAX_VISIBLE_OPERATOR_BADGES = 3;
 
 interface QueryToolbarProps {
-  children?: React.ReactNode;
-  filters?: React.ReactNode;
+  children?: ReactNode;
+  filters?: ReactNode;
 }
 
 /**
  * Generic query toolbar with filter controls on the left and actions on the right.
  */
 export function QueryToolbar({ children, filters }: QueryToolbarProps) {
-  const operatorLabel = useSelectedOperatorLabel();
-  const setSelectedNodeIds = useSetSelectedNodeIds();
-  const setSelectedOperatorLabel = useSetSelectedOperatorLabel();
-  const setSelectedNodeData = useSetSelectedNodeData();
+  const operatorSelection = useOperatorSelection();
+  const updateOperatorSelection = useOperatorSelectionActions();
 
-  const clearOperator = () => {
-    setSelectedNodeIds(new Set());
-    setSelectedOperatorLabel(null);
-    setSelectedNodeData(null);
+  const selectedOperators = useMemo(
+    () =>
+      Array.from(operatorSelection.selections, ([id, selection]) => ({
+        id,
+        label: selection.label,
+      })),
+    [operatorSelection.selections]
+  );
+
+  const clearOperators = () => {
+    updateOperatorSelection({ type: 'clear' });
+  };
+
+  const removeOperator = (operatorId: string) => {
+    updateOperatorSelection({ type: 'remove', selectionId: operatorId });
   };
 
   return (
     <div className="flex min-h-8 items-center gap-4 border-b border-border px-3 py-1 text-xs text-muted-foreground shrink-0">
       <div className="flex min-w-0 flex-1 items-center gap-1.5">
         {filters}
-        <Filter className="h-3 w-3 shrink-0" />
-        {operatorLabel ? (
-          <span className="inline-flex shrink-0 items-center gap-1 rounded-sm bg-primary/15 text-primary px-1.5 py-0.5 font-medium">
-            {operatorLabel}
+        <div
+          className="flex min-w-0 max-w-[40%] items-center gap-1.5 overflow-hidden"
+          data-testid="operator-filter-badges"
+        >
+          <Filter className="h-3 w-3 shrink-0" />
+          {selectedOperators.length > 0 ? (
+            <TruncatedBadgeList
+              items={selectedOperators}
+              maxVisible={MAX_VISIBLE_OPERATOR_BADGES}
+              getItemKey={operator => operator.id}
+              getItemLabel={operator => operator.label}
+              className="min-w-0 flex-nowrap overflow-hidden"
+              overflowBadgeClassName="px-1.5 py-0"
+              renderOverflowLabel={hiddenCount => `and ${hiddenCount} more`}
+              renderBadge={operator => (
+                <Badge
+                  variant="outline"
+                  className="min-w-0 max-w-36 shrink bg-primary/10 px-1.5 py-0 font-medium text-primary"
+                  title={operator.label}
+                >
+                  <span className="truncate">{operator.label}</span>
+                  <button
+                    type="button"
+                    onClick={() => removeOperator(operator.id)}
+                    aria-label={`Remove ${operator.label}`}
+                    className="ml-0.5 shrink-0 cursor-pointer rounded-sm opacity-70 hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    <X className="size-2.5" />
+                  </button>
+                </Badge>
+              )}
+            />
+          ) : !filters ? (
+            <span className="shrink-0">No filters</span>
+          ) : null}
+          {selectedOperators.length > 0 && (
             <button
-              aria-label={`Clear operator filter ${operatorLabel}`}
-              onClick={clearOperator}
-              className="rounded-sm hover:bg-primary/20 p-0.5 -mr-0.5 transition-colors cursor-pointer"
               type="button"
+              onClick={clearOperators}
+              aria-label="Clear all operator filters"
+              className="shrink-0 cursor-pointer rounded-sm px-1 py-0.5 font-medium text-primary hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
-              <X className="h-2.5 w-2.5" />
+              Clear
             </button>
-          </span>
-        ) : !filters ? (
-          <span>No filters</span>
-        ) : null}
+          )}
+        </div>
       </div>
 
       {children && <div className="flex shrink-0 items-center gap-2">{children}</div>}

--- a/ui/packages/@quent/components/src/ui/option-multi-select.tsx
+++ b/ui/packages/@quent/components/src/ui/option-multi-select.tsx
@@ -8,6 +8,7 @@ import { Badge } from './badge';
 import { Button } from './button';
 import { Input } from './input';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
+import { TruncatedBadgeList } from './truncated-badge-list';
 
 export interface OptionMultiSelectOption {
   value: string;
@@ -69,8 +70,6 @@ export function OptionMultiSelect({
       options.filter(option => (selectedOptionIds ? selectedOptionIds.has(option.value) : true)),
     [options, selectedOptionIds]
   );
-  const visibleSelectedOptions = selectedOptions.slice(0, maxVisibleBadges);
-  const hiddenSelectedCount = Math.max(0, selectedOptions.length - visibleSelectedOptions.length);
 
   const filteredOptions = useMemo(() => {
     if (!search) {
@@ -222,10 +221,14 @@ export function OptionMultiSelect({
           {selectedOptions.length === 0 ? (
             <span className="text-xs text-muted-foreground italic">{noneSelectedText}</span>
           ) : (
-            <div className="flex flex-wrap items-center gap-1">
-              {visibleSelectedOptions.map(option => (
+            <TruncatedBadgeList
+              items={selectedOptions}
+              maxVisible={maxVisibleBadges}
+              getItemKey={option => option.value}
+              getItemLabel={optionLabel}
+              overflowBadgeClassName="px-1.5 py-0"
+              renderBadge={option => (
                 <Badge
-                  key={option.value}
                   variant="outline"
                   className={cn(
                     'px-1.5 py-0 text-data bg-primary/10 border-primary/40 hover:bg-primary/15',
@@ -245,13 +248,8 @@ export function OptionMultiSelect({
                     <X className="size-2.5" />
                   </button>
                 </Badge>
-              ))}
-              {hiddenSelectedCount > 0 && (
-                <Badge variant="outline" className="px-1.5 py-0 bg-muted/40 text-muted-foreground">
-                  +{hiddenSelectedCount} more
-                </Badge>
               )}
-            </div>
+            />
           )}
         </div>
       )}

--- a/ui/packages/@quent/components/src/ui/truncated-badge-list.test.tsx
+++ b/ui/packages/@quent/components/src/ui/truncated-badge-list.test.tsx
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Badge } from './badge';
+import { TruncatedBadgeList } from './truncated-badge-list';
+
+describe('TruncatedBadgeList', () => {
+  it('lists hidden item labels in the overflow badge title', () => {
+    render(
+      <TruncatedBadgeList
+        items={['Alpha', 'Beta', 'Gamma']}
+        maxVisible={1}
+        getItemKey={item => item}
+        getItemLabel={item => item}
+        renderBadge={item => <Badge>{item}</Badge>}
+      />
+    );
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    expect(screen.getByText('+2 more')).toHaveAttribute('title', 'Beta, Gamma');
+  });
+});

--- a/ui/packages/@quent/components/src/ui/truncated-badge-list.tsx
+++ b/ui/packages/@quent/components/src/ui/truncated-badge-list.tsx
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Fragment, type Key, type ReactNode } from 'react';
+import { cn } from '@quent/utils';
+import { Badge } from './badge';
+
+export interface TruncatedBadgeListProps<T> {
+  items: readonly T[];
+  maxVisible: number;
+  getItemKey: (item: T) => Key;
+  getItemLabel: (item: T) => string;
+  renderBadge: (item: T) => ReactNode;
+  renderOverflowLabel?: (hiddenCount: number) => ReactNode;
+  className?: string;
+  overflowBadgeClassName?: string;
+}
+
+export function TruncatedBadgeList<T>({
+  items,
+  maxVisible,
+  getItemKey,
+  getItemLabel,
+  renderBadge,
+  renderOverflowLabel = hiddenCount => `+${hiddenCount} more`,
+  className,
+  overflowBadgeClassName,
+}: TruncatedBadgeListProps<T>) {
+  const visibleItems = items.slice(0, Math.max(0, maxVisible));
+  const hiddenItems = items.slice(visibleItems.length);
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1', className)}>
+      {visibleItems.map(item => (
+        <Fragment key={getItemKey(item)}>{renderBadge(item)}</Fragment>
+      ))}
+      {hiddenItems.length > 0 && (
+        <Badge
+          variant="outline"
+          className={cn('shrink-0 bg-muted/40 text-muted-foreground', overflowBadgeClassName)}
+          title={hiddenItems.map(getItemLabel).join(', ')}
+        >
+          {renderOverflowLabel(hiddenItems.length)}
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/ui/packages/@quent/hooks/src/dag/operatorSelectionActions.test.ts
+++ b/ui/packages/@quent/hooks/src/dag/operatorSelectionActions.test.ts
@@ -195,4 +195,33 @@ describe('operator selection actions', () => {
     );
     expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['join', groupedJoinData]]));
   });
+
+  it('keeps inspected selections that are not present in the loaded DAG', () => {
+    const store = createStore();
+    const timelineData = {
+      nodeId: 'timeline-only',
+      label: 'Timeline operator',
+      operationType: 'scan',
+      statistics: [],
+    };
+    store.set(operatorSelectionActionAtom, {
+      type: 'add',
+      selectionId: 'timeline-only',
+      label: 'Timeline operator',
+      operatorIds: ['timeline-only'],
+      inspectedData: timelineData,
+    });
+
+    store.set(operatorSelectionActionAtom, {
+      type: 'hydrate',
+      selections: [],
+      unresolvedOperatorIds: ['timeline-only'],
+    });
+
+    expect(store.get(operatorSelectionAtom).selections.get('timeline-only')).toEqual({
+      label: 'Timeline operator',
+      operatorIds: new Set(['timeline-only']),
+    });
+    expect(store.get(selectedNodesDataAtom)).toEqual(new Map([['timeline-only', timelineData]]));
+  });
 });


### PR DESCRIPTION
# Description
* Switch DAG and operator-timeline clicks to toggle complete logical selections in [DAGChart.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/DAGChart.tsx) and [OperatorGanttChart.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx); pane click and Clear remove all selections.



* Ship toolbar representation atomically: add [truncated-badge-list.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/ui/truncated-badge-list.tsx), its tests/export, update [QueryToolbar.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/timeline/QueryToolbar.tsx) for bounded badges and per-item removal, and reuse the primitive in [option-multi-select.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/ui/option-multi-select.tsx).



* Adapt PR 1’s panel to useSelectedNodesData() in [DAGNodeInfoPanel.tsx](https://github.com/rapidsai/quent/pull/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.tsx), retaining nested higher-level operators while allowing multiple top-level accordions and titles.



* Include the corresponding toolbar, panel, DAG, action-atom, and selection tests. Keep parent/child dedupe in this activation path so users never see a temporary duplicate-badge state.


## Related Issues

<!-- Link related issues: closes #123, relates to #456 -->

## Testing

Result after merge: DAG, operator timeline, toolbar, panel, timeline filters, deep links, and existing selected-ID consumers change together; no interval exists where only one interaction surface supports multi-select.

## Screenshots

<!-- For UI changes, include screenshots or videos when possible. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>