### PR TITLE
feat(fsm): encode FSM transition sequence field in schemas

### DIFF
--- a/crates/analyzer/src/fsm/events.rs
+++ b/crates/analyzer/src/fsm/events.rs
@@ -23,7 +23,7 @@ use crate::{
 /// A single transition in an analyzed FSM.
 pub struct TransitionEvent<T> {
     /// Per-instance transition sequence number.
-    pub seq: u64,
+    pub seq: u16,
     timestamp: TimeUnixNanoSec,
     state_name: &'static str,
     pub usages: SmallVec<[AnalyzedUsage; 1]>,
@@ -55,10 +55,10 @@ impl<T> Timestamp for TransitionEvent<T> {
 }
 
 impl<T> OrderKey for TransitionEvent<T> {
-    type Key = u64;
+    type Key = (TimeUnixNanoSec, u16);
 
     fn order_key(&self) -> Self::Key {
-        self.seq
+        (self.timestamp, self.seq)
     }
 }
 
@@ -357,6 +357,37 @@ mod tests {
                 .map(|transition| (transition.seq, transition.data.0))
                 .collect::<Vec<_>>(),
             [(0, 0), (1, 1)]
+        );
+    }
+
+    #[test]
+    fn sequence_wrap_is_ordered_by_timestamp() {
+        let id = Uuid::from_u128(1);
+        let mut builder = FsmEventsBuilder::try_new(id).unwrap();
+        builder.push(Event::new(
+            id,
+            101,
+            FsmEvent {
+                seq: 0,
+                state: TestTransition(0),
+            },
+        ));
+        builder.push(Event::new(
+            id,
+            100,
+            FsmEvent {
+                seq: u16::MAX,
+                state: TestTransition(1),
+            },
+        ));
+
+        let fsm = builder.try_build().unwrap();
+        assert_eq!(
+            fsm.transitions()
+                .iter()
+                .map(|transition| (transition.timestamp(), transition.seq))
+                .collect::<Vec<_>>(),
+            [(100, u16::MAX), (101, 0)]
         );
     }
 }

--- a/crates/analyzer/src/fsm/events.rs
+++ b/crates/analyzer/src/fsm/events.rs
@@ -10,7 +10,7 @@
 use quent_dynamic_attributes::DynamicAttribute;
 use quent_events::Event;
 use quent_model::{FsmEvent, ModelBuilder, analyze::TransitionInfo};
