### PR TITLE
feat(ui): display worker info for stats panel operators

### DIFF
--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
@@ -43,6 +43,37 @@ function SelectedNode() {
   return <DAGNodeInfoPanel />;
 }
 
+function SameNameOnDifferentWorkers() {
+  const updateOperatorSelection = useOperatorSelectionActions();
+
+  useEffect(() => {
+    updateOperatorSelection({
+      type: 'add',
+      selectionId: 'scan',
+      label: 'Table scan',
+      operatorIds: ['scan-1', 'scan-2'],
+      selectedData: {
+        nodeId: 'scan-1',
+        label: 'Table scan',
+        operationType: 'scan',
+        statistics: [{ key: 'output_rows', value: 10 }],
+        workerLabel: 'worker-1',
+        relatedOperators: [
+          {
+            nodeId: 'scan-2',
+            label: 'Table scan',
+            operationType: 'scan',
+            statistics: [{ key: 'output_rows', value: 20 }],
+            workerLabel: 'worker-2',
+          },
+        ],
+      },
+    });
+  }, [updateOperatorSelection]);
+
+  return <DAGNodeInfoPanel />;
+}
+
 function SwitchSelectedNode() {
   const [showLogical, setShowLogical] = useState(true);
   const updateOperatorSelection = useOperatorSelectionActions();
@@ -219,6 +250,18 @@ describe('DAGNodeInfoPanel', () => {
     expect(
       await screen.findByRole('button', { name: 'Toggle Logical join details' })
     ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('shows a worker label so same-named operators can be told apart', async () => {
+    render(
+      <Provider>
+        <SameNameOnDifferentWorkers />
+      </Provider>
+    );
+
+    await screen.findAllByText('Table scan');
+    expect(screen.getByText('worker-1')).toBeInTheDocument();
+    expect(screen.getByText('worker-2')).toBeInTheDocument();
   });
 
   it('collapses related child operators independently', async () => {

--- a/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
+++ b/ui/packages/@quent/components/src/dag/DAGNodeInfoPanel.test.tsx
@@ -262,6 +262,15 @@ describe('DAGNodeInfoPanel', () => {
     await screen.findAllByText('Table scan');
     expect(screen.getByText('worker-1')).toBeInTheDocument();
     expect(screen.getByText('worker-2')).toBeInTheDocument();
+
+    // Each toggle must have a distinct accessible name, otherwise screen readers
+    // and role-based queries can't tell same-named operators apart.
+    expect(
+      screen.getByRole('button', { name: 'Toggle Table scan (worker-1) details' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Toggle Table scan (worker-2) details' })
+    ).toBeInTheDocument();
   });
 
   it('collapses related child operators independently', async () => {

--- a/ui/packages/@quent/components/src/dag/dagSelection.ts
+++ b/ui/packages/@quent/components/src/dag/dagSelection.ts
@@ -33,11 +33,13 @@ function getSelectedOperatorData(node: DAGNode): SelectedOperatorGroupData {
     label: node.label,
     operationType: node.type,
     statistics: parseCustomStatistics(metadata?.rawNode),
+    workerLabel: metadata?.operatorWorkerLabels?.[node.id],
     relatedOperators: metadata?.relatedOperators?.map(operator => ({
       nodeId: operator.id,
       label: operator.instance_name ?? operator.operator_type_name ?? 'Operator',
       operationType: operator.operator_type_name?.toLowerCase() ?? 'operator',
       statistics: parseCustomStatistics(operator),
+      workerLabel: metadata?.operatorWorkerLabels?.[operator.id],
     })),
   };
 }

--- a/ui/packages/@quent/components/src/node-info/OperatorAccordion.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorAccordion.tsx
@@ -36,13 +36,21 @@ export const OperatorAccordion = ({
         className="group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm px-1.5 py-1 my-1 text-left hover:bg-muted/50"
         aria-label={`Toggle ${operator.label} details`}
       >
-        <DataText className="min-w-0 truncate text-xs font-medium" title={operator.label}>
+        <DataText className="min-w-0 flex-1 truncate text-xs font-medium" title={operator.label}>
           {operator.label}
         </DataText>
-        <DataText className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs capitalize text-muted-foreground">
+        <DataText className="shrink-0 rounded bg-muted px-1.5 pt-0.5 pb-px text-xs leading-none capitalize text-muted-foreground">
           {operator.operationType}
         </DataText>
-        <ChevronDown className="ml-auto h-3 w-3 shrink-0 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
+        {operator.workerLabel && (
+          <DataText
+            className="min-w-0 shrink truncate text-[10px] text-muted-foreground"
+            title={`Worker: ${operator.workerLabel}`}
+          >
+            {operator.workerLabel}
+          </DataText>
+        )}
+        <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent>{children}</CollapsibleContent>
     </div>

--- a/ui/packages/@quent/components/src/node-info/OperatorAccordion.tsx
+++ b/ui/packages/@quent/components/src/node-info/OperatorAccordion.tsx
@@ -34,7 +34,11 @@ export const OperatorAccordion = ({
     <div className="min-w-0 flex-1">
       <CollapsibleTrigger
         className="group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm px-1.5 py-1 my-1 text-left hover:bg-muted/50"
-        aria-label={`Toggle ${operator.label} details`}
+        aria-label={
+          operator.workerLabel
+            ? `Toggle ${operator.label} (${operator.workerLabel}) details`
+            : `Toggle ${operator.label} details`
+        }
       >
         <DataText className="min-w-0 flex-1 truncate text-xs font-medium" title={operator.label}>
           {operator.label}

--- a/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
+++ b/ui/packages/@quent/components/src/query-plan/QueryPlanNode.tsx
@@ -40,6 +40,7 @@ export interface QueryPlanNodeData extends Record<string, unknown> {
     rawNode?: Operator;
     relatedOperatorIds?: string[];
     relatedOperators?: Operator[];
+    operatorWorkerLabels?: Record<string, string | undefined>;
   };
   hasIncoming?: boolean;
   hasOutgoing?: boolean;

--- a/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.test.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.test.ts
@@ -2,21 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import type { QueryBundle, EntityRef, Plan, Operator, Port, PlanTree } from '@quent/utils';
+import type { QueryBundle, EntityRef, Plan, Operator, Port, PlanTree, Worker } from '@quent/utils';
 import { validateQueryBundle, getTreeData, getPlanDAG } from './query-bundle-transformer';
 
 // ---- Helpers ---------------------------------------------------------------
 
 function makePlan(
   id: string,
-  opts: { instanceName?: string | null; edges?: Plan['edges'] } = {}
+  opts: { instanceName?: string | null; edges?: Plan['edges']; workerId?: string | null } = {}
 ): Plan {
   return {
     id,
     instance_name: opts.instanceName ?? null,
     parent: null,
-    worker_id: null,
+    worker_id: opts.workerId ?? null,
     edges: opts.edges ?? [],
+  };
+}
+
+function makeWorker(id: string, instanceName: string | null = null): Worker {
+  return {
+    id,
+    parent_engine_id: null,
+    instance_name: instanceName,
+    start_unix_ns: null,
+    end_unix_ns: null,
   };
 }
 
@@ -58,6 +68,7 @@ function makeBundle(
   opts: {
     operators?: Record<string, Operator | undefined>;
     ports?: Record<string, Port | undefined>;
+    workers?: Record<string, Worker | undefined>;
     planTree?: PlanTree;
   } = {}
 ): QueryBundle<EntityRef> {
@@ -66,6 +77,7 @@ function makeBundle(
       plans,
       operators: opts.operators ?? {},
       ports: opts.ports ?? {},
+      workers: opts.workers ?? {},
     },
     plan_tree: opts.planTree ?? makePlanTree(Object.keys(plans)[0] ?? 'p1'),
   } as unknown as QueryBundle<EntityRef>;
@@ -369,6 +381,74 @@ describe('getPlanDAG', () => {
     const bundle = makeBundle({ p1: plan }, { operators: { op1, op2 }, ports: { port1, port2 } });
     const result = getPlanDAG(bundle, 'p1');
     expect(result.nodes.find(n => n.id === 'op1')!.metadata!.rawNode).toBe(op1);
+  });
+
+  it('attaches the resolved worker label to node metadata', () => {
+    const op1 = makeOperator('op1', { typeName: 'Scan', planId: 'p1' });
+    const op2 = makeOperator('op2', { typeName: 'Join' });
+    const port1 = makePort('port1', 'op1');
+    const port2 = makePort('port2', 'op2');
+    const plan = makePlan('p1', { edges: [{ source: 'port1', target: 'port2' }], workerId: 'w1' });
+    const worker = makeWorker('w1', 'drone-1');
+    const bundle = makeBundle(
+      { p1: plan },
+      { operators: { op1, op2 }, ports: { port1, port2 }, workers: { w1: worker } }
+    );
+    const result = getPlanDAG(bundle, 'p1');
+    expect(result.nodes.find(n => n.id === 'op1')!.metadata!.operatorWorkerLabels).toEqual({
+      op1: 'drone-1',
+    });
+  });
+
+  it('sets the worker label to undefined when the operator has no plan or worker', () => {
+    const op1 = makeOperator('op1', { typeName: 'Scan' }); // no planId
+    const op2 = makeOperator('op2', { typeName: 'Join' });
+    const port1 = makePort('port1', 'op1');
+    const port2 = makePort('port2', 'op2');
+    const plan = makePlan('p1', { edges: [{ source: 'port1', target: 'port2' }] });
+    const bundle = makeBundle({ p1: plan }, { operators: { op1, op2 }, ports: { port1, port2 } });
+    const result = getPlanDAG(bundle, 'p1');
+    expect(result.nodes.find(n => n.id === 'op1')!.metadata!.operatorWorkerLabels).toEqual({
+      op1: undefined,
+    });
+  });
+
+  it('attaches worker labels for related operators, keyed by their own id', () => {
+    const logical = makeOperator('logical', {
+      typeName: 'LogicalJoin',
+      planId: 'logical-plan',
+    });
+    const sibling = makeOperator('sibling', { typeName: 'LogicalScan', planId: 'logical-plan' });
+    const physical = makeOperator('physical', {
+      typeName: 'HashJoin',
+      planId: 'physical-plan',
+      parentOperatorIds: ['logical'],
+    });
+    const logicalPort = makePort('logical-port', 'logical');
+    const siblingPort = makePort('sibling-port', 'sibling');
+    const logicalPlan = makePlan('logical-plan', {
+      edges: [{ source: 'logical-port', target: 'sibling-port' }],
+      workerId: 'w-logical',
+    });
+    const physicalPlan = makePlan('physical-plan', { workerId: 'w-physical' });
+    const bundle = makeBundle(
+      { 'logical-plan': logicalPlan, 'physical-plan': physicalPlan },
+      {
+        operators: { logical, sibling, physical },
+        ports: { 'logical-port': logicalPort, 'sibling-port': siblingPort },
+        workers: {
+          'w-logical': makeWorker('w-logical', 'drone-logical'),
+          'w-physical': makeWorker('w-physical', 'drone-physical'),
+        },
+      }
+    );
+
+    const result = getPlanDAG(bundle, 'logical-plan');
+
+    expect(result.nodes.find(n => n.id === 'logical')!.metadata!.operatorWorkerLabels).toEqual({
+      logical: 'drone-logical',
+      physical: 'drone-physical',
+    });
   });
 
   it('attaches related lower-level operator IDs from parent_operator_ids', () => {

--- a/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.test.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.test.ts
@@ -413,6 +413,20 @@ describe('getPlanDAG', () => {
     });
   });
 
+  it('sets the worker label to undefined when the operator has a plan with no matching worker', () => {
+    const op1 = makeOperator('op1', { typeName: 'Scan', planId: 'p1' });
+    const op2 = makeOperator('op2', { typeName: 'Join' });
+    const port1 = makePort('port1', 'op1');
+    const port2 = makePort('port2', 'op2');
+    // Plan has no worker_id, and no worker is present in the bundle either.
+    const plan = makePlan('p1', { edges: [{ source: 'port1', target: 'port2' }] });
+    const bundle = makeBundle({ p1: plan }, { operators: { op1, op2 }, ports: { port1, port2 } });
+    const result = getPlanDAG(bundle, 'p1');
+    expect(result.nodes.find(n => n.id === 'op1')!.metadata!.operatorWorkerLabels).toEqual({
+      op1: undefined,
+    });
+  });
+
   it('attaches worker labels for related operators, keyed by their own id', () => {
     const logical = makeOperator('logical', {
       typeName: 'LogicalJoin',

--- a/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
+++ b/ui/packages/@quent/components/src/services/query-plan/query-bundle-transformer.ts
@@ -3,7 +3,14 @@
 
 import type { DAGNode, DAGEdge, QueryPlanDataItem } from './types';
 import type { QueryBundle, EntityRef } from '@quent/utils';
-import { buildRelatedOperatorIdsById, Operator, Port, Plan, PlanTree } from '@quent/utils';
+import {
+  buildRelatedOperatorIdsById,
+  operatorWorkerLabel,
+  Operator,
+  Port,
+  Plan,
+  PlanTree,
+} from '@quent/utils';
 
 interface PlanTreeNode extends PlanTree {
   query?: string | null;
@@ -33,6 +40,24 @@ const getNodeEntity = (
       : undefined;
     if (operator) {
       const relatedOperatorIds = relatedOperatorIdsById.get(operator.id) ?? [];
+      const relatedOperators = relatedOperatorIds.flatMap(id => {
+        const relatedOperator = bundle.entities.operators[id];
+        return relatedOperator ? [relatedOperator] : [];
+      });
+      const operatorWorkerLabels: Record<string, string | undefined> = {
+        [operator.id]: operatorWorkerLabel(
+          operator,
+          bundle.entities.plans,
+          bundle.entities.workers
+        ),
+      };
+      for (const relatedOperator of relatedOperators) {
+        operatorWorkerLabels[relatedOperator.id] = operatorWorkerLabel(
+          relatedOperator,
+          bundle.entities.plans,
+          bundle.entities.workers
+        );
+      }
       return {
         id: operator.id,
         label: operator.instance_name ?? operator.operator_type_name ?? 'Node',
@@ -40,10 +65,8 @@ const getNodeEntity = (
         metadata: {
           rawNode: operator,
           relatedOperatorIds,
-          relatedOperators: relatedOperatorIds.flatMap(id => {
-            const relatedOperator = bundle.entities.operators[id];
-            return relatedOperator ? [relatedOperator] : [];
-          }),
+          relatedOperators,
+          operatorWorkerLabels,
         },
       };
     }

--- a/ui/packages/@quent/utils/src/index.ts
+++ b/ui/packages/@quent/utils/src/index.ts
@@ -96,6 +96,7 @@ export type {
   SelectedOperatorData,
   SelectedOperatorGroupData,
 } from './operatorTypes';
+export { operatorLocationDescription, operatorWorkerLabel } from './operatorTypes';
 export {
   buildRelatedOperatorIdsById,
   resolveOperatorSelectionCandidates,

--- a/ui/packages/@quent/utils/src/operatorTypes.ts
+++ b/ui/packages/@quent/utils/src/operatorTypes.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { StatValue } from './dagTypes';
+import type { Operator, Plan, Worker } from './types';
 
 export interface OperatorSelection {
   readonly label: string;
@@ -21,8 +22,36 @@ export interface SelectedOperatorData {
   label: string;
   operationType: string;
   statistics: Array<{ key: string; value: StatValue; quantity?: string }>;
+  workerLabel?: string;
 }
 
 export interface SelectedOperatorGroupData extends SelectedOperatorData {
   relatedOperators?: SelectedOperatorData[];
+}
+
+/** Builds a "Plan / Worker" subtitle so operators sharing the same name can be told apart. */
+export function operatorLocationDescription(
+  operator: Operator,
+  plans: Record<string, Plan>,
+  workers: Record<string, Worker>
+): string | undefined {
+  const plan = operator.plan_id ? plans[operator.plan_id] : undefined;
+  if (!plan) {
+    return undefined;
+  }
+  const planLabel = plan.instance_name ?? plan.id;
+  const worker = plan.worker_id ? workers[plan.worker_id] : undefined;
+  const workerLabel = worker ? (worker.instance_name ?? worker.id) : null;
+  return workerLabel ? `Plan: ${planLabel} · Worker: ${workerLabel}` : `Plan: ${planLabel}`;
+}
+
+/** Resolves just the worker name for an operator, so operators sharing the same name can be told apart. */
+export function operatorWorkerLabel(
+  operator: Operator,
+  plans: Record<string, Plan>,
+  workers: Record<string, Worker>
+): string | undefined {
+  const plan = operator.plan_id ? plans[operator.plan_id] : undefined;
+  const worker = plan?.worker_id ? workers[plan.worker_id] : undefined;
+  return worker ? (worker.instance_name ?? worker.id) : undefined;
 }

--- a/ui/packages/@quent/utils/src/operatorTypes.ts
+++ b/ui/packages/@quent/utils/src/operatorTypes.ts
@@ -29,19 +29,29 @@ export interface SelectedOperatorGroupData extends SelectedOperatorData {
   relatedOperators?: SelectedOperatorData[];
 }
 
+/** Resolves the plan and worker an operator ran on, if known. */
+function resolveOperatorWorker(
+  operator: Operator,
+  plans: Record<string, Plan>,
+  workers: Record<string, Worker>
+): { plan?: Plan; worker?: Worker } {
+  const plan = operator.plan_id ? plans[operator.plan_id] : undefined;
+  const worker = plan?.worker_id ? workers[plan.worker_id] : undefined;
+  return { plan, worker };
+}
+
 /** Builds a "Plan / Worker" subtitle so operators sharing the same name can be told apart. */
 export function operatorLocationDescription(
   operator: Operator,
   plans: Record<string, Plan>,
   workers: Record<string, Worker>
 ): string | undefined {
-  const plan = operator.plan_id ? plans[operator.plan_id] : undefined;
+  const { plan, worker } = resolveOperatorWorker(operator, plans, workers);
   if (!plan) {
     return undefined;
   }
   const planLabel = plan.instance_name ?? plan.id;
-  const worker = plan.worker_id ? workers[plan.worker_id] : undefined;
-  const workerLabel = worker ? (worker.instance_name ?? worker.id) : null;
+  const workerLabel = worker ? (worker.instance_name ?? worker.id) : undefined;
   return workerLabel ? `Plan: ${planLabel} · Worker: ${workerLabel}` : `Plan: ${planLabel}`;
 }
 
@@ -51,7 +61,6 @@ export function operatorWorkerLabel(
   plans: Record<string, Plan>,
   workers: Record<string, Worker>
 ): string | undefined {
-  const plan = operator.plan_id ? plans[operator.plan_id] : undefined;
-  const worker = plan?.worker_id ? workers[plan.worker_id] : undefined;
+  const { worker } = resolveOperatorWorker(operator, plans, workers);
   return worker ? (worker.instance_name ?? worker.id) : undefined;
 }

--- a/ui/packages/@quent/utils/src/operatorTypes.ts
+++ b/ui/packages/@quent/utils/src/operatorTypes.ts
@@ -29,7 +29,6 @@ export interface SelectedOperatorGroupData extends SelectedOperatorData {
   relatedOperators?: SelectedOperatorData[];
 }
 
-/** Resolves the plan and worker an operator ran on, if known. */
 function resolveOperatorWorker(
   operator: Operator,
   plans: Record<string, Plan>,
@@ -40,7 +39,6 @@ function resolveOperatorWorker(
   return { plan, worker };
 }
 
-/** Builds a "Plan / Worker" subtitle so operators sharing the same name can be told apart. */
 export function operatorLocationDescription(
   operator: Operator,
   plans: Record<string, Plan>,
@@ -55,7 +53,6 @@ export function operatorLocationDescription(
   return workerLabel ? `Plan: ${planLabel} · Worker: ${workerLabel}` : `Plan: ${planLabel}`;
 }
 
-/** Resolves just the worker name for an operator, so operators sharing the same name can be told apart. */
 export function operatorWorkerLabel(
   operator: Operator,
   plans: Record<string, Plan>,

--- a/ui/src/components/entities-table/useEntityTable.ts
+++ b/ui/src/components/entities-table/useEntityTable.ts
@@ -10,6 +10,7 @@ import {
 } from '@quent/hooks';
 import type { OptionMultiSelectOption, SelectFieldOption } from '@quent/components';
 import {
+  operatorLocationDescription,
   resolveSelectedOperatorSelections,
   toggleOperatorSelection as resolveOperatorSelectionToggle,
   type EntityRef,
@@ -26,7 +27,6 @@ import {
   entityRows,
   hasNonDefaultEntitySettings,
   normalizePageSize,
-  operatorLocationDescription,
   parseOptionalNumber,
   resourceLocationDescription,
   validateEntityFilters,

--- a/ui/src/components/entities-table/utils.ts
+++ b/ui/src/components/entities-table/utils.ts
@@ -5,9 +5,7 @@ import type {
   EntityListRequest,
   EntityListResponse,
   FiniteStateMachine,
-  Operator,
   OperatorFilter,
-  Plan,
   QueryFilter,
   Resource,
   ResourceGroup,
@@ -165,22 +163,6 @@ export function parseOptionalNumber(value: string): number | null {
   }
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
-}
-
-/** Builds a "Plan / Worker" subtitle so operators sharing the same name can be told apart. */
-export function operatorLocationDescription(
-  operator: Operator,
-  plans: Record<string, Plan>,
-  workers: Record<string, Worker>
-): string | undefined {
-  const plan = operator.plan_id ? plans[operator.plan_id] : undefined;
-  if (!plan) {
-    return undefined;
-  }
-  const planLabel = plan.instance_name ?? plan.id;
-  const worker = plan.worker_id ? workers[plan.worker_id] : undefined;
-  const workerLabel = worker ? (worker.instance_name ?? worker.id) : null;
-  return workerLabel ? `Plan: ${planLabel} · Worker: ${workerLabel}` : `Plan: ${planLabel}`;
 }
 
 /** Builds a "Worker" subtitle so resources sharing the same name across workers can be told apart. */


### PR DESCRIPTION
# Description

Adds worker information to each operator section in `DAGNodeInfoPanel`, so that the various operators can be distinguished from one another.  Additionally, extracts worker and worker+plan label buildings functions as helpers that be can used throughout the app rather than localized in components. Also updates unit tests to test for new conditions.

## Related Issues
Closes: #700 

## Testing

1. Select an operator in DAG, check stats panel - if available, worker info should now be displayed in-line with the operator name on the trigger of the collapsible panel

## Screenshots

https://github.com/user-attachments/assets/b4092fc5-aa2a-4940-b791-0e6900d87a1c

