### PR TITLE
feat(simulator): add self-contained Docker example

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,8 @@ docker compose up --build
 ```
 
 The collector listens on port `7836`, and the analysis API listens on port
-`8080`.
+`8080`. This development image intentionally omits the embedded UI so the
+frontend can run separately with Vite and hot reload.
 
 ## Run the UI development server
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,35 @@ engines. An elaborate example of how Quent is used to produce a domain-specific
 analysis toolchain with a user interface in this domain is shown below:
 ![Quent overview demo](ui/docs/screenshots/demo.gif)
 
+## Try it
+
+### Query-engine UI
+
+To quickly get an idea of what the framework can do, run the query-engine UI
+shown above. This simulator is one example of a performance-analysis
+application built with Quent; it targets the query-engine domain.
+
+Install [Docker](https://docs.docker.com/compose/install/) with the Compose
+plugin, then start the complete example from the repository root:
+
+```bash
+docker compose -f examples/simulator/docker-compose.yml up --build
+```
+
+Open <http://localhost:8080> after the services start. Docker Compose serves the
+UI and analysis API, and runs the simulator once to generate a sample
+query-engine dataset. Press `Ctrl+C` to stop the stack.
+
+For frontend development with Vite and hot reload, see the
+[development guide](DEVELOPMENT.md#run-the-ui-development-server).
+
+### Explore the modeling approach
+
+The hosted [Quent Schema Explorer](https://rapidsai.github.io/quent/) is a
+browser-based YAML schema editor and visualization tool. Use it to edit example
+schemas and explore how Quent models entities, events, finite-state machines,
+resources, and their relationships without installing anything.
+
 ## Why
 
 Quent is built to address a growing complexity gap between complex modern
@@ -93,23 +122,23 @@ Polars](https://docs.rapids.ai/api/cudf/stable/cudf_polars/).
 
 Built-in mods include things useful for a wide variety of applications:
 
-- `quent-fsm`: describes the potential sequences of events by modeling entities
-  as finite-state machines.
+- [`quent-fsm`](crates/fsm/): describes the potential sequences of events by
+  modeling entities as finite-state machines.
   - Through this mod, the instrumentation library can be generated
     such that invalid transitions are already rejected at compile time, and/or
     an analysis library can validate whether FSM transition events followed the
     described topology.
-- `quent-resource`: defines resources such as memories, channels, and processing
-  elements, and how other entities can use them.
+- [`quent-resource`](crates/resource/): defines resources such as memories,
+  channels, and processing elements, and how other entities can use them.
   - Through this mod, an analysis library can provide functionality
     that checks whether resources were saturated above some threshold for a
     certain duration, or it can generate data for a resource utilization
     timeline visualization.
-- `quent-ref-target`: constrains references to other entities to be of a certain
-  type.
-- `quent-ref-scope`: allows forming hierarchies of event-emitting entities to,
-  e.g., provide the canonical path of performance analysis exploration through
-  all event data from a UI.
+- [`quent-ref-target`](crates/ref-target/): constrains references to other
+  entities to be of a certain type.
+- [`quent-ref-tree`](crates/ref-tree/): allows forming hierarchies of
+  event-emitting entities to, e.g., provide the canonical path of performance
+  analysis exploration through all event data from a UI.
 
 Mods can be self-authored to provide components around application- or
 domain-specific concerns. For example, applications like query engines often
@@ -149,7 +178,7 @@ entities:
       started:
         attributes:
           # ... and what its arguments were
-          args: list<string>
+          args: { list: string }
 ```
 
 ### Generating an instrumentation library
@@ -193,20 +222,21 @@ semantics. This ultimately helps ensure that events can be properly interpreted
 during analysis and that the outcome can be properly visualized (or otherwise
 utilized).
 
-Quent's YAML-based source format provides built-in syntax for FSMs:
+Quent's YAML-based source format provides built-in syntax for FSMs. Every FSM
+has exactly one initial state, every transition target must be declared, and a
+state with no `to` transitions is final:
 
 ```yaml
 quent: alpha
 model: hello
 
 fsms:
-  App:s
+  App:
     states:
       started:
         initial: true
         to: [ended]
       ended:
-        to: [exit]
         attributes:
           success: bool
 ```
