### PR TITLE
feat(schema,vibe): add schema explorer dark theme

### DIFF
--- a/experimental/vibe/ui/schema-explorer/src/App.svelte
+++ b/experimental/vibe/ui/schema-explorer/src/App.svelte
@@ -35,6 +35,12 @@
     parseYamlSchema,
     parserErrorMessage,
   } from './yaml-schema';
+  import {
+    observeTheme,
+    readThemePreference,
+    saveThemePreference,
+    type ThemePreference,
+  } from './theme';
 
   type ModelSelectionId = ExampleModelId | 'loaded';
 
@@ -62,6 +68,7 @@
   let editorPane = $state<PaneAPI | null>(null);
   let graphPane = $state<PaneAPI | null>(null);
   let selectionsPane = $state<PaneAPI | null>(null);
+  let themePreference = $state<ThemePreference>(readThemePreference());
   let config = $state<ResolvedEntityGraphConfig>({
     ...DEFAULT_ENTITY_GRAPH_CONFIG,
   });
@@ -103,6 +110,12 @@
       hoverSelection === null &&
       breadcrumbPreview === null,
   );
+
+  $effect(() => {
+    const preference = themePreference;
+    saveThemePreference(preference);
+    return observeTheme(preference);
+  });
 
   $effect(() => {
     const source = yamlSource;
@@ -374,6 +387,18 @@
           Save
         </button>
       </div>
+      <label class="ml-auto flex shrink-0 items-center gap-2">
+        <span class="text-xs font-medium">Theme</span>
+        <select
+          class="select select-bordered select-sm w-28"
+          bind:value={themePreference}
+          aria-label="Color theme"
+        >
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
     </header>
   {/if}
 

--- a/experimental/vibe/ui/schema-explorer/src/main.ts
+++ b/experimental/vibe/ui/schema-explorer/src/main.ts
@@ -5,5 +5,12 @@ import { mount } from 'svelte';
 
 import App from './App.svelte';
 import './style.css';
+import {
+  applyTheme,
+  readThemePreference,
+  resolveTheme,
+} from './theme';
+
+applyTheme(resolveTheme(readThemePreference()));
 
 mount(App, { target: document.getElementById('app')! });

--- a/experimental/vibe/ui/schema-explorer/src/style.css
+++ b/experimental/vibe/ui/schema-explorer/src/style.css
@@ -5,9 +5,32 @@
 
 @import "tailwindcss";
 @plugin "daisyui" {
-  themes: light --default;
+  themes: light --default, dark --prefersdark;
 }
 @source "../../schema-viewer/src";
+
+[data-theme="dark"] {
+  --quent-viewer-background: var(--color-base-100);
+  --quent-viewer-surface: var(--color-base-200);
+  --quent-viewer-surface-strong: var(--color-base-300);
+  --quent-viewer-border: color-mix(
+    in oklab,
+    var(--color-base-content) 22%,
+    transparent
+  );
+  --quent-viewer-text: var(--color-base-content);
+  --quent-viewer-muted: color-mix(
+    in oklab,
+    var(--color-base-content) 62%,
+    transparent
+  );
+  --quent-viewer-accent: var(--color-primary);
+  --quent-viewer-tree: #34d399;
+  --quent-viewer-entity: #60a5fa;
+  --quent-viewer-fsm: #fbbf24;
+  --quent-viewer-resource: #c084fc;
+  --quent-viewer-record: #22d3ee;
+}
 
 html,
 body,

--- a/experimental/vibe/ui/schema-explorer/src/theme.ts
+++ b/experimental/vibe/ui/schema-explorer/src/theme.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = Exclude<ThemePreference, 'system'>;
+
+const STORAGE_KEY = 'quent-schema-explorer-theme';
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+export function readThemePreference(): ThemePreference {
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return value === 'light' || value === 'dark' ? value : 'system';
+  } catch {
+    return 'system';
+  }
+}
+
+export function saveThemePreference(preference: ThemePreference): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, preference);
+  } catch {
+    // The selected theme still applies for the current page lifetime.
+  }
+}
+
+export function resolveTheme(
+  preference: ThemePreference,
+  prefersDark = window.matchMedia(SYSTEM_DARK_QUERY).matches,
+): ResolvedTheme {
+  return preference === 'system'
+    ? prefersDark
+      ? 'dark'
+      : 'light'
+    : preference;
+}
+
+export function applyTheme(theme: ResolvedTheme): void {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function observeTheme(
+  preference: ThemePreference,
+): () => void {
+  const systemTheme = window.matchMedia(SYSTEM_DARK_QUERY);
+  const update = (): void => {
+    applyTheme(resolveTheme(preference, systemTheme.matches));
+  };
+
+  update();
+  if (preference !== 'system') return () => {};
+
+  systemTheme.addEventListener('change', update);
+  return () => systemTheme.removeEventListener('change', update);
+}


### PR DESCRIPTION
## Summary

- add Light, Dark, and System theme options to the schema explorer
- persist the selected preference and apply it before mounting the application
- update System mode when the OS color preference changes
- provide an explorer-local dark palette for schema viewer components

## Testing

- schema explorer type and Svelte checks
- schema explorer ESLint
- production build
- browser verification of persistence and live system-theme switching
- copyright verification
- `git diff --check`

_Written by Codex._