-use quent_time::{TimeOrderedCollector, TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec};
+use quent_time::{OrderKey, OrderedCollector, TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec};
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -22,6 +22,8 @@ use crate::{
 
 /// A single transition in an analyzed FSM.
 pub struct TransitionEvent<T> {
+    /// Per-instance transition sequence number.
+    pub seq: u64,
     timestamp: TimeUnixNanoSec,
     state_name: &'static str,
     pub usages: SmallVec<[AnalyzedUsage; 1]>,
@@ -32,6 +34,7 @@ pub struct TransitionEvent<T> {
 impl<T> std::fmt::Debug for TransitionEvent<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TransitionEvent")
+            .field("seq", &self.seq)
             .field("timestamp", &self.timestamp)
             .field("state_name", &self.state_name)
             .field("usages", &self.usages)
@@ -48,6 +51,14 @@ pub struct AnalyzedUsage {
 impl<T> Timestamp for TransitionEvent<T> {
     fn timestamp(&self) -> TimeUnixNanoSec {
         self.timestamp
+    }
+}
+
+impl<T> OrderKey for TransitionEvent<T> {
+    type Key = u64;
+
+    fn order_key(&self) -> Self::Key {
+        self.seq
     }
 }
 
@@ -86,7 +97,7 @@ impl<'a> Usage<'a> for UsageWithSpan<'a> {
 pub struct FsmEventsBuilder<T: TransitionInfo> {
     id: Uuid,
     instance_name: String,
-    transitions: TimeOrderedCollector<TransitionEvent<T>>,
+    transitions: OrderedCollector<TransitionEvent<T>>,
 }
 
 impl<T: TransitionInfo> FsmEventsBuilder<T> {
@@ -99,7 +110,7 @@ impl<T: TransitionInfo> FsmEventsBuilder<T> {
             Ok(Self {
                 id,
                 instance_name: String::new(),
-                transitions: TimeOrderedCollector::default(),
+                transitions: OrderedCollector::default(),
             })
         }
     }
@@ -110,7 +121,7 @@ impl<T: TransitionInfo> FsmEventsBuilder<T> {
     }
 
     pub fn push(&mut self, event: Event<FsmEvent<T>>) {
-        let state = event.data.state;
+        let FsmEvent { seq, state } = event.data;
         let state_name = state.state_name();
         // Capture instance name from the first transition that provides one.
         if self.instance_name.is_empty()
@@ -131,6 +142,7 @@ impl<T: TransitionInfo> FsmEventsBuilder<T> {
             })
             .collect();
         self.transitions.push(TransitionEvent {
+            seq,
             timestamp: event.timestamp,
             state_name,
             usages,
@@ -283,5 +295,68 @@ impl<T: TransitionInfo> FsmTypeDeclaration for FsmEvents<T> {
             states,
             transitions,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct TestTransition(u8);
+
+    impl TransitionInfo for TestTransition {
+        fn state_name(&self) -> &'static str {
+            "test"
+        }
+
+        fn usages(&self) -> Vec<quent_model::analyze::ExtractedUsage> {
+            Vec::new()
+        }
+
+        fn instance_name(&self) -> Option<&str> {
+            None
+        }
+
+        fn parent_group_id(&self) -> Option<Uuid> {
+            None
+        }
+
+        fn fsm_type_name() -> &'static str {
+            "test"
+        }
+
+        fn collect_model(_: &mut ModelBuilder) {}
+    }
+
+    #[test]
+    fn equal_timestamp_transitions_are_ordered_by_sequence() {
+        let id = Uuid::from_u128(1);
+        let mut builder = FsmEventsBuilder::try_new(id).unwrap();
+        builder.push(Event::new(
+            id,
+            100,
+            FsmEvent {
+                seq: 1,
+                state: TestTransition(1),
+            },
+        ));
+        builder.push(Event::new(
+            id,
+            100,
+            FsmEvent {
+                seq: 0,
+                state: TestTransition(0),
+            },
+        ));
+
+        let fsm = builder.try_build().unwrap();
+        assert_eq!(
+            fsm.transitions()
+                .iter()
+                .map(|transition| (transition.seq, transition.data.0))
+                .collect::<Vec<_>>(),
+            [(0, 0), (1, 1)]
+        );
     }
 }

--- a/crates/analyzer/src/fsm/runtime.rs
+++ b/crates/analyzer/src/fsm/runtime.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use rustc_hash::FxHashMap as HashMap;
 
 use quent_dynamic_attributes::DynamicAttribute;
-use quent_time::{TimeOrderedCollector, TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec};
+use quent_time::{OrderKey, OrderedCollector, TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec};
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -55,6 +55,14 @@ impl Timestamp for RtFsmTransition {
     }
 }
 
+impl OrderKey for RtFsmTransition {
+    type Key = TimeUnixNanoSec;
+
+    fn order_key(&self) -> Self::Key {
+        self.timestamp
+    }
+}
+
 impl Transition for RtFsmTransition {
     fn name(&self) -> &str {
         self.name.as_str()
@@ -69,7 +77,7 @@ pub struct RtFsmBuilder<T> {
     id: Uuid,
     type_name: Option<String>,
     instance_name: Option<String>,
-    transitions: TimeOrderedCollector<T>,
+    transitions: OrderedCollector<T>,
 }
 
 impl<T> RtFsmBuilder<T> {
@@ -78,7 +86,7 @@ impl<T> RtFsmBuilder<T> {
             id,
             type_name: None,
             instance_name: None,
-            transitions: TimeOrderedCollector::default(),
+            transitions: OrderedCollector::default(),
         }
     }
     pub fn set_type_name(&mut self, type_name: String) -> &mut Self {
@@ -93,7 +101,7 @@ impl<T> RtFsmBuilder<T> {
 
 impl<T> RtFsmBuilder<T>
 where
-    T: Timestamp,
+    T: OrderKey,
 {
     pub fn push(&mut self, state: T) {
         self.transitions.push(state)
@@ -102,7 +110,7 @@ where
 
 impl<T> Extend<T> for RtFsmBuilder<T>
 where
-    T: Timestamp,
+    T: OrderKey,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         for item in iter {

--- a/crates/analyzer/src/resource/runtime.rs
+++ b/crates/analyzer/src/resource/runtime.rs
@@ -3,7 +3,7 @@
 
 //! Run-time defined Resources and Resource Groups (in analysis)
 
-use quent_time::{TimeOrderedCollector, TimeUnixNanoSec, Timestamp};
+use quent_time::{OrderKey, OrderedCollector, TimeUnixNanoSec, Timestamp};
 use uuid::Uuid;
 
 use crate::{
@@ -33,6 +33,14 @@ impl Timestamp for RtResourceTransition {
     }
 }
 
+impl OrderKey for RtResourceTransition {
+    type Key = TimeUnixNanoSec;
+
+    fn order_key(&self) -> Self::Key {
+        self.timestamp()
+    }
+}
+
 impl Transition for RtResourceTransition {
     fn name(&self) -> &str {
         match self {
@@ -50,7 +58,7 @@ pub struct RtResourceBuilder {
     instance_name: Option<String>,
     type_name: Option<String>,
     parent_group_id: Option<Uuid>,
-    transitions: TimeOrderedCollector<RtResourceTransition>,
+    transitions: OrderedCollector<RtResourceTransition>,
 }
 
 impl RtResourceBuilder {

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -5,7 +5,7 @@
 
 mod entity_ref;
 
-use quent_time::{TimeUnixNanoSec, Timestamp, timestamp};
+use quent_time::{OrderKey, TimeUnixNanoSec, Timestamp, timestamp};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -79,6 +79,14 @@ impl<T> Event<T> {
 
 impl<T> Timestamp for Event<T> {
     fn timestamp(&self) -> TimeUnixNanoSec {
+        self.timestamp
+    }
+}
+
+impl<T> OrderKey for Event<T> {
+    type Key = TimeUnixNanoSec;
+
+    fn order_key(&self) -> Self::Key {
         self.timestamp
     }
 }

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -5,10 +5,10 @@ use std::collections::HashSet;
 
 use quent_constraints::Constraint;
 use quent_schema::builder::{AnnotationsBuilder, BuilderError, EntityBuilder, EventBuilder};
-use quent_schema::{Annotations, Cardinality, Entity, Field, Identifier, Path};
+use quent_schema::{Annotations, Cardinality, DataType, Entity, Field, Identifier, Path};
 use thiserror::Error;
 
-use crate::{Fsm, FsmConstraint, FsmError, Transition, check_entity};
+use crate::{Fsm, FsmConstraint, FsmError, SEQUENCE_FIELD_NAME, Transition, check_entity};
 
 /// A declared state of an FSM entity.
 pub struct StateDecl {
@@ -91,8 +91,8 @@ impl FsmEntityBuilder {
     ///
     /// Returns [`FsmEntityBuilderError`] if a state name is declared twice,
     /// there is not exactly one initial state, a state has a duplicate
-    /// attribute name, the topology fails to serialize, or the topology is
-    /// invalid.
+    /// attribute name (including the reserved `seq` name), the topology fails
+    /// to serialize, or the topology is invalid.
     pub fn build(self) -> Result<Entity, FsmEntityBuilderError> {
         let Self {
             path,
@@ -132,10 +132,19 @@ impl FsmEntityBuilder {
             .collect();
         let fsm = Fsm::new(initial, transitions);
 
+        let sequence_annotations = AnnotationsBuilder::new()
+            .with_docs("The per-instance transition order.")
+            .build()?;
         let mut entity = EntityBuilder::new(path);
         for state in states {
             let cardinality = fsm.cardinality(&state.name).unwrap_or(Cardinality::Once);
             let event = EventBuilder::new(state.name, cardinality)
+                .with_field(Field::new(
+                    Identifier::try_new(SEQUENCE_FIELD_NAME)
+                        .expect("the reserved sequence field name is valid"),
+                    DataType::U64,
+                    sequence_annotations.clone(),
+                ))
                 .with_fields(state.attributes)
                 .build()?;
             entity = entity.with_event(event);

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -142,7 +142,7 @@ impl FsmEntityBuilder {
                 .with_field(Field::new(
                     Identifier::try_new(SEQUENCE_FIELD_NAME)
                         .expect("the reserved sequence field name is valid"),
-                    DataType::U64,
+                    DataType::U16,
                     sequence_annotations.clone(),
                 ))
                 .with_fields(state.attributes)

--- a/crates/fsm/src/builder.rs
+++ b/crates/fsm/src/builder.rs
@@ -133,7 +133,7 @@ impl FsmEntityBuilder {
         let fsm = Fsm::new(initial, transitions);
 
         let sequence_annotations = AnnotationsBuilder::new()
-            .with_docs("The per-instance transition order.")
+            .with_docs("The per-instance sequence number for equal-timestamp transitions.")
             .build()?;
         let mut entity = EntityBuilder::new(path);
         for state in states {

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -12,7 +12,7 @@ use petgraph::{
 };
 use quent_constraints::{Constraint, utils::bullet_list};
 use quent_schema::{
-    Cardinality, Entity, Identifier, Path,
+    Cardinality, DataType, Entity, Identifier, Path,
     visitor::{Cursor, Element, Visitor},
 };
 use serde::{Deserialize, Serialize};
@@ -21,6 +21,9 @@ use thiserror::Error;
 mod builder;
 
 pub use builder::{FsmEntityBuilder, FsmEntityBuilderError, StateDecl};
+
+/// Reserved state-event field carrying per-instance transition order.
+pub const SEQUENCE_FIELD_NAME: &str = "seq";
 
 /// A directed transition between two named states in an [`Fsm`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -171,6 +174,8 @@ impl Fsm {
 /// 5. The initial state is not a final state.
 /// 6. A state on a cycle has [`Cardinality::Multi`], otherwise
 ///    [`Cardinality::Once`].
+/// 7. Every state event has a `seq` field of type [`DataType::U64`] carrying
+///    its per-instance transition order.
 #[derive(Default)]
 pub struct FsmConstraint {
     errors: Vec<FsmError>,
@@ -228,6 +233,26 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
         .events()
         .map(|e| (e.name(), e.cardinality()))
         .collect();
+
+    for event in entity.events() {
+        match event
+            .fields()
+            .find(|field| field.name() == SEQUENCE_FIELD_NAME)
+        {
+            None => errors.push(FsmError::MissingSequenceField {
+                entity: entity.path().clone(),
+                state: event.name().clone(),
+            }),
+            Some(field) if field.ty() != &DataType::U64 => {
+                errors.push(FsmError::SequenceFieldTypeMismatch {
+                    entity: entity.path().clone(),
+                    state: event.name().clone(),
+                    found: Box::new(field.ty().clone()),
+                });
+            }
+            Some(_) => {}
+        }
+    }
 
     // Gather every state named
     let states: HashSet<&Identifier> = fsm.states().collect();
@@ -359,6 +384,16 @@ pub enum FsmError {
         state: Identifier,
         expected: Cardinality,
         found: Cardinality,
+    },
+    #[error("entity \"{entity}\" fsm: state \"{state}\" is missing reserved `seq` field")]
+    MissingSequenceField { entity: Path, state: Identifier },
+    #[error(
+        "entity \"{entity}\" fsm: state \"{state}\" expects reserved `seq` field type U64, but found {found:?}"
+    )]
+    SequenceFieldTypeMismatch {
+        entity: Path,
+        state: Identifier,
+        found: Box<DataType>,
     },
     #[error("multiple fsm violations:\n{}", bullet_list(.0))]
     Multiple(Vec<FsmError>),

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -180,16 +180,17 @@ impl Fsm {
 /// Analyzers order transitions by timestamp and then by `seq`. The sequence
 /// number disambiguates transitions that share a timestamp because of clock
 /// resolution or batched capture, while the timestamp preserves chronological
-/// order across sequence-number rollover and out-of-order delivery. Producers
-/// should use a wrapping counter scoped to each FSM instance, conventionally
-/// beginning at zero.
+/// order across sequence-number rollover and potential out-of-order exporting.
+/// Producers should use a wrapping counter scoped to each FSM instance,
+/// conventionally beginning at zero.
 ///
 /// Wrapping after 65,536 transitions is explicitly permitted. Ambiguous order
 /// would require one FSM instance to emit a full sequence-number cycle without
-/// its observed timestamp advancing. Equal timestamps are already uncommon,
-/// and that many transitions within one timestamp interval is not practical on
-/// current systems. Exact reconstruction across a rollover nevertheless
-/// requires the transitions on either side to have different timestamps.
+/// its nanosecond-precision timestamp advancing. Equal timestamps are already
+/// uncommon, and that many transitions within one timestamp interval is not
+/// practical on current systems. Exact reconstruction across a rollover
+/// nevertheless requires the transitions on either side to have different
+/// timestamps.
 ///
 /// This constraint validates only that every state event declares the field
 /// with the required type. It does not inspect emitted values, so duplicate

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -22,7 +22,7 @@ mod builder;
 
 pub use builder::{FsmEntityBuilder, FsmEntityBuilderError, StateDecl};
 
-/// Reserved state-event field carrying per-instance transition order.
+/// Reserved state-event field used to order equal-timestamp transitions.
 pub const SEQUENCE_FIELD_NAME: &str = "seq";
 
 /// A directed transition between two named states in an [`Fsm`].
@@ -174,15 +174,22 @@ impl Fsm {
 /// 5. The initial state is not a final state.
 /// 6. A state on a cycle has [`Cardinality::Multi`], otherwise
 ///    [`Cardinality::Once`].
-/// 7. Every state event has a `seq` field of type [`DataType::U16`] carrying
-///    its per-instance transition order.
+/// 7. Every state event has a `seq` field of type [`DataType::U16`] carrying a
+///    per-instance transition sequence number.
 ///
-/// The `seq` field separates logical transition order from timestamp order.
-/// Multiple transitions can have the same timestamp, and event delivery can
-/// reorder them, so timestamps alone cannot reliably reconstruct an FSM's
-/// lifecycle. Producers should assign monotonically increasing values within
-/// each FSM instance, conventionally beginning at zero. A `u16` supports up to
-/// 65,536 distinct sequence values per instance.
+/// Analyzers order transitions by timestamp and then by `seq`. The sequence
+/// number disambiguates transitions that share a timestamp because of clock
+/// resolution or batched capture, while the timestamp preserves chronological
+/// order across sequence-number rollover and out-of-order delivery. Producers
+/// should use a wrapping counter scoped to each FSM instance, conventionally
+/// beginning at zero.
+///
+/// Wrapping after 65,536 transitions is explicitly permitted. Ambiguous order
+/// would require one FSM instance to emit a full sequence-number cycle without
+/// its observed timestamp advancing. Equal timestamps are already uncommon,
+/// and that many transitions within one timestamp interval is not practical on
+/// current systems. Exact reconstruction across a rollover nevertheless
+/// requires the transitions on either side to have different timestamps.
 ///
 /// This constraint validates only that every state event declares the field
 /// with the required type. It does not inspect emitted values, so duplicate

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -174,8 +174,19 @@ impl Fsm {
 /// 5. The initial state is not a final state.
 /// 6. A state on a cycle has [`Cardinality::Multi`], otherwise
 ///    [`Cardinality::Once`].
-/// 7. Every state event has a `seq` field of type [`DataType::U64`] carrying
+/// 7. Every state event has a `seq` field of type [`DataType::U16`] carrying
 ///    its per-instance transition order.
+///
+/// The `seq` field separates logical transition order from timestamp order.
+/// Multiple transitions can have the same timestamp, and event delivery can
+/// reorder them, so timestamps alone cannot reliably reconstruct an FSM's
+/// lifecycle. Producers should assign monotonically increasing values within
+/// each FSM instance, conventionally beginning at zero. A `u16` supports up to
+/// 65,536 distinct sequence values per instance.
+///
+/// This constraint validates only that every state event declares the field
+/// with the required type. It does not inspect emitted values, so duplicate
+/// values, gaps, and nonzero initial values are not schema violations.
 #[derive(Default)]
 pub struct FsmConstraint {
     errors: Vec<FsmError>,
@@ -243,7 +254,7 @@ pub(crate) fn check_entity(entity: &Entity, fsm: &Fsm, errors: &mut Vec<FsmError
                 entity: entity.path().clone(),
                 state: event.name().clone(),
             }),
-            Some(field) if field.ty() != &DataType::U64 => {
+            Some(field) if field.ty() != &DataType::U16 => {
                 errors.push(FsmError::SequenceFieldTypeMismatch {
                     entity: entity.path().clone(),
                     state: event.name().clone(),
@@ -388,7 +399,7 @@ pub enum FsmError {
     #[error("entity \"{entity}\" fsm: state \"{state}\" is missing reserved `seq` field")]
     MissingSequenceField { entity: Path, state: Identifier },
     #[error(
-        "entity \"{entity}\" fsm: state \"{state}\" expects reserved `seq` field type U64, but found {found:?}"
+        "entity \"{entity}\" fsm: state \"{state}\" expects reserved `seq` field type U16, but found {found:?}"
     )]
     SequenceFieldTypeMismatch {
         entity: Path,

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -4,13 +4,21 @@
 use quent_constraints::Constraint as _;
 use quent_fsm::{FsmConstraint, FsmEntityBuilder, FsmEntityBuilderError, FsmError, StateDecl};
 use quent_schema::{
-    Annotations, Cardinality, Entity, Event, Schema,
-    builder::{AnnotationsBuilder, EntityBuilder},
+    Annotations, Cardinality, DataType, Entity, Event, Field, Schema,
+    builder::{AnnotationsBuilder, BuilderError, EntityBuilder},
     test_utils::{entity as bare_entity, event_with, ident, schema},
 };
 
 fn event(name: &str, cardinality: Cardinality) -> Event {
-    event_with(name, cardinality, vec![])
+    event_with(
+        name,
+        cardinality,
+        [Field::new(
+            ident("seq"),
+            DataType::U64,
+            Annotations::default(),
+        )],
+    )
 }
 
 fn state(name: &str, to: &[&str], initial: bool) -> StateDecl {
@@ -73,6 +81,54 @@ fn well_formed_linear_fsm_passes() {
         &fsm,
     );
     assert!(validate(&schema_with(entity)).is_empty());
+}
+
+#[test]
+fn missing_sequence_field_is_rejected() {
+    let data = fsm("a", &[("a", "b")]);
+    let entity = entity_with(
+        "E",
+        vec![
+            event_with("a", Cardinality::Once, []),
+            event("b", Cardinality::Once),
+        ],
+        &data,
+    );
+
+    assert!(validate(&schema_with(entity)).iter().any(|error| matches!(
+        error,
+        FsmError::MissingSequenceField { state, .. } if state == "a"
+    )));
+}
+
+#[test]
+fn incorrectly_typed_sequence_field_is_rejected() {
+    let data = fsm("a", &[("a", "b")]);
+    let entity = entity_with(
+        "E",
+        vec![
+            event_with(
+                "a",
+                Cardinality::Once,
+                [Field::new(
+                    ident("seq"),
+                    DataType::U32,
+                    Annotations::default(),
+                )],
+            ),
+            event("b", Cardinality::Once),
+        ],
+        &data,
+    );
+
+    assert!(validate(&schema_with(entity)).iter().any(|error| matches!(
+        error,
+        FsmError::SequenceFieldTypeMismatch {
+            state,
+            found,
+            ..
+        } if state == "a" && found.as_ref() == &DataType::U32
+    )));
 }
 
 #[test]
@@ -326,7 +382,35 @@ fn builder_produces_entity_with_state_events() {
 
     let names: Vec<_> = entity.events().map(|e| e.name().to_string()).collect();
     assert_eq!(names, vec!["a", "b"]);
+    for event in entity.events() {
+        let fields: Vec<_> = event.fields().collect();
+        assert_eq!(fields[0].name(), "seq");
+        assert_eq!(fields[0].ty(), &DataType::U64);
+        assert_eq!(
+            fields[0].annotations().docs(),
+            Some("The per-instance transition order.")
+        );
+    }
     assert!(entity.annotations().has_constraint(FsmConstraint::NAME));
+}
+
+#[test]
+fn builder_rejects_reserved_sequence_attribute() {
+    let mut initial = state("a", &["b"], true);
+    initial.attributes.push(Field::new(
+        ident("seq"),
+        DataType::U64,
+        Annotations::default(),
+    ));
+    let error = FsmEntityBuilder::new(ident("E"))
+        .with_states([initial, state("b", &[], false)])
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        FsmEntityBuilderError::Build(BuilderError::DuplicateName(name)) if name == "seq"
+    ));
 }
 
 #[test]

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -15,7 +15,7 @@ fn event(name: &str, cardinality: Cardinality) -> Event {
         cardinality,
         [Field::new(
             ident("seq"),
-            DataType::U64,
+            DataType::U16,
             Annotations::default(),
         )],
     )
@@ -385,7 +385,7 @@ fn builder_produces_entity_with_state_events() {
     for event in entity.events() {
         let fields: Vec<_> = event.fields().collect();
         assert_eq!(fields[0].name(), "seq");
-        assert_eq!(fields[0].ty(), &DataType::U64);
+        assert_eq!(fields[0].ty(), &DataType::U16);
         assert_eq!(
             fields[0].annotations().docs(),
             Some("The per-instance transition order.")
@@ -399,7 +399,7 @@ fn builder_rejects_reserved_sequence_attribute() {
     let mut initial = state("a", &["b"], true);
     initial.attributes.push(Field::new(
         ident("seq"),
-        DataType::U64,
+        DataType::U16,
         Annotations::default(),
     ));
     let error = FsmEntityBuilder::new(ident("E"))

--- a/crates/fsm/tests/fsm-constraint.rs
+++ b/crates/fsm/tests/fsm-constraint.rs
@@ -388,7 +388,7 @@ fn builder_produces_entity_with_state_events() {
         assert_eq!(fields[0].ty(), &DataType::U16);
         assert_eq!(
             fields[0].annotations().docs(),
-            Some("The per-instance transition order.")
+            Some("The per-instance sequence number for equal-timestamp transitions.")
         );
     }
     assert!(entity.annotations().has_constraint(FsmConstraint::NAME));

--- a/crates/instrumentation-build/example/src/lib.rs
+++ b/crates/instrumentation-build/example/src/lib.rs
@@ -84,9 +84,9 @@ fn emit_events(context: Context<Demo>) -> Result<Uuid, Box<dyn std::error::Error
     // FSMs will get typestate pattern handles in the future, also see
     // https://github.com/rapidsai/quent/issues/416
     let mut query = context.observer::<Query>().handle();
-    query.submitted("select 1".to_owned(), conn.as_entity_ref())?;
-    query.running(10)?;
-    query.ready(true)?;
+    query.submitted(0, "select 1".to_owned(), conn.as_entity_ref())?;
+    query.running(1, 10)?;
+    query.ready(2, true)?;
 
     conn.closed()?;
 

--- a/crates/model-macros/src/fsm_macro.rs
+++ b/crates/model-macros/src/fsm_macro.rs
@@ -484,7 +484,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
         #[doc(alias = "handle")]
         pub struct #handle_name {
             id: quent_model::uuid::Uuid,
-            seq: u64,
+            seq: u16,
             exited: bool,
             inner: ::std::sync::Arc<quent_model::Observer<#event_type>>,
         }
@@ -507,7 +507,7 @@ pub fn expand(input: TokenStream) -> syn::Result<TokenStream> {
 
             fn emit_transition(&mut self, state: #transition_enum) {
                 let seq = self.seq;
-                self.seq += 1;
+                self.seq = self.seq.wrapping_add(1);
                 let event = quent_model::FsmEvent { seq, state };
                 self.inner.send(quent_model::Event::new(
                     self.id,

--- a/crates/model-macros/src/resource_derive.rs
+++ b/crates/model-macros/src/resource_derive.rs
@@ -846,7 +846,7 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
         #[doc(alias = "handle")]
         #vis struct #handle_name {
             id: quent_model::uuid::Uuid,
-            seq: u64,
+            seq: u16,
             exited: bool,
             inner: ::std::sync::Arc<quent_model::Observer<#event_type>>,
         }
@@ -871,7 +871,7 @@ fn expand_impl(input: DeriveInput, resizable: bool) -> syn::Result<TokenStream> 
 
             fn emit_transition(&mut self, state: #transition_enum) {
                 let seq = self.seq;
-                self.seq += 1;
+                self.seq = self.seq.wrapping_add(1);
                 let event = quent_model::FsmEvent { seq, state };
                 self.inner.send(quent_model::Event::new(
                     self.id,

--- a/crates/model/src/fsm_event.rs
+++ b/crates/model/src/fsm_event.rs
@@ -14,9 +14,9 @@
 /// `S` is the transition enum (one variant per state + exit).
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FsmEvent<S> {
-    /// Per-instance sequence number, monotonically increasing.
-    /// Establishes total ordering of transitions within a single FSM instance.
-    pub seq: u64,
+    /// Wrapping per-instance sequence number used to order transitions that
+    /// have the same event timestamp.
+    pub seq: u16,
     /// The state being entered and its attributes.
     pub state: S,
 }

--- a/crates/time/src/lib.rs
+++ b/crates/time/src/lib.rs
@@ -118,37 +118,47 @@ pub trait Timestamp {
     fn timestamp(&self) -> TimeUnixNanoSec;
 }
 
-/// Maintains a timestamp-ordered sequence of items.
+/// Provides the key used to order an item in an [`OrderedCollector`].
+pub trait OrderKey {
+    /// The item's sortable key type.
+    type Key: Ord;
+
+    /// Return the key used to order this item.
+    fn order_key(&self) -> Self::Key;
+}
+
+/// Maintains an ordered sequence of items.
 ///
-/// Optimized for when the common case is that items arrive in timestamp order,
+/// Optimized for when the common case is that items arrive in key order,
 /// in which case [`Self::push`] is O(1). Out-of-order items are inserted via
 /// binary search (O(log n) search + O(n) insertion).
 ///
-/// Stable: items with equal timestamps keep their arrival order.
-pub struct TimeOrderedCollector<T>(Vec<T>);
+/// Stable: items with equal keys keep their arrival order.
+pub struct OrderedCollector<T>(Vec<T>);
 
-impl<T> Default for TimeOrderedCollector<T> {
+impl<T> Default for OrderedCollector<T> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<T> TimeOrderedCollector<T>
+impl<T> OrderedCollector<T>
 where
-    T: Timestamp,
+    T: OrderKey,
 {
-    pub fn push(&mut self, state: T) {
+    pub fn push(&mut self, item: T) {
         if let Some(last) = self.0.last()
-            && last.timestamp() <= state.timestamp()
+            && last.order_key() <= item.order_key()
         {
-            self.0.push(state);
+            self.0.push(item);
         } else {
             // `<=` (upper bound): late arrivals land after ties, matching the fast path.
             // `<` (lower bound) would insert before ties, reversing arrival order.
+            let key = item.order_key();
             let pos = self
                 .0
-                .partition_point(|s| s.timestamp() <= state.timestamp());
-            self.0.insert(pos, state);
+                .partition_point(|existing| existing.order_key() <= key);
+            self.0.insert(pos, item);
         }
     }
 
@@ -157,9 +167,9 @@ where
     }
 }
 
-impl<T> Extend<T> for TimeOrderedCollector<T>
+impl<T> Extend<T> for OrderedCollector<T>
 where
-    T: Timestamp,
+    T: OrderKey,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         for transition in iter {
@@ -172,18 +182,20 @@ where
 mod collector_tests {
     use super::*;
 
-    /// Carries its timestamp plus a tag, so equal-timestamp ordering is visible.
+    /// Carries its order key plus a tag, so equal-key ordering is visible.
     #[derive(Debug, PartialEq, Eq)]
-    struct Tagged(TimeUnixNanoSec, &'static str);
+    struct Tagged(u8, &'static str);
 
-    impl Timestamp for Tagged {
-        fn timestamp(&self) -> TimeUnixNanoSec {
+    impl OrderKey for Tagged {
+        type Key = u8;
+
+        fn order_key(&self) -> Self::Key {
             self.0
         }
     }
 
-    fn collect(items: impl IntoIterator<Item = Tagged>) -> Vec<(TimeUnixNanoSec, &'static str)> {
-        let mut collector = TimeOrderedCollector::default();
+    fn collect(items: impl IntoIterator<Item = Tagged>) -> Vec<(u8, &'static str)> {
+        let mut collector = OrderedCollector::default();
         collector.extend(items);
         collector
             .into_inner()
@@ -209,7 +221,7 @@ mod collector_tests {
     }
 
     #[test]
-    fn equal_timestamps_keep_arrival_order_on_the_fast_path() {
+    fn equal_keys_keep_arrival_order_on_the_fast_path() {
         assert_eq!(
             collect([Tagged(10, "first"), Tagged(10, "second")]),
             [(10, "first"), (10, "second")]
@@ -218,8 +230,8 @@ mod collector_tests {
 
     /// Regression: `<` predicate (lower bound) reversed arrival order on the slow path.
     #[test]
-    fn equal_timestamps_keep_arrival_order_on_the_slow_path() {
-        // t=20 "later" triggers the slow path for the subsequent t=10 "second".
+    fn equal_keys_keep_arrival_order_on_the_slow_path() {
+        // Key 20 triggers the slow path for the subsequent second item at key 10.
         assert_eq!(
             collect([
                 Tagged(10, "first"),
@@ -231,7 +243,7 @@ mod collector_tests {
     }
 
     #[test]
-    fn equal_timestamps_keep_arrival_order_across_a_run() {
+    fn equal_keys_keep_arrival_order_across_a_run() {
         assert_eq!(
             collect([
                 Tagged(10, "a"),

--- a/crates/yaml/tests/fsm.rs
+++ b/crates/yaml/tests/fsm.rs
@@ -53,7 +53,7 @@ fn fsm_builds_events_and_derives_cardinality() {
     for event in query.events() {
         let fields: Vec<_> = event.fields().collect();
         assert_eq!(fields[0].name(), "seq");
-        assert_eq!(fields[0].ty(), &DataType::U64);
+        assert_eq!(fields[0].ty(), &DataType::U16);
     }
 }
 

--- a/crates/yaml/tests/fsm.rs
+++ b/crates/yaml/tests/fsm.rs
@@ -5,7 +5,7 @@
 //! deriving their cardinality from the topology and validating it.
 
 use quent_schema::test_utils::{ident, path};
-use quent_schema::{Cardinality, Schema};
+use quent_schema::{Cardinality, DataType, Schema};
 use quent_yaml::{Error, parse_from_str};
 
 const FSM: &str = "quent.fsm.v0.1.0";
@@ -50,6 +50,30 @@ fn fsm_builds_events_and_derives_cardinality() {
     assert!(matches!(card("progress"), Cardinality::Multi));
     assert!(matches!(card("submitted"), Cardinality::Once));
     assert!(matches!(card("finished"), Cardinality::Once));
+    for event in query.events() {
+        let fields: Vec<_> = event.fields().collect();
+        assert_eq!(fields[0].name(), "seq");
+        assert_eq!(fields[0].ty(), &DataType::U64);
+    }
+}
+
+#[test]
+fn reserved_sequence_attribute_is_rejected() {
+    let errors = errors_of(
+        "\
+quent: alpha
+model: m
+fsms:
+  E:
+    states:
+      a:
+        initial: true
+        attributes: { seq: u64 }
+        to: [b]
+      b: {}
+",
+    );
+    assert!(errors.contains("duplicate name \"seq\""), "{errors}");
 }
 
 #[test]

--- a/examples/readme/src/main.rs
+++ b/examples/readme/src/main.rs
@@ -48,8 +48,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Spawn a thread.
     let mut thread = context.observer::<Thread>().handle();
-    thread.idle(worker.as_entity_ref())?;
-    thread.active()?;
+    thread.idle(0, worker.as_entity_ref())?;
+    thread.active(1)?;
 
     // Emit a structured log event.
     context.observer::<Info>().handle().recorded(
@@ -75,19 +75,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Queue and execute a task with typed resource usage claims.
     let mut task = context.observer::<Task>().handle();
     task.queued(
+        0,
         "my_task_31415".to_owned(),
         1,
         worker.as_entity_ref(),
         Some(queue.as_entity_ref_with(QueueUsage { entries: 1 })),
     )?;
-    task.computing(Some(thread.as_entity_ref_with(ThreadUsage)), None)?;
+    task.computing(1, Some(thread.as_entity_ref_with(ThreadUsage)), None)?;
     task.computing(
+        2,
         Some(thread.as_entity_ref_with(ThreadUsage)),
         Some(memory.as_entity_ref_with(MemoryPoolUsage { bytes: 1024 })),
     )?;
-    task.exit()?;
-    thread.idle(worker.as_entity_ref())?;
-    thread.exit()?;
+    task.exit(3)?;
+    thread.idle(2, worker.as_entity_ref())?;
+    thread.exit(3)?;
 
     // Flush all entity streams before reporting the output directory.
     drop((

--- a/integrations/nvtx/analyzer/src/model.rs
+++ b/integrations/nvtx/analyzer/src/model.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use nvtx_bridge::NvtxEventEntity;
 use nvtx_events::NvtxEvent;
 use quent_events::Event;
-use quent_time::{TimeOrderedCollector, TimeUnixNanoSec};
+use quent_time::{OrderedCollector, TimeUnixNanoSec};
 
 use crate::anomalies::ReconstructionAnomalies;
 use crate::ranges::{PushPopRanges, StartEndRanges};
@@ -179,7 +179,7 @@ impl NvtxModelBuilder {
     pub fn build(events: impl IntoIterator<Item = Event<NvtxEventEntity>>) -> NvtxModel {
         // Pass 1a — materialize in timestamp order. Equal timestamps keep
         // arrival order, so replay is deterministic.
-        let mut collector = TimeOrderedCollector::default();
+        let mut collector = OrderedCollector::default();
         collector.extend(events);
         let ordered = collector.into_inner();
 


### PR DESCRIPTION
# Description

Represent FSM transition ordering directly in schemas with a reserved `seq: u16` field on every state event.

Replace `TimeOrderedCollector` with the generic `OrderedCollector` and `OrderKey`. Existing consumers remain timestamp-ordered, while analyzed FSM transitions order by `(timestamp, seq)` so sequence numbers disambiguate equal timestamps.

Legacy and schema-generated FSM events both use wrapping `u16` sequence numbers. Rollover is permitted because ambiguity would require one FSM instance to emit 65,536 transitions without its observed timestamp advancing. This is almost certainly impossible in practice.

Schema-generated instrumentation remains generic and temporarily exposes `seq` as the first transition-method argument until typestate generation provides automatic sequencing.

## Related Issues

Part of #191, follow-up will leverage this as a part of #416 so users don't need to explicitly set `seq`. #416 is an explicit goal for the first stable beta release.

## Testing

- `pixi run cargo fmt --all -- --check`
- Targeted tests for `quent-time`, `quent-events`, `quent-fsm`, `quent-yaml`, `quent-analyzer`, `quent-instrumentation-build`, generated examples, and `nvtx-analyzer`
- Warning-as-error Clippy for changed crates and examples
- Workspace tests excluding Linux-only NVTX injection dependents and Python extensions requiring unavailable `libpython3.14.dylib`

## Screenshots

Not applicable; no UI changes.

_Written by Codex._