### PR TITLE
fix: show playhead lines on gantt charts by default

### DIFF
--- a/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
+++ b/ui/packages/@quent/components/src/gantt-chart/GanttChart.tsx
@@ -80,7 +80,7 @@ export function GanttChart<T extends GanttDatum>({
   expandable = false,
   expandLabel = 'Expand chart',
   collapseLabel = 'Collapse chart',
-  showPlayhead = false,
+  showPlayhead = true,
   renderTooltip,
   onBackgroundClick,
 }: GanttChartProps<T>) {


### PR DESCRIPTION
# Description
Flips gantt chart default to show playhead by default. 

## Related Issues
None

## Testing
1. Open query with entities + nvtx ranges
2. Expand rows so entities, operators, and nvtx swimlane charts are visible (doesnt have to all be in the same viewport)
3. Click play in the data-flow 
4. Verify that the playhead line appears on all swimlane/gantt style charts, play pause stop all function as before

## Screenshots

https://github.com/user-attachments/assets/63e824de-dcbd-4fb1-b1e5-b45d333c4026


