### PR TITLE
feat(ui): [4] multi operator select query plan data flow

### DIFF
--- a/ui/e2e/operator-selection.spec.ts
+++ b/ui/e2e/operator-selection.spec.ts
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, type Locator, type Page, test } from '@playwright/test';
+import { allowedMissingNvtxCatalogErrors } from './utils/allowed-errors';
+import { captureErrors, expectNoErrors } from './utils/error-capture';
+
+const ENGINE_ID = '00000000-0000-0000-0000-000000000001';
+const QUERY_ID = '00000000-0000-0000-0000-000000000004';
+const QUERY_PATH = `/profile/engine/${ENGINE_ID}/query/${QUERY_ID}`;
+const QUERY_DURATION_SECONDS = 7;
+
+const LOGICAL_AGGREGATE_ID = '00000000-0000-0000-0000-000000000009';
+const PARTIAL_AGGREGATE_W0_ID = '00000000-0000-0000-0000-00000000000d';
+const FINAL_AGGREGATE_ID = '00000000-0000-0000-0000-00000000000e';
+const PARTIAL_AGGREGATE_W1_ID = '00000000-0000-0000-0000-000000000030';
+
+async function openTimeline(page: Page) {
+  const errors = await captureErrors(page);
+  const response = await page.goto(`${QUERY_PATH}/timeline`);
+
+  expect(response?.ok()).toBe(true);
+  await expect(page).toHaveURL(new RegExp(`${QUERY_PATH}/timeline$`));
+  await expect(page.locator(`.react-flow__node[data-id="${LOGICAL_AGGREGATE_ID}"]`)).toBeVisible();
+  return errors;
+}
+
+async function openOperatorGanttCharts(page: Page) {
+  await page.getByText('worker-0', { exact: true }).click();
+  await page.getByText('worker-1', { exact: true }).click();
+  await expect(
+    page.getByRole('group', { name: /Operator Gantt chart:.*FinalAggregate/ })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('group', { name: /Operator Gantt chart:.*PartialAggregate/ })
+  ).toHaveCount(2);
+}
+
+async function clickGanttAtSecond(chart: Locator, second: number) {
+  const box = await chart.boundingBox();
+  expect(box).not.toBeNull();
+  await chart.click({
+    position: {
+      x: ((box!.width - 10) * second) / QUERY_DURATION_SECONDS,
+      y: box!.height / 2,
+    },
+  });
+}
+
+async function expectSelectedGanttOperators(page: Page, expectedIds: string[]) {
+  await expect
+    .poll(async () => {
+      const selectedIds = await page
+        .getByRole('group', { name: /^Operator Gantt chart:/ })
+        .evaluateAll(charts =>
+          charts.flatMap(chart =>
+            (chart.getAttribute('data-selected-operator-ids') ?? '').split(' ').filter(Boolean)
+          )
+        );
+      return selectedIds.sort();
+    })
+    .toEqual([...expectedIds].sort());
+}
+
+function dagNode(page: Page, operatorId: string) {
+  return page.locator(`.react-flow__node[data-id="${operatorId}"]`);
+}
+
+function operatorOption(page: Page, label: string, location: string) {
+  return page.getByRole('option').filter({ hasText: label }).filter({ hasText: location });
+}
+
+async function openEntityOperatorSelect(page: Page) {
+  await page.getByRole('link', { name: 'Entities' }).click();
+  const operatorSelect = page.getByRole('combobox', { name: 'Operator' });
+  await expect(operatorSelect).toBeVisible();
+  await operatorSelect.click();
+}
+
+test('logical operator selection stays synchronized across views and can be cleared', async ({
+  page,
+}) => {
+  const errors = await openTimeline(page);
+  await openOperatorGanttCharts(page);
+
+  await dagNode(page, LOGICAL_AGGREGATE_ID).click();
+
+  await expectSelectedGanttOperators(page, [
+    PARTIAL_AGGREGATE_W0_ID,
+    FINAL_AGGREGATE_ID,
+    PARTIAL_AGGREGATE_W1_ID,
+  ]);
+  await expect(page.getByTestId('operator-details-title')).toContainText('Aggregate');
+  await expect(page.getByTestId(`operator-accordion-${LOGICAL_AGGREGATE_ID}`)).toBeVisible();
+  await expect(page.getByTestId(`operator-accordion-${PARTIAL_AGGREGATE_W0_ID}`)).toBeVisible();
+  await expect(page.getByTestId(`operator-accordion-${FINAL_AGGREGATE_ID}`)).toBeVisible();
+  await expect(page.getByTestId(`operator-accordion-${PARTIAL_AGGREGATE_W1_ID}`)).toBeVisible();
+
+  await openEntityOperatorSelect(page);
+  await expect(operatorOption(page, 'Aggregate', 'Plan: logical')).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+  await expect(operatorOption(page, 'PartialAggregate', 'Worker: worker-0')).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+  await expect(operatorOption(page, 'FinalAggregate', 'Worker: worker-0')).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+  await expect(operatorOption(page, 'PartialAggregate', 'Worker: worker-1')).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+
+  await page.getByRole('link', { name: 'Timeline' }).click();
+  const worker0Chart = page.getByRole('group', {
+    name: /Operator Gantt chart:.*FinalAggregate/,
+  });
+  await clickGanttAtSecond(worker0Chart, 3.5);
+
+  await expect(page.getByRole('button', { name: 'Remove Aggregate' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Remove FinalAggregate' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Remove PartialAggregate' })).toBeVisible();
+  await expectSelectedGanttOperators(page, [FINAL_AGGREGATE_ID, PARTIAL_AGGREGATE_W1_ID]);
+  await expect(page.getByTestId(`operator-accordion-${LOGICAL_AGGREGATE_ID}`)).toHaveCount(0);
+  await expect(page.getByTestId('operator-details-title')).toContainText('FinalAggregate');
+  await expect(page.getByTestId('operator-details-title')).toContainText('PartialAggregate');
+
+  await page.getByRole('button', { name: 'Clear all operator filters' }).click();
+  await expect(page.getByRole('button', { name: 'Clear all operator filters' })).toHaveCount(0);
+  await expect(page.getByTestId('operator-details-title')).toHaveCount(0);
+  await expectSelectedGanttOperators(page, []);
+
+  await openEntityOperatorSelect(page);
+  await expect(page.getByRole('combobox', { name: 'Operator' })).toHaveText('All operators');
+  await expect(page.getByRole('option', { selected: true })).toHaveCount(0);
+  await page.waitForLoadState('networkidle');
+  await expectNoErrors(page, errors, allowedMissingNvtxCatalogErrors);
+});
+
+test('Gantt and entity operator selections stay synchronized with the DAG and details', async ({
+  page,
+}) => {
+  const errors = await openTimeline(page);
+  await openOperatorGanttCharts(page);
+  await expect(page.getByRole('button', { name: 'Clear all operator filters' })).toHaveCount(0);
+
+  const worker0Chart = page.getByRole('group', {
+    name: /Operator Gantt chart:.*FinalAggregate/,
+  });
+  await clickGanttAtSecond(worker0Chart, 3.5);
+  await clickGanttAtSecond(worker0Chart, 4.5);
+
+  await expectSelectedGanttOperators(page, [PARTIAL_AGGREGATE_W0_ID, FINAL_AGGREGATE_ID]);
+  await expect(dagNode(page, PARTIAL_AGGREGATE_W0_ID).locator('.border-2')).toBeVisible();
+  await expect(dagNode(page, FINAL_AGGREGATE_ID).locator('.border-2')).toBeVisible();
+  await expect(page.getByTestId('operator-details-title')).toContainText('PartialAggregate');
+  await expect(page.getByTestId('operator-details-title')).toContainText('FinalAggregate');
+
+  await openEntityOperatorSelect(page);
+  const partialAggregate = operatorOption(page, 'PartialAggregate', 'Worker: worker-0');
+  const finalAggregate = operatorOption(page, 'FinalAggregate', 'Worker: worker-0');
+  await expect(partialAggregate).toHaveAttribute('aria-selected', 'true');
+  await expect(finalAggregate).toHaveAttribute('aria-selected', 'true');
+
+  await partialAggregate.click();
+  await expect(partialAggregate).toHaveAttribute('aria-selected', 'false');
+  await expect(dagNode(page, PARTIAL_AGGREGATE_W0_ID).locator('.border-2')).toHaveCount(0);
+  await expect(dagNode(page, FINAL_AGGREGATE_ID).locator('.border-2')).toBeVisible();
+  await expect(page.getByTestId('operator-details-title')).not.toContainText('PartialAggregate');
+  await expect(page.getByTestId('operator-details-title')).toContainText('FinalAggregate');
+
+  await finalAggregate.click();
+  await expect(finalAggregate).toHaveAttribute('aria-selected', 'false');
+  await expect(dagNode(page, FINAL_AGGREGATE_ID).locator('.border-2')).toHaveCount(0);
+  await expect(page.getByTestId('operator-details-title')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Clear all operator filters' })).toHaveCount(0);
+
+  await page.getByRole('link', { name: 'Timeline' }).click();
+  await expectSelectedGanttOperators(page, []);
+  await page.waitForLoadState('networkidle');
+  await expectNoErrors(page, errors, allowedMissingNvtxCatalogErrors);
+});

--- a/ui/packages/@quent/components/src/index.ts
+++ b/ui/packages/@quent/components/src/index.ts
@@ -186,6 +186,7 @@ export {
 export {
   getPlanDAG,
   getTreeData,
+  getSelectedOperatorCountsByPlan,
   validateQueryBundle,
 } from './services/query-plan/query-bundle-transformer';
 export type { DAGData, QueryPlanDataItem, QueryPlanNodeData } from './services/query-plan/types';

--- a/ui/packages/@quent/components/src/node-info/OperatorDataFlowBlock.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorDataFlowBlock.tsx
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DataFlowFrame, DataFlowMeta, SelectedOperatorGroupData } from '@quent/hooks';
+import {
+  aggregateDataFlowOperatorFrames,
+  type DataFlowFrame,
+  type DataFlowMeta,
+  type SelectedOperatorGroupData,
+} from '@quent/hooks';
 import { DataFlowMatrix } from '../dag/DataFlowMatrix';
 import { OperatorAccordion, type OperatorDisclosureState } from './OperatorAccordion';
 
@@ -17,33 +22,47 @@ export const OperatorDataFlowBlock = ({
   meta: DataFlowMeta;
   frame: DataFlowFrame;
   isDark: boolean;
-} & OperatorDisclosureState) => (
-  <OperatorAccordion
-    operator={operator}
-    open={isOpen(operator.nodeId)}
-    onOpenChange={open => onOpenChange(operator.nodeId, open)}
-  >
-    <DataFlowMatrix
-      meta={meta}
-      frame={frame}
-      operatorFrame={frame.perOperator.get(operator.nodeId)}
-      isDark={isDark}
-    />
-    {operator.relatedOperators?.map(related => (
-      <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
-        <OperatorAccordion
-          operator={related}
-          open={isOpen(related.nodeId)}
-          onOpenChange={open => onOpenChange(related.nodeId, open)}
-        >
-          <DataFlowMatrix
-            meta={meta}
-            frame={frame}
-            operatorFrame={frame.perOperator.get(related.nodeId)}
-            isDark={isDark}
-          />
-        </OperatorAccordion>
-      </div>
-    ))}
-  </OperatorAccordion>
-);
+} & OperatorDisclosureState) => {
+  const relatedOperatorIds = new Set(
+    operator.relatedOperators?.map(related => related.nodeId) ?? []
+  );
+  const relatedFrames = [...relatedOperatorIds].flatMap(operatorId => {
+    const relatedFrame = frame.perOperator.get(operatorId);
+    return relatedFrame ? [relatedFrame] : [];
+  });
+  const operatorFrame =
+    relatedOperatorIds.size > 0
+      ? aggregateDataFlowOperatorFrames(
+          relatedFrames,
+          meta.stateNames.length,
+          meta.decl.dimension_keys.length,
+          frame.labelMeasure === frame.measure
+        )
+      : frame.perOperator.get(operator.nodeId);
+
+  return (
+    <OperatorAccordion
+      operator={operator}
+      open={isOpen(operator.nodeId)}
+      onOpenChange={open => onOpenChange(operator.nodeId, open)}
+    >
+      <DataFlowMatrix meta={meta} frame={frame} operatorFrame={operatorFrame} isDark={isDark} />
+      {operator.relatedOperators?.map(related => (
+        <div key={related.nodeId} className="mt-1.5 border-t pt-1.5">
+          <OperatorAccordion
+            operator={related}
+            open={isOpen(related.nodeId)}
+            onOpenChange={open => onOpenChange(related.nodeId, open)}
+          >
+            <DataFlowMatrix
+              meta={meta}
+              frame={frame}
+              operatorFrame={frame.perOperator.get(related.nodeId)}
+              isDark={isDark}
+            />
+          </OperatorAccordion>
+        </div>
+      ))}
+    </OperatorAccordion>
+  );
+};