@@ -232,7 +262,9 @@ across languages without maintaining separate language-specific SDKs.
 
 To give a more illustrative example of some built-in mod features, the example
 below shows an application event model for a contrived distributed application
-whose FSM-modeled entities use resources and tree-forming references:
+whose entities use the [`quent-fsm`](crates/fsm/),
+[`quent-resource`](crates/resource/), and
+[`quent-ref-tree`](crates/ref-tree/) mods:
 
 ```yaml
 quent: alpha
@@ -294,11 +326,12 @@ fsms:
         attributes:
           memory: { uses: Memory }
           thread: { uses: Thread }
-        to: [sending, exit]
+        to: [sending, finished]
       sending:
         attributes:
           channel: { uses: Channel }
-        to: [exit]
+        to: [finished]
+      finished: {}
 ```
 
 Quent can also represent traditional telemetry signals, e.g. (simplified):
@@ -338,20 +371,18 @@ fsms:
         to: [closed]
         attributes:
           name: string
-      closed:
-        to: [exit]
+      closed: {}
 
   TracingSpan: # like the Rust "tracing" crate spans
     states:
       entered:
         initial: true
-        to: [exit, closed]
+        to: [exited, closed]
         attributes:
           name: string
       exited:
         to: [entered, closed]
-      closed:
-        to: [exit]
+      closed: {}
 ```
 
 ## More information

--- a/examples/simulator/Dockerfile
+++ b/examples/simulator/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM ghcr.io/prefix-dev/pixi:0.72.2 AS builder
+
+WORKDIR /quent
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/rattler/cache \
+    --mount=type=cache,target=/root/.cargo/registry \
+    pixi run --frozen pnpm --dir ui install --frozen-lockfile --reporter=append-only && \
+    pixi run --frozen cargo build --release --locked \
+        -p quent-simulator-server \
+        -p quent-simulator \
+        --features quent-simulator-server/ui && \
+    cp target/release/quent-simulator-server target/release/quent-simulator /quent/
+
+FROM debian:trixie AS runtime
+
+WORKDIR /quent
+
+COPY --from=builder /quent/quent-simulator-server /quent/quent-simulator-server
+COPY --from=builder /quent/quent-simulator /quent/quent-simulator
+
+EXPOSE 8080
+EXPOSE 7836

--- a/examples/simulator/Dockerfile.dockerignore
+++ b/examples/simulator/Dockerfile.dockerignore
@@ -1,17 +1,15 @@
-# Rust build outputs
 target/
+data/
+events/
+server/data/*.ndjson
 .pixi/
 
-# Generated/runtime data the server writes to a mounted volume
-data/
-server/data/*.ndjson
-
-# Generic noise that should never enter a Docker build context.
 **/node_modules/
 **/dist/
 **/.pnpm-store/
 **/.cache/
 **/.turbo/
+
 .git/
 .github/
 .vscode/

--- a/examples/simulator/docker-compose.yml
+++ b/examples/simulator/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  server:
+    build:
+      context: ../..
+      dockerfile: examples/simulator/Dockerfile
+    image: quent-simulator-example
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    command: "/quent/quent-simulator-server --log-level debug"
+
+  simulator:
+    image: quent-simulator-example
+    depends_on:
+      - server
+    restart: "no"
+    environment:
+      QUENT_COLLECTOR_ADDRESS: "http://server:7836"
+    command: "/quent/quent-simulator --num-query-groups 1 --num-queries 1 --num-workers 4 --num-threads 8 --num-tasks 64"


### PR DESCRIPTION
# Description

- Add a simulator-specific Pixi Docker image and Compose stack that embeds the query-engine UI and generates sample telemetry without requiring host Pixi.
- Document the Docker quick start and hosted Schema Explorer while preserving the existing Vite development workflow.
- Update README schemas to current list and FSM syntax, and link the built-in mods to their crates.

## Testing

- `podman-compose -f examples/simulator/docker-compose.yml build`
- Embedded UI HTTP smoke test
- `podman-compose -f examples/simulator/docker-compose.yml config`
- `pixi run --frozen rumdl check README.md DEVELOPMENT.md`
- README YAML snippets checked with `quent-yaml-check`
- `git diff --check`

_Written by Codex._