--- a/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
+++ b/ui/packages/@quent/components/src/operator-timeline/OperatorGanttChart.tsx
@@ -61,6 +61,11 @@ export function OperatorGanttChart({
   const resolveOperatorTypeColor = useColorResolver(COLOR_REGISTRY_KEYS.OPERATOR_TYPES);
   const barLabelTextColor = textColor;
   const selectedOperatorIds = useSelectedOperatorIds();
+  const chartLabel = `Operator Gantt chart: ${operators.map(operator => operator.label).join(', ')}`;
+  const selectedVisibleOperatorIds = operators
+    .filter(operator => selectedOperatorIds.has(operator.operatorId))
+    .map(operator => operator.operatorId)
+    .sort();
 
   const customSeriesData = useMemo(
     () =>
@@ -224,19 +229,25 @@ export function OperatorGanttChart({
   );
 
   return (
-    <GanttChart
-      data={customSeriesData}
-      durationSeconds={durationSeconds}
-      height={height}
-      maxHeight={MAX_HEIGHT}
-      rowHeight={BAR_HEIGHT}
-      isDark={isDark}
-      seriesName="operator-span"
-      renderItem={renderItem}
-      emptyMessage="No operator active spans"
-      cursor="pointer"
-      onEvents={handleClick}
-      renderTooltip={renderTooltip}
-    />
+    <div
+      role="group"
+      aria-label={chartLabel}
+      data-selected-operator-ids={selectedVisibleOperatorIds.join(' ')}
+    >
+      <GanttChart
+        data={customSeriesData}
+        durationSeconds={durationSeconds}
+        height={height}
+        maxHeight={MAX_HEIGHT}
+        rowHeight={BAR_HEIGHT}
+        isDark={isDark}
+        seriesName="operator-span"
+        renderItem={renderItem}
+        emptyMessage="No operator active spans"
+        cursor="pointer"
+        onEvents={handleClick}
+        renderTooltip={renderTooltip}
+      />
+    </div>
   );
 }

--- a/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.test.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.test.ts
@@ -2,8 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import type { QueryBundle, EntityRef, Plan, Operator, Port, PlanTree } from '@quent/utils';
-import { validateQueryBundle, getTreeData, getPlanDAG } from './query-bundle-transformer';
+import type { QueryBundle, EntityRef, Plan, Operator, Port, PlanTree, Worker } from '@quent/utils';
+import {
+  getPlanDAG,
+  getSelectedOperatorCountsByPlan,
+  getTreeData,
+  validateQueryBundle,
+} from './query-bundle-transformer';
 
 // ---- Helpers ---------------------------------------------------------------
 
@@ -45,6 +50,16 @@ function makePort(id: string, operatorId: string | null): Port {
   return { id, operator_id: operatorId, instance_name: null, statistics: null };
 }
 
+function makeWorker(id: string, instanceName: string | null): Worker {
+  return {
+    id,
+    instance_name: instanceName,
+    parent_engine_id: null,
+    start_unix_ns: null,
+    end_unix_ns: null,
+  };
+}
+
 function makePlanTree(
   id: string,
   worker: string | null = null,
@@ -58,6 +73,7 @@ function makeBundle(
   opts: {
     operators?: Record<string, Operator | undefined>;
     ports?: Record<string, Port | undefined>;
+    workers?: Record<string, Worker | undefined>;
     planTree?: PlanTree;
   } = {}
 ): QueryBundle<EntityRef> {
@@ -66,6 +82,7 @@ function makeBundle(
       plans,
       operators: opts.operators ?? {},
       ports: opts.ports ?? {},
+      workers: opts.workers ?? {},
     },
     plan_tree: opts.planTree ?? makePlanTree(Object.keys(plans)[0] ?? 'p1'),
   } as unknown as QueryBundle<EntityRef>;
@@ -128,6 +145,17 @@ describe('getTreeData', () => {
     expect(getTreeData(bundle)[0]!.workerId).toBe('worker-7');
   });
 
+  it('sets workerName from the referenced worker entity', () => {
+    const bundle = makeBundle(
+      { p1: makePlan('p1') },
+      {
+        planTree: makePlanTree('p1', 'worker-7'),
+        workers: { 'worker-7': makeWorker('worker-7', 'GPU Worker 7') },
+      }
+    );
+    expect(getTreeData(bundle)[0]!.workerName).toBe('GPU Worker 7');
+  });
+
   it('sets workerId to undefined when plan_tree.worker is null', () => {
     const bundle = makeBundle({ p1: makePlan('p1') }, { planTree: makePlanTree('p1', null) });
     expect(getTreeData(bundle)[0]!.workerId).toBeUndefined();
@@ -173,6 +201,36 @@ describe('getTreeData', () => {
     expect(child.name).toBe('Query Plan: p2');
     expect(child.workerId).toBe('worker-2');
     expect(child.planType).toBe('Merge');
+  });
+});
+
+// ---- getSelectedOperatorCountsByPlan --------------------------------------
+
+describe('getSelectedOperatorCountsByPlan', () => {
+  it('counts selected operators by their owning plan', () => {
+    const bundle = makeBundle(
+      { p1: makePlan('p1'), p2: makePlan('p2') },
+      {
+        operators: {
+          'op-1': makeOperator('op-1', { planId: 'p1' }),
+          'op-2': makeOperator('op-2', { planId: 'p1' }),
+          'op-3': makeOperator('op-3', { planId: 'p2' }),
+          unassigned: makeOperator('unassigned'),
+        },
+      }
+    );
+
+    expect(
+      getSelectedOperatorCountsByPlan(
+        bundle,
+        new Set(['op-1', 'op-2', 'op-3', 'unassigned', 'missing'])
+      )
+    ).toEqual(
+      new Map([
+        ['p1', 2],
+        ['p2', 1],
+      ])
+    );
   });
 });
 

--- a/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
@@ -3,7 +3,14 @@
 
 import type { DAGNode, DAGEdge, QueryPlanDataItem } from './types';
 import type { QueryBundle, EntityRef } from '@quent/utils';
-import { buildRelatedOperatorIdsById, Operator, Port, Plan, PlanTree } from '@quent/utils';
+import {
+  buildRelatedOperatorIdsById,
+  Operator,
+  Port,
+  Plan,
+  PlanTree,
+  Worker,
+} from '@quent/utils';
 
 interface PlanTreeNode extends PlanTree {
   query?: string | null;
@@ -55,18 +62,24 @@ const getNodeEntity = (
 /**
  * Recursively transform a plan node into TreeView format and provide display data
  */
-const transformNodeForTreeView = (node: PlanTreeNode, plans: Plan[]): QueryPlanDataItem => {
+const transformNodeForTreeView = (
+  node: PlanTreeNode,
+  plans: Plan[],
+  workers: { [id: string]: Worker | undefined }
+): QueryPlanDataItem => {
   const plan = plans.find(plan => plan.id === node.id);
+  const worker = node.worker ? workers[node.worker] : undefined;
 
   return {
     id: node.id,
     name: `Query Plan: ${node.id}`,
     queryId: node.id ?? undefined,
     workerId: node.worker ?? undefined,
+    workerName: worker?.instance_name ?? undefined,
     planType: plan?.instance_name ?? undefined,
     className: 'rounded-none',
     children: node.children?.length
-      ? node.children?.map(child => transformNodeForTreeView(child, plans))
+      ? node.children?.map(child => transformNodeForTreeView(child, plans, workers))
       : undefined,
   };
 };
@@ -82,7 +95,23 @@ export const getTreeData = (bundle: QueryBundle<EntityRef>): QueryPlanDataItem[]
   const plans = Object.values(bundle.entities.plans).filter(
     (plan): plan is Plan => plan !== undefined
   );
-  return [bundle.plan_tree].map(node => transformNodeForTreeView(node, plans));
+  return [bundle.plan_tree].map(node =>
+    transformNodeForTreeView(node, plans, bundle.entities.workers ?? {})
+  );
+};
+
+export const getSelectedOperatorCountsByPlan = (
+  bundle: QueryBundle<EntityRef>,
+  selectedOperatorIds: ReadonlySet<string>
+): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const operatorId of selectedOperatorIds) {
+    const planId = bundle.entities.operators[operatorId]?.plan_id;
+    if (planId) {
+      counts.set(planId, (counts.get(planId) ?? 0) + 1);
+    }
+  }
+  return counts;
 };
 
 /**

--- a/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
@@ -3,14 +3,7 @@
 
 import type { DAGNode, DAGEdge, QueryPlanDataItem } from './types';
 import type { QueryBundle, EntityRef } from '@quent/utils';
-import {
-  buildRelatedOperatorIdsById,
-  Operator,
-  Port,
-  Plan,
-  PlanTree,
-  Worker,
-} from '@quent/utils';
+import { buildRelatedOperatorIdsById, Operator, Port, Plan, PlanTree, Worker } from '@quent/utils';
 
 interface PlanTreeNode extends PlanTree {
   query?: string | null;

--- a/ui/packages/@quent/components/src/services/query-plan/types.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/types.ts
@@ -7,6 +7,7 @@ import type { DAGNode, DAGEdge, QuantitySpec } from '@quent/utils';
 export interface QueryPlanDataItem extends TreeDataItem {
   queryId?: string;
   workerId?: string;
+  workerName?: string;
   planType?: string;
 }
 

--- a/ui/packages/@quent/hooks/src/dataFlow/dataFlow.utils.test.ts
+++ b/ui/packages/@quent/hooks/src/dataFlow/dataFlow.utils.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from 'vitest';
 import type { DataFlowTimelineBinned, FsmTypeDecl, QuantitySpec } from '@quent/utils';
 import {
+  aggregateDataFlowOperatorFrames,
   buildDataFlowMeta,
   computeWindowMax,
   extractBinConfig,
@@ -20,9 +21,56 @@ import {
   resolveDataFlowWindow,
   timeToBinIndex,
   type DataFlowBinConfig,
+  type DataFlowOperatorFrame,
 } from './dataFlow.utils';
 
 const NUM_BINS = 4;
+
+describe('aggregateDataFlowOperatorFrames', () => {
+  const first: DataFlowOperatorFrame = {
+    total: 6,
+    byState: [3, 3],
+    byDimension: [1, 5],
+    matrix: [
+      [1, 2],
+      [0, 3],
+    ],
+    labelByState: [10, 30],
+    labelByDimension: [10, 30],
+  };
+  const second: DataFlowOperatorFrame = {
+    total: 9,
+    byState: [4, 5],
+    byDimension: [9, 0],
+    matrix: [
+      [4, 0],
+      [5, 0],
+    ],
+    labelByState: [40, 50],
+    labelByDimension: [90, 0],
+  };
+
+  it('sums state, dimension, matrix, and label values', () => {
+    expect(aggregateDataFlowOperatorFrames([first, second], 2, 2, false)).toEqual({
+      total: 15,
+      byState: [7, 8],
+      byDimension: [10, 5],
+      matrix: [
+        [5, 2],
+        [5, 3],
+      ],
+      labelByState: [50, 80],
+      labelByDimension: [100, 30],
+    });
+  });
+
+  it('aliases label totals when labels follow the displayed measure', () => {
+    const result = aggregateDataFlowOperatorFrames([first, second], 2, 2, true);
+
+    expect(result.labelByState).toBe(result.byState);
+    expect(result.labelByDimension).toBe(result.byDimension);
+  });
+});
 
 /** 4 bins over [0, 8) seconds; two dimension keys; two measures. */
 function makeBinned(operators: DataFlowTimelineBinned['operators'] = {}): DataFlowTimelineBinned {

--- a/ui/packages/@quent/hooks/src/dataFlow/dataFlow.utils.ts
+++ b/ui/packages/@quent/hooks/src/dataFlow/dataFlow.utils.ts
@@ -85,6 +85,54 @@ export interface DataFlowOperatorFrame {
   labelByDimension: number[];
 }
 
+/** Sums operator frames into one state-by-dimension distribution. */
+export function aggregateDataFlowOperatorFrames(
+  frames: Iterable<DataFlowOperatorFrame>,
+  stateCount: number,
+  dimensionCount: number,
+  labelsFollowMeasure: boolean
+): DataFlowOperatorFrame {
+  const matrix = Array.from({ length: stateCount }, () =>
+    Array.from({ length: dimensionCount }, () => 0)
+  );
+  const separateLabelByState = labelsFollowMeasure
+    ? null
+    : Array.from({ length: stateCount }, () => 0);
+  const separateLabelByDimension = labelsFollowMeasure
+    ? null
+    : Array.from({ length: dimensionCount }, () => 0);
+
+  for (const frame of frames) {
+    for (let stateIndex = 0; stateIndex < stateCount; stateIndex++) {
+      for (let dimensionIndex = 0; dimensionIndex < dimensionCount; dimensionIndex++) {
+        matrix[stateIndex]![dimensionIndex]! += frame.matrix[stateIndex]?.[dimensionIndex] ?? 0;
+      }
+      if (separateLabelByState) {
+        separateLabelByState[stateIndex]! += frame.labelByState[stateIndex] ?? 0;
+      }
+    }
+    if (separateLabelByDimension) {
+      for (let dimensionIndex = 0; dimensionIndex < dimensionCount; dimensionIndex++) {
+        separateLabelByDimension[dimensionIndex]! += frame.labelByDimension[dimensionIndex] ?? 0;
+      }
+    }
+  }
+
+  const byState = matrix.map(row => row.reduce((sum, value) => sum + value, 0));
+  const byDimension = Array.from({ length: dimensionCount }, (_, dimensionIndex) =>
+    matrix.reduce((sum, row) => sum + row[dimensionIndex]!, 0)
+  );
+
+  return {
+    total: byState.reduce((sum, value) => sum + value, 0),
+    byState,
+    byDimension,
+    matrix,
+    labelByState: separateLabelByState ?? byState,
+    labelByDimension: separateLabelByDimension ?? byDimension,
+  };
+}
+
 /** Snapshot of the data-flow distribution at the playhead's bin. */
 export interface DataFlowFrame {
   binIndex: number;

--- a/ui/packages/@quent/hooks/src/index.ts
+++ b/ui/packages/@quent/hooks/src/index.ts
@@ -128,6 +128,7 @@ export {
   resolveDataFlowMeasure,
   resolveDataFlowLabelMeasure,
   resolveDataFlowDimensions,
+  aggregateDataFlowOperatorFrames,
   formatDataFlowValue,
   formatDataFlowValueCompact,
   fitDataFlowSegmentLabel,

--- a/ui/src/components/DataFlowOverlay.test.tsx
+++ b/ui/src/components/DataFlowOverlay.test.tsx
@@ -49,6 +49,20 @@ const RESPONSE: DataFlowTimelineBinned = {
   },
 };
 
+const AGGREGATE_RESPONSE: DataFlowTimelineBinned = {
+  ...RESPONSE,
+  operators: {
+    ...RESPONSE.operators,
+    'op-2': {
+      values: {
+        tasks: {
+          queueing: { memory: [2, 0, 0, 0] },
+        },
+      },
+    },
+  },
+};
+
 // Same op-1 as RESPONSE plus a huge op-2: the window max (1000) squeezes
 // op-1's segments below label width (1/1000 of the ~168px track).
 const NARROW_RESPONSE: DataFlowTimelineBinned = {
@@ -397,7 +411,8 @@ describe('DAGNodeInfoPanel matrix under tier selection', () => {
 
   function renderPanel(
     selectedDimensions: ReadonlySet<string> | null,
-    operator: SelectedOperatorGroupData = selectedOperator
+    operator: SelectedOperatorGroupData = selectedOperator,
+    response: DataFlowTimelineBinned = RESPONSE
   ) {
     function SelectNode({ value }: { value: SelectedOperatorGroupData }) {
       const updateOperatorSelection = useOperatorSelectionActions();
@@ -418,7 +433,7 @@ describe('DAGNodeInfoPanel matrix under tier selection', () => {
     }
     return render(
       <Provider>
-        <Harness response={RESPONSE} selectedDimensions={selectedDimensions}>
+        <Harness response={response} selectedDimensions={selectedDimensions}>
           <>
             <DagPlayhead />
             <SelectNode value={operator} />
@@ -451,23 +466,36 @@ describe('DAGNodeInfoPanel matrix under tier selection', () => {
     expect(within(screen.getByRole('table')).getAllByText('0')).toHaveLength(9);
   });
 
-  it('renders matrices for a higher-level operator and its nested operators', () => {
-    renderPanel(null, {
-      nodeId: 'logical',
-      label: 'Logical operator',
-      operationType: 'join',
-      statistics: [],
-      relatedOperators: [selectedOperator],
-    });
+  it('aggregates nested operator matrices into the higher-level operator', () => {
+    renderPanel(
+      null,
+      {
+        nodeId: 'logical',
+        label: 'Logical operator',
+        operationType: 'join',
+        statistics: [],
+        relatedOperators: [
+          selectedOperator,
+          {
+            nodeId: 'op-2',
+            label: 'Op 2',
+            operationType: 'scan',
+            statistics: [],
+          },
+        ],
+      },
+      AGGREGATE_RESPONSE
+    );
     fireEvent.mouseDown(screen.getByRole('tab', { name: 'Data Flow' }), { button: 0 });
 
     const parent = screen.getByTestId('operator-accordion-logical');
     expect(within(parent).getByRole('button', { name: 'Toggle Op 1 details' })).toBeInTheDocument();
 
     const matrices = screen.getAllByRole('table');
-    expect(matrices).toHaveLength(2);
-    expect(within(matrices[0]).getAllByText('0')).toHaveLength(9);
+    expect(matrices).toHaveLength(3);
+    expect(within(matrices[0]).getAllByText('3.0')).not.toHaveLength(0);
     expect(within(matrices[1]).getAllByText('1.0')).not.toHaveLength(0);
+    expect(within(matrices[2]).getAllByText('2.0')).not.toHaveLength(0);
   });
 });
 

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -5,10 +5,15 @@ import { useEffect, useLayoutEffect, useMemo, useRef, lazy, Suspense } from 'rea
 import type { PanelImperativeHandle } from 'react-resizable-panels';
 import { useQueryBundle, useDataFlow } from '@quent/client';
 import { useQueryPlanVisualization } from '@/hooks/useQueryPlanVisualization';
-import { TreeView } from '@quent/components';
+import { Badge, getSelectedOperatorCountsByPlan, TreeView } from '@quent/components';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@quent/components';
 import { thinScrollbarClass, type QueryPlanDataItem } from '@quent/components';
-import { useSelectedPlanId, useSetSelectedPlanId, useSetHoveredWorkerId } from '@quent/hooks';
+import {
+  useSelectedNodeIds,
+  useSelectedPlanId,
+  useSetSelectedPlanId,
+  useSetHoveredWorkerId,
+} from '@quent/hooks';
 import { DAGControls, DAGNodeInfoPanel, DagPlayhead } from '@quent/components';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@quent/components';
 import {
@@ -47,11 +52,19 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
   const planId = useSelectedPlanId();
   const setPlanId = useSetSelectedPlanId();
   const setHoveredWorkerId = useSetHoveredWorkerId();
+  const selectedOperatorIds = useSelectedNodeIds();
   const {
     data: queryBundle,
     isLoading: queryBundleLoading,
     error: queryBundleError,
   } = useQueryBundle({ engineId, queryId });
+  const selectedOperatorCountsByPlan = useMemo(
+    () =>
+      queryBundle
+        ? getSelectedOperatorCountsByPlan(queryBundle, selectedOperatorIds)
+        : new Map<string, number>(),
+    [queryBundle, selectedOperatorIds]
+  );
 
   const { dagData, treeData, error: dagError } = useQueryPlanVisualization(queryBundle, planId);
   const operators = useMemo(
@@ -152,25 +165,42 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
   const singleQueryPlan = treeData.length === 1 && !treeData[0]?.children;
 
   const renderItem = ({ item, hasChildren }: { item: QueryPlanDataItem; hasChildren: boolean }) => {
+    const selectedOperatorCount = selectedOperatorCountsByPlan.get(item.id) ?? 0;
+    const selectedOperatorLabel = `${selectedOperatorCount} selected operator${
+      selectedOperatorCount === 1 ? '' : 's'
+    } in this plan`;
+
     return (
       <div className="flex flex-col items-start py-0.5 pl-1">
-        {singleQueryPlan ? (
-          <span className="text-xs">
-            Query: <DataText>{item.queryId}</DataText>
-          </span>
-        ) : (
-          <span className="text-xs">
-            <DataText className="capitalize">{item.planType}</DataText>
-            {!hasChildren && (
-              <span>
-                : <DataText>{item.id}</DataText>
-              </span>
-            )}
-          </span>
-        )}
+        <div className="flex items-center gap-1.5">
+          {singleQueryPlan ? (
+            <span className="text-xs">
+              Query: <DataText>{item.queryId}</DataText>
+            </span>
+          ) : (
+            <span className="text-xs">
+              <DataText className="capitalize">{item.planType}</DataText>
+              {!hasChildren && (
+                <span>
+                  : <DataText>{item.id}</DataText>
+                </span>
+              )}
+            </span>
+          )}
+          {selectedOperatorCount > 0 && (
+            <Badge
+              variant="secondary"
+              className="h-4 min-w-4 rounded-full px-1 py-0 text-[10px] leading-none"
+              aria-label={selectedOperatorLabel}
+              title={selectedOperatorLabel}
+            >
+              {selectedOperatorCount}
+            </Badge>
+          )}
+        </div>
         {item.workerId && (
           <span className="text-xs text-muted-foreground">
-            <DataText>Worker: {item.workerId}</DataText>
+            <DataText>Worker: {item.workerName ?? item.workerId}</DataText>
           </span>
         )}
         {hasChildren && (

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -166,9 +166,9 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
 
   const renderItem = ({ item, hasChildren }: { item: QueryPlanDataItem; hasChildren: boolean }) => {
     const selectedOperatorCount = selectedOperatorCountsByPlan.get(item.id) ?? 0;
-    const selectedOperatorLabel = `${selectedOperatorCount} selected operator${
+    const selectedOperatorLabel = `${selectedOperatorCount} operator${
       selectedOperatorCount === 1 ? '' : 's'
-    } in this plan`;
+    } selected`;
 
     return (
       <div className="flex flex-col items-start py-0.5 pl-1">

--- a/ui/src/components/QueryPlan.tsx
+++ b/ui/src/components/QueryPlan.tsx
@@ -9,7 +9,7 @@ import { Badge, getSelectedOperatorCountsByPlan, TreeView } from '@quent/compone
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@quent/components';
 import { thinScrollbarClass, type QueryPlanDataItem } from '@quent/components';
 import {
-  useSelectedNodeIds,
+  useSelectedOperatorIds,
   useSelectedPlanId,
   useSetSelectedPlanId,
   useSetHoveredWorkerId,
@@ -52,7 +52,7 @@ export function QueryPlan({ queryId, engineId }: { queryId: string; engineId: st
   const planId = useSelectedPlanId();
   const setPlanId = useSetSelectedPlanId();
   const setHoveredWorkerId = useSetHoveredWorkerId();
-  const selectedOperatorIds = useSelectedNodeIds();
+  const selectedOperatorIds = useSelectedOperatorIds();
   const {
     data: queryBundle,
     isLoading: queryBundleLoading,


### PR DESCRIPTION
# Description
Tying up loose ends with multi/higher level operator selection
* Add indicators to query plan tree to indicate the number of selected operators in each
* e2e test for operators crossfilter
* Integrate multi/higher level operator selection with data flow grid + colored bars

<!-- What does this PR do and why? -->

## Related Issues
Fixes #621

<!-- Link related issues: closes #123, relates to #456 -->

## Testing

### Selected Operator Indicators
* Select operators from the logical plan, confirm badges show up on sub plans indicating how many related operators are selected there
* Navigate to sub plans and select more/deselect etc - If a logical operator's sub operator is DEselected, the logical plan should become deselected. Otherwise counts should update in the query plan tree 1:1.

### E2E
* e2e tests pass, cover major operator selection flows

### Data Flow
* Select higher level operator
* Scrub through dataflow until child nodes have some usage on resources
* Verify that both the data flow data grid numbers add up for the logical node (sum of children), and that the node reflects those same numbers in the colored bars. 


## Screenshots

Selected operators badges, show worker name instead of ID:
https://github.com/user-attachments/assets/3b114887-dc99-4369-bec6-576ec0283d21


Data Flow:

<img width="572" height="838" alt="Screenshot 2026-09-17 at 12 31 07 PM" src="https://github.com/user-attachments/assets/97029635-a7f9-43a4-8fc6-2cdb344b0590" />

<!-- For UI changes, include screenshots or videos when possible. -